### PR TITLE
Prevent failed Storybook publishing from breaking the build

### DIFF
--- a/script/postpublish
+++ b/script/postpublish
@@ -9,5 +9,7 @@ if [[ -f $file ]]; then
 fi
 
 if [[ "$GITHUB_REF" = "refs/heads/master" ]]; then
-    npm run publish-storybook
+    npm run --silent publish-storybook || (
+        echo "Whoops! Failed to publish Storybook. This is not a fatal error."
+    )
 fi


### PR DESCRIPTION
This runs `npm run publish-storybook` with `--silent` to suppress output, and echos a warning about failure if it doesn't exit cleanly.