### PR TITLE
Fix scrolling of code examples

### DIFF
--- a/docs/Frame.js
+++ b/docs/Frame.js
@@ -39,7 +39,7 @@ export default class Frame extends React.Component {
   getBody(children) {
     return (
       <Measure bounds onResize={rect => this.setHeight(rect.bounds.height)}>
-        {({measureRef}) => <div ref={measureRef}>{children}</div>}
+        {({measureRef}) => <div ref={measureRef} style={{overflow: 'auto'}}>{children}</div>}
       </Measure>
     )
   }

--- a/docs/Frame.js
+++ b/docs/Frame.js
@@ -39,7 +39,11 @@ export default class Frame extends React.Component {
   getBody(children) {
     return (
       <Measure bounds onResize={rect => this.setHeight(rect.bounds.height)}>
-        {({measureRef}) => <div ref={measureRef} style={{overflow: 'auto'}}>{children}</div>}
+        {({measureRef}) => (
+          <div ref={measureRef} style={{overflow: 'auto'}}>
+            {children}
+          </div>
+        )}
       </Measure>
     )
   }


### PR DESCRIPTION
This fixes #708 where some code examples in the docs show a scrollbar.

![Screen Shot 2019-03-11 at 8 07 50 PM](https://user-images.githubusercontent.com/378023/54119737-6469f100-4439-11e9-9bdd-11863efd9810.png)

The problem seems to be that if a code example uses margin, it doesn't get included when calculating the height for the `<iframe>`. For example the `.tabnav` has a height of `37px` with a bottom-margin of `15px`, but the height of the `<iframe>` is only `37px`, causing the rest to scroll.

Adding `overflow: auto` to a parent element of the code example seems to fix it.

✨ [Preview](https://primer-css-fix-docs-code-example-height.now.sh/css/components/navigation) ✨

## Alternatives

We could add any other property that creates a new [block formatting context](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context). Not sure if  `overflow: auto` has side effects? 🤔  `display: flow-root` would be most appropriate, but [browser support](https://caniuse.com/#search=flow-root) isn't that great yet.
