### PR TITLE
Fix: restore missing marketing padding utilities

### DIFF
--- a/src/marketing/utilities/padding.scss
+++ b/src/marketing/utilities/padding.scss
@@ -6,9 +6,19 @@
   @include breakpoint($breakpoint) {
     @each $scale, $size in $marketing-spacers {
 
-      .pt#{$variant}-#{$scale} { padding-top: #{$size} !important; }
-      .pb#{$variant}-#{$scale} { padding-bottom: #{$size} !important; }
+      /* Set a #{$size} padding for all sides */
+      .p#{$variant}-#{$scale}  { padding: #{$size} !important; }
 
+      /* Set a #{$size} padding to the top */
+      .pt#{$variant}-#{$scale}  { padding-top: #{$size} !important; }
+      /* Set a #{$size} padding to the right */
+      .pr#{$variant}-#{$scale}  { padding-right: #{$size} !important; }
+      /* Set a #{$size} padding to the bottom */
+      .pb#{$variant}-#{$scale}  { padding-bottom: #{$size} !important; }
+      /* Set a #{$size} padding to the left */
+      .pl#{$variant}-#{$scale}  { padding-left: #{$size} !important; }
+
+      /* Set a #{$size} padding to the top & bottom */
       .py#{$variant}-#{$scale} {
         padding-top: #{$size} !important;
         padding-bottom: #{$size} !important;


### PR DESCRIPTION
I flubbed the merge of master into #636, so this is my attempt at restoring those changes. (I'm so sorry, Tyson!)

Running `script/selector-diff-report` locally shows a bunch of new classnames. @trosage and/or @gladwearefriends, do you mind double-checking the code and this list to make sure I got it right? 🙇 

```diff
> .p-7
> .pr-7
> .pl-7
> .p-8
> .pr-8
> .pl-8
> .p-9
> .pr-9
> .pl-9
> .p-10
> .pr-10
> .pl-10
> .p-11
> .pr-11
> .pl-11
> .p-12
> .pr-12
> .pl-12
> .p-sm-7
> .pr-sm-7
> .pl-sm-7
> .p-sm-8
> .pr-sm-8
> .pl-sm-8
> .p-sm-9
> .pr-sm-9
> .pl-sm-9
> .p-sm-10
> .pr-sm-10
> .pl-sm-10
> .p-sm-11
> .pr-sm-11
> .pl-sm-11
> .p-sm-12
> .pr-sm-12
> .pl-sm-12
> .p-md-7
> .pr-md-7
> .pl-md-7
> .p-md-8
> .pr-md-8
> .pl-md-8
> .p-md-9
> .pr-md-9
> .pl-md-9
> .p-md-10
> .pr-md-10
> .pl-md-10
> .p-md-11
> .pr-md-11
> .pl-md-11
> .p-md-12
> .pr-md-12
> .pl-md-12
> .p-lg-7
> .pr-lg-7
> .pl-lg-7
> .p-lg-8
> .pr-lg-8
> .pl-lg-8
> .p-lg-9
> .pr-lg-9
> .pl-lg-9
> .p-lg-10
> .pr-lg-10
> .pl-lg-10
> .p-lg-11
> .pr-lg-11
> .pl-lg-11
> .p-lg-12
> .pr-lg-12
> .pl-lg-12
> .p-xl-7
> .pr-xl-7
> .pl-xl-7
> .p-xl-8
> .pr-xl-8
> .pl-xl-8
> .p-xl-9
> .pr-xl-9
> .pl-xl-9
> .p-xl-10
> .pr-xl-10
> .pl-xl-10
> .p-xl-11
> .pr-xl-11
> .pl-xl-11
> .p-xl-12
> .pr-xl-12
> .pl-xl-12
```

