### PR TITLE
Fix UnderlineNav overflow

### DIFF
--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -8,7 +8,6 @@
 
 .UnderlineNav-body {
   display: flex;
-  margin-bottom: -1px;
 }
 
 .UnderlineNav-item {

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -8,6 +8,7 @@
 
 .UnderlineNav-body {
   display: flex;
+  margin-bottom: -1px;
 }
 
 .UnderlineNav-item {

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -2,6 +2,8 @@
   display: flex;
   justify-content: space-between;
   border-bottom: 1px solid $gray-200;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .UnderlineNav-body {

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -1,9 +1,9 @@
 .UnderlineNav {
   display: flex;
-  justify-content: space-between;
-  border-bottom: 1px solid $gray-200;
   overflow-x: auto;
   overflow-y: hidden;
+  border-bottom: 1px solid $gray-200;
+  justify-content: space-between;
 }
 
 .UnderlineNav-body {


### PR DESCRIPTION
This makes some tweaks to the UnderlineNav component:

1. Adds `overflow-x: auto` for horizontal scrolling, and `overflow-y: hidden` to prevent vertical scrolling.
1. ~Removes 1px clipping via `margin-bottom: -1px` on `.UnderlineNav-body` (because: why?)~

I'm requesting reviews from folks who have lots of experience with this component. Thanks!