### PR TITLE
Docs site fixes

### DIFF
--- a/now.json
+++ b/now.json
@@ -11,7 +11,8 @@
     "postcss.config.js",
     "pages",
     "script",
-    "src"
+    "src",
+    "static"
   ],
   "scale": {
     "sfo": {


### PR DESCRIPTION
1. ~We don't need `now` as a dependency since we're using primer/deploy.~ Turns out we do: primer/deploy#10
1. The `files` list in `now.json` is missing "static", which prevents the favicon and some other images from being uploaded to the deployment.