### PR TITLE
Fix storybook, post-sync

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -39,7 +39,7 @@ addParameters({
 })
 
 configure(() => {
-  const loadMarkdown = require.context('../src', true, /\.md$/)
+  const loadMarkdown = require.context('../pages/css', true, /\.md$/)
   for (const path of loadMarkdown.keys()) {
     loadMarkdown(path)
   }

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,2 +1,2 @@
-<link rel="stylesheet" href="https://unpkg.com/octicons@7.0.1/build/build.css">
+<link rel="stylesheet" href="https://unpkg.com/octicons@8.5.0/build/build.css">
 <script src="https://github.com/site/assets/styleguide.js" async></script>

--- a/.storybook/story-loader.js
+++ b/.storybook/story-loader.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-const {dirname} = require('path')
+const {basename, dirname, join} = require('path')
 const parseFromString = require('code-blocks/lib/fromString')
 
 module.exports = function storyLoader(markdown) {
@@ -15,11 +15,7 @@ module.exports = function storyLoader(markdown) {
 
   // strip the sourcePath from the beginning of the resourcePath
   const file = resourcePath.replace(`${sourcePath}/`, '')
-  // finally, remove "/README" or "/docs" from the path,
-  // then strip the ".md" filename extension
-  const path = dirname(file)
-    .replace(/(\/README|\/docs)/, '')
-    .replace(/\.md$/, '')
+  const path = join(dirname(file), basename(file, '.md'))
 
   const stories = storiesFromMarkdown(markdown, file)
   if (stories.length) {

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,10 +1,8 @@
 const {resolve} = require('path')
-const sourcePath = resolve(__dirname, '../src')
+const pagesPath = resolve(__dirname, '../pages/css')
 
 module.exports = ({config}) => {
-  const babel = config.module.rules.find(rule => {
-    return rule.test.test('test.js')
-  }).use[0]
+  const babel = config.module.rules[0].use[0]
 
   config.module.rules = config.module.rules.filter(rule => {
     return !rule.test.test('test.md')
@@ -13,20 +11,19 @@ module.exports = ({config}) => {
   config.module.rules.push(
     {
       test: /\.md$/,
-      include: sourcePath,
+      include: pagesPath,
       loaders: [
         babel,
         {
           loader: require.resolve('./story-loader'),
           options: {
-            sourcePath
+            sourcePath: pagesPath
           }
         }
       ]
     },
     {
       test: /\.scss$/,
-      include: sourcePath,
       loaders: [
         'style-loader',
         'css-loader',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/css",
-  "version": "12.1.0",
+  "version": "12.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/pages/css/getting-started/index.md
+++ b/pages/css/getting-started/index.md
@@ -77,7 +77,7 @@ $blue: #0000ff;
 
 Don't forget to add the compiled CSS to the `<head>` section of your page.
 
-```html dead
+```html inert=true
 <link href="path/to/style.css" rel="stylesheet">
 ```
 
@@ -85,6 +85,6 @@ Don't forget to add the compiled CSS to the `<head>` section of your page.
 
 You won't need to install any node modules for a static site, you can use the built CSS. The best thing to do is to [download the built CSS](https://unpkg.com/primer/build/build.css) from the npm module and host it yourself. If that's not an option, you can include a CDN link in your html:
 
-```html dead
+```html inert=true
 <link href="https://unpkg.com/primer/build/build.css" rel="stylesheet">
 ```

--- a/pages/css/principles/html.md
+++ b/pages/css/principles/html.md
@@ -15,7 +15,7 @@ title: HTML
 * Avoid trailing slashes in self-closing elements. For example, `<br>`, `<hr>`, `<img>`, and `<input>`.
 * Don't set `tabindex` manually—rely on the browser to set the order.
 
-```html dead={true}
+```html inert=true
 <p class="line-note m-0" data-attribute="106">
   This is my paragraph of special text.
 </p>
@@ -25,7 +25,7 @@ title: HTML
 
 Many attributes don't require a value to be set, like `disabled` or `checked`, so don't set them.
 
-```html dead={true}
+```html inert=true
 <input type="text" disabled>
 
 <input type="checkbox" value="1" checked>
@@ -41,7 +41,7 @@ For more information, [read the WhatWG section](http://www.whatwg.org/specs/web-
 
 Whenever possible, avoid superfluous parent elements when writing HTML. Many times this requires iteration and refactoring, but produces less HTML. For example:
 
-```html dead={true}
+```html inert=true
 <!-- Not so great -->
 <span class="avatar">
   <img src="https://github.com/github.png">
@@ -62,7 +62,7 @@ Whenever possible, avoid superfluous parent elements when writing HTML. Many tim
 
 Make use of `<thead>`, `<tfoot>`, `<tbody>`, and `<th>` tags (and `scope` attribute) when appropriate. (Note: `<tfoot>` goes above `<tbody>` for speed reasons. You want the browser to load the footer before a table full of data.)
 
-```html dead={true}
+```html inert=true
 <table summary="This is a chart of invoices for 2011.">
   <thead>
     <tr>


### PR DESCRIPTION
This updates various Storybook bits to look for Markdown files in `/pages/css` rather than `/src`, and updates some "dead" code examples to use the new `inert=true` fenced code block prop.