### PR TITLE
Add more .border-white-fade utilities

### DIFF
--- a/pages/css/utilities/borders.md
+++ b/pages/css/utilities/borders.md
@@ -115,36 +115,36 @@ Use `.border-white-fade-xx` to add a white border with various levels of alpha t
 
 ```html
 <div class="bg-gray-dark text-white p-3 mb-3">
-  <div class="border-bottom border-white-fade-15 p-2 mb-2">
+  <div class="border border-white-fade-15 p-2 mb-2">
     .border-white-fade-15
   </div>
-  <div class="border-bottom border-white-fade-30 p-2 mb-2">
+  <div class="border border-white-fade-30 p-2 mb-2">
     .border-white-fade-30
   </div>
-  <div class="border-bottom border-white-fade-50 p-2 mb-2">
+  <div class="border border-white-fade-50 p-2 mb-2">
     .border-white-fade-50
   </div>
-  <div class="border-bottom border-white-fade-70 p-2 mb-2">
+  <div class="border border-white-fade-70 p-2 mb-2">
     .border-white-fade-70
   </div>
-  <div class="border-bottom border-white-fade-85 p-2 mb-2">
+  <div class="border border-white-fade-85 p-2 mb-2">
     .border-white-fade-85
   </div>
 </div>
 <div class="bg-blue text-white p-3">
-  <div class="border-bottom border-white-fade-15 p-2 mb-2">
+  <div class="border border-white-fade-15 p-2 mb-2">
     .border-white-fade-15
   </div>
-  <div class="border-bottom border-white-fade-30 p-2 mb-2">
+  <div class="border border-white-fade-30 p-2 mb-2">
     .border-white-fade-30
   </div>
-  <div class="border-bottom border-white-fade-50 p-2 mb-2">
+  <div class="border border-white-fade-50 p-2 mb-2">
     .border-white-fade-50
   </div>
-  <div class="border-bottom border-white-fade-70 p-2 mb-2">
+  <div class="border border-white-fade-70 p-2 mb-2">
     .border-white-fade-70
   </div>
-  <div class="border-bottom border-white-fade-85 p-2 mb-2">
+  <div class="border border-white-fade-85 p-2 mb-2">
     .border-white-fade-85
   </div>
 </div>

--- a/pages/css/utilities/borders.md
+++ b/pages/css/utilities/borders.md
@@ -111,6 +111,45 @@ On dark backgrounds use `border-white-fade` instead. It adds an rgba white borde
 </div>
 ```
 
+Use `.border-white-fade-xx` to add a white border with various levels of alpha transparency.
+
+```html
+<div class="bg-gray-dark text-white p-3 mb-3">
+  <div class="border-bottom border-white-fade-15 p-2 mb-2">
+    .border-white-fade-15
+  </div>
+  <div class="border-bottom border-white-fade-30 p-2 mb-2">
+    .border-white-fade-30
+  </div>
+  <div class="border-bottom border-white-fade-50 p-2 mb-2">
+    .border-white-fade-50
+  </div>
+  <div class="border-bottom border-white-fade-70 p-2 mb-2">
+    .border-white-fade-70
+  </div>
+  <div class="border-bottom border-white-fade-85 p-2 mb-2">
+    .border-white-fade-85
+  </div>
+</div>
+<div class="bg-blue text-white p-3">
+  <div class="border-bottom border-white-fade-15 p-2 mb-2">
+    .border-white-fade-15
+  </div>
+  <div class="border-bottom border-white-fade-30 p-2 mb-2">
+    .border-white-fade-30
+  </div>
+  <div class="border-bottom border-white-fade-50 p-2 mb-2">
+    .border-white-fade-50
+  </div>
+  <div class="border-bottom border-white-fade-70 p-2 mb-2">
+    .border-white-fade-70
+  </div>
+  <div class="border-bottom border-white-fade-85 p-2 mb-2">
+    .border-white-fade-85
+  </div>
+</div>
+```
+
 ## Border style
 
 Use `border-dashed` to give an element a dashed border.

--- a/pages/css/utilities/borders.md
+++ b/pages/css/utilities/borders.md
@@ -101,6 +101,16 @@ Use `border-black-fade` to add an rgba black border with an alpha transparency o
 </div>
 ```
 
+On dark backgrounds use `border-white-fade` instead. It adds an rgba white border with an alpha transparency of `0.15`.
+
+```html
+<div class="bg-gray-dark text-white p-3">
+  <div class="border border-white-fade p-2">
+    .border-white-fade
+  </div>
+</div>
+```
+
 ## Border style
 
 Use `border-dashed` to give an element a dashed border.

--- a/pages/css/utilities/marketing-borders.md
+++ b/pages/css/utilities/marketing-borders.md
@@ -2,54 +2,9 @@
 title: Marketing Borders
 sort_title: Borders Marketing
 path: utilities/marketing-borders
-status: New release
+status: Deprecated
 source: 'https://github.com/primer/css/blob/master/src/marketing/utilities/borders.scss'
 bundle: marketing-utilities
 ---
 
-The following border utilities are meant to be used in addition to those within primer-core.
-
-{:toc}
-
-## Border Colors
-
-### White border with alpha transparency
-
-Use `.border-white-fade-xx` to add a white border with various levels of alpha transparency. This is useful when you want a border that is a lighter shade of the background color. Additional border colors are available in [primer-core border utilities](/css/utilities/borders#border-colors).
-
-```html
-<div class="bg-gray-dark text-white p-3 mb-3">
-  <div class="border-bottom border-white-fade-15 p-2 mb-2">
-    .border-white-fade-15
-  </div>
-  <div class="border-bottom border-white-fade-30 p-2 mb-2">
-    .border-white-fade-30
-  </div>
-  <div class="border-bottom border-white-fade-50 p-2 mb-2">
-    .border-white-fade-50
-  </div>
-  <div class="border-bottom border-white-fade-70 p-2 mb-2">
-    .border-white-fade-70
-  </div>
-  <div class="border-bottom border-white-fade-85 p-2 mb-2">
-    .border-white-fade-85
-  </div>
-</div>
-<div class="bg-blue text-white p-3">
-  <div class="border-bottom border-white-fade-15 p-2 mb-2">
-    .border-white-fade-15
-  </div>
-  <div class="border-bottom border-white-fade-30 p-2 mb-2">
-    .border-white-fade-30
-  </div>
-  <div class="border-bottom border-white-fade-50 p-2 mb-2">
-    .border-white-fade-50
-  </div>
-  <div class="border-bottom border-white-fade-70 p-2 mb-2">
-    .border-white-fade-70
-  </div>
-  <div class="border-bottom border-white-fade-85 p-2 mb-2">
-    .border-white-fade-85
-  </div>
-</div>
-```
+The `.border-white-fade` styles are now part of [primer-core border utilities](/css/utilities/borders#border-colors).

--- a/pages/css/utilities/marketing-borders.md
+++ b/pages/css/utilities/marketing-borders.md
@@ -2,12 +2,12 @@
 title: Marketing Borders
 sort_title: Borders Marketing
 path: utilities/marketing-borders
-status: Stable
+status: New release
 source: 'https://github.com/primer/css/blob/master/src/marketing/utilities/borders.scss'
 bundle: marketing-utilities
 ---
 
-The following border utilities are meant to used in addition to those within primer-core.
+The following border utilities are meant to be used in addition to those within primer-core.
 
 {:toc}
 
@@ -15,17 +15,41 @@ The following border utilities are meant to used in addition to those within pri
 
 ### White border with alpha transparency
 
-Use `.border-white-fade` to add a white border with an alpha transparency of 0.15. This is useful when you want a border that is a lighter shade of the background color. Additional border colors are available in [primer-core border utilities](/css/utilities/borders#border-colors).
+Use `.border-white-fade-xx` to add a white border with various levels of alpha transparency. This is useful when you want a border that is a lighter shade of the background color. Additional border colors are available in [primer-core border utilities](/css/utilities/borders#border-colors).
 
 ```html
-<div class="bg-gray-dark text-white p-3 mb-2">
-  <span class="border border-white-fade p-2">
-    .border-white-fade .bg-gray-dark
-  </span>
+<div class="bg-gray-dark text-white p-3 mb-3">
+  <div class="border-bottom border-white-fade-15 p-2 mb-2">
+    .border-white-fade-15
+  </div>
+  <div class="border-bottom border-white-fade-30 p-2 mb-2">
+    .border-white-fade-30
+  </div>
+  <div class="border-bottom border-white-fade-50 p-2 mb-2">
+    .border-white-fade-50
+  </div>
+  <div class="border-bottom border-white-fade-70 p-2 mb-2">
+    .border-white-fade-70
+  </div>
+  <div class="border-bottom border-white-fade-85 p-2 mb-2">
+    .border-white-fade-85
+  </div>
 </div>
 <div class="bg-blue text-white p-3">
-  <span class="border border-white-fade p-2">
-    .border-white-fade .bg-blue
-  </span>
+  <div class="border-bottom border-white-fade-15 p-2 mb-2">
+    .border-white-fade-15
+  </div>
+  <div class="border-bottom border-white-fade-30 p-2 mb-2">
+    .border-white-fade-30
+  </div>
+  <div class="border-bottom border-white-fade-50 p-2 mb-2">
+    .border-white-fade-50
+  </div>
+  <div class="border-bottom border-white-fade-70 p-2 mb-2">
+    .border-white-fade-70
+  </div>
+  <div class="border-bottom border-white-fade-85 p-2 mb-2">
+    .border-white-fade-85
+  </div>
 </div>
 ```

--- a/pages/css/utilities/marketing-borders.md
+++ b/pages/css/utilities/marketing-borders.md
@@ -7,4 +7,4 @@ source: 'https://github.com/primer/css/blob/master/src/marketing/utilities/borde
 bundle: marketing-utilities
 ---
 
-The `.border-white-fade` styles are now part of [primer-core border utilities](/css/utilities/borders#border-colors).
+The `.border-white-fade` styles are now part of [core border utilities](/css/utilities/borders#border-colors).

--- a/src/marketing/utilities/borders.scss
+++ b/src/marketing/utilities/borders.scss
@@ -1,11 +1,4 @@
-// Border utilities
+// Marketing border utilities
 
 // XXX If you're looking for responsive border utilities, they've moved to
 // ../../utilities/borders.scss
-
-/* Use with .border to turn the border white with transparency */
-.border-white-fade-15 { border-color: $white-fade-15 !important; }
-.border-white-fade-30 { border-color: $white-fade-30 !important; }
-.border-white-fade-50 { border-color: $white-fade-50 !important; }
-.border-white-fade-70 { border-color: $white-fade-70 !important; }
-.border-white-fade-85 { border-color: $white-fade-85 !important; }

--- a/src/marketing/utilities/borders.scss
+++ b/src/marketing/utilities/borders.scss
@@ -2,3 +2,10 @@
 
 // XXX If you're looking for responsive border utilities, they've moved to
 // ../../utilities/borders.scss
+
+/* Use with .border to turn the border white with transparency */
+.border-white-fade-15 { border-color: $white-fade-15 !important; }
+.border-white-fade-30 { border-color: $white-fade-30 !important; }
+.border-white-fade-50 { border-color: $white-fade-50 !important; }
+.border-white-fade-70 { border-color: $white-fade-70 !important; }
+.border-white-fade-85 { border-color: $white-fade-85 !important; }

--- a/src/marketing/utilities/borders.scss
+++ b/src/marketing/utilities/borders.scss
@@ -1,9 +1,4 @@
 // Border utilities
 
 // XXX If you're looking for responsive border utilities, they've moved to
-// ../../primer-utilities/lib/borders.scss
-
-/* Use with .border to turn the border rgba white 0.15 */
-.border-white-fade {
-  border-color: $white-fade-15 !important;
-}
+// ../../utilities/borders.scss

--- a/src/support/variables/colors.scss
+++ b/src/support/variables/colors.scss
@@ -16,6 +16,7 @@ $highlight-yellow: rgba(255, 247, 140, 0.5);
 
 // Border colors
 $border-black-fade:  $black-fade-15 !default;
+$border-white-fade:  $white-fade-15 !default;
 
 $border-blue:        $blue-500 !default;
 $border-blue-light:  $blue-200 !default;

--- a/src/utilities/borders.scss
+++ b/src/utilities/borders.scss
@@ -38,6 +38,8 @@
 .border-gray-dark   { border-color: $border-gray-dark !important; }
 /* Use with .border to turn the border rgba black 0.15 */
 .border-black-fade  { border-color: $border-black-fade !important; }
+/* Use with .border to turn the border rgba white 0.15 */
+.border-white-fade  { border-color: $border-white-fade !important; }
 
 $edges: (
   top: (top-left, top-right),

--- a/src/utilities/borders.scss
+++ b/src/utilities/borders.scss
@@ -36,6 +36,7 @@
 .border-gray-light  { border-color: $border-gray-light !important; }
 /* Use with .border to turn the border gray-dark */
 .border-gray-dark   { border-color: $border-gray-dark !important; }
+
 /* Use with .border to turn the border rgba black 0.15 */
 .border-black-fade  { border-color: $border-black-fade !important; }
 /* Use with .border to turn the border rgba white 0.15 */

--- a/src/utilities/borders.scss
+++ b/src/utilities/borders.scss
@@ -42,13 +42,6 @@
 /* Use with .border to turn the border rgba white 0.15 */
 .border-white-fade  { border-color: $border-white-fade !important; }
 
-/* Use with .border to turn the border white w/varying transparency */
-.border-white-fade-15 { border-color: $white-fade-15 !important; }
-.border-white-fade-30 { border-color: $white-fade-30 !important; }
-.border-white-fade-50 { border-color: $white-fade-50 !important; }
-.border-white-fade-70 { border-color: $white-fade-70 !important; }
-.border-white-fade-85 { border-color: $white-fade-85 !important; }
-
 $edges: (
   top: (top-left, top-right),
   right: (top-right, bottom-right),
@@ -106,6 +99,13 @@ $edges: (
     }
   }
 }
+
+/* Use with .border to turn the border white w/varying transparency */
+.border-white-fade-15 { border-color: $white-fade-15 !important; }
+.border-white-fade-30 { border-color: $white-fade-30 !important; }
+.border-white-fade-50 { border-color: $white-fade-50 !important; }
+.border-white-fade-70 { border-color: $white-fade-70 !important; }
+.border-white-fade-85 { border-color: $white-fade-85 !important; }
 
 /* Add a 50% border-radius to make something into a circle */
 .circle { border-radius: 50% !important; }

--- a/src/utilities/borders.scss
+++ b/src/utilities/borders.scss
@@ -42,6 +42,13 @@
 /* Use with .border to turn the border rgba white 0.15 */
 .border-white-fade  { border-color: $border-white-fade !important; }
 
+/* Use with .border to turn the border white w/varying transparency */
+.border-white-fade-15 { border-color: $white-fade-15 !important; }
+.border-white-fade-30 { border-color: $white-fade-30 !important; }
+.border-white-fade-50 { border-color: $white-fade-50 !important; }
+.border-white-fade-70 { border-color: $white-fade-70 !important; }
+.border-white-fade-85 { border-color: $white-fade-85 !important; }
+
 $edges: (
   top: (top-left, top-right),
   right: (top-right, bottom-right),
@@ -99,13 +106,6 @@ $edges: (
     }
   }
 }
-
-/* Use with .border to turn the border white w/varying transparency */
-.border-white-fade-15 { border-color: $white-fade-15 !important; }
-.border-white-fade-30 { border-color: $white-fade-30 !important; }
-.border-white-fade-50 { border-color: $white-fade-50 !important; }
-.border-white-fade-70 { border-color: $white-fade-70 !important; }
-.border-white-fade-85 { border-color: $white-fade-85 !important; }
 
 /* Add a 50% border-radius to make something into a circle */
 .circle { border-radius: 50% !important; }

--- a/src/utilities/borders.scss
+++ b/src/utilities/borders.scss
@@ -1,4 +1,4 @@
-// Border utilities
+// Core border utilities
 // stylelint-disable primer/selector-no-utility
 // stylelint-disable block-opening-brace-space-before, comment-empty-line-before
 
@@ -41,6 +41,13 @@
 .border-black-fade  { border-color: $border-black-fade !important; }
 /* Use with .border to turn the border rgba white 0.15 */
 .border-white-fade  { border-color: $border-white-fade !important; }
+
+/* Use with .border to turn the border white w/varying transparency */
+.border-white-fade-15 { border-color: $white-fade-15 !important; }
+.border-white-fade-30 { border-color: $white-fade-30 !important; }
+.border-white-fade-50 { border-color: $white-fade-50 !important; }
+.border-white-fade-70 { border-color: $white-fade-70 !important; }
+.border-white-fade-85 { border-color: $white-fade-85 !important; }
 
 $edges: (
   top: (top-left, top-right),


### PR DESCRIPTION
This PR adds a few new `.border-white-fade` utility classes to be used on dark backgrounds.

- [x] Moves `.border-white-fade` from "marketing" to "core".
- [x] Adds multiple `.border-white-fade-xx` utilities to "marketing".

## ✨ New in core

<img width="485" alt="screen shot 2019-03-08 at 4 58 40 pm" src="https://user-images.githubusercontent.com/378023/54015585-73e00480-41c3-11e9-817b-3e9d40911c85.png">

![image](https://user-images.githubusercontent.com/378023/54248307-866d8b80-457f-11e9-9fa6-bde6de918d36.png)

/cc @primer/ds-core
