### PR TITLE
Remove "prepare" npm script that runs "dist"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "npm-run-all -s lint-css lint-js",
     "lint-css": "stylelint --quiet --syntax scss src/**/*.scss",
     "lint-js": "eslint lib docs .storybook",
-    "now-build": "next build",
+    "now-build": "npm run dist && next build",
     "now-start": "next start",
     "now-test": "npm-run-all -s now-build now-start",
     "postpublish": "script/postpublish",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "now-start": "next start",
     "now-test": "npm-run-all -s now-build now-start",
     "postpublish": "script/postpublish",
-    "prepare": "npm run dist",
     "prepublishOnly": "script/prepublish",
     "publish-storybook": "script/publish-storybook",
     "start": "next dev",


### PR DESCRIPTION
This is a fix for one aspect of #715: if a repo/app/project uses a different version of Node than you've used to run `npm install` in _this_ repo, running `npm link` will fail because it will attempt to build the CSS using a node-sass binary for the wrong version of Node.

So instead of running `dist` in our `prepare` script (which goes away), we run `dist` in the `now-build` script. I've tested this in dot-com and confirmed that `bin/npm link ../../primer/css` works after having run `npm install` in this repo with a different version of Node. ✨ 