### PR TITLE
Dark input

### DIFF
--- a/pages/css/components/forms.md
+++ b/pages/css/components/forms.md
@@ -86,6 +86,14 @@ Textual form controls have a white background by default. You can change this to
 </form>
 ```
 
+On dark backgrounds use `.input-dark` to make inputs have a semi transparent white background.
+
+```html
+<form class="bg-gray-dark p-3">
+  <input class="form-control input-dark" type="search" placeholder="Dark input" aria-label="Dark input">
+</form>
+```
+
 #### Sizing
 
 Make inputs smaller, larger, or full-width with an additional class.

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -65,14 +65,14 @@ label {
 
   &::placeholder {
     color: inherit;
-    opacity: .6; // inceases contrast ratio to 4.52
+    opacity: 0.6; // inceases contrast ratio to 4.52
   }
 
   &.focus,
   &:focus {
-    background-color: rgba($white, .075);
+    background-color: rgba($white, 0.075);
     border-color: $black-fade-30;
-    box-shadow: 0 0 0 0.2em rgba($blue-300, .4);
+    box-shadow: 0 0 0 0.2em rgba($blue-300, 0.4);
   }
 }
 

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -56,6 +56,26 @@ label {
   color: $text-gray-light;
 }
 
+// Inputs on dark backgrounds.
+.input-dark {
+  color: $white;
+  background-color: $white-fade-15;
+  border-color: transparent;
+  box-shadow: none;
+
+  &::placeholder {
+    color: inherit;
+    opacity: .6; // inceases contrast ratio to 4.52
+  }
+
+  &.focus,
+  &:focus {
+    background-color: rgba($white, .075);
+    border-color: $black-fade-30;
+    box-shadow: 0 0 0 0.2em rgba($blue-300, .4);
+  }
+}
+
 // Mini inputs, to match .minibutton
 .input-sm {
   min-height: 28px;


### PR DESCRIPTION
This adds an `.input-dark` modifier that can be used with `.form-control` inputs. Closes https://github.com/github/design-systems/issues/586

![dark-input](https://user-images.githubusercontent.com/378023/54412540-777d0980-4736-11e9-8daf-23ea85170b7b.gif)

## Why should this be in Primer?

Currently there are 3 dark inputs on github.com that all have their own styling. There are also small differences in how they look.

Use case | Screenshot
--- | ---
Header search input when **logged in** | ![image](https://user-images.githubusercontent.com/378023/54413009-c6776e80-4737-11e9-88d2-c6ecf8c2505f.png)
Header search input when **logged out** | ![image](https://user-images.githubusercontent.com/378023/54413071-f6267680-4737-11e9-8933-e8b0f80ee926.png)
Project filter input in **fullscreen mode** | ![image](https://user-images.githubusercontent.com/378023/54413119-122a1800-4738-11e9-84b8-98cd6d314c44.png)

By offering an `.input-dark` version, we hopefully can:

- Reduce custom CSS needed
- Have a consistent look across all use cases.

## Concerns

- Colors and size might slightly change.
- The current use cases have icons and a light dropdown when focused. This will probably still need some custom CSS and the savings don't make a huge difference.

 ## Next steps

Try to use `.input-dark` on github.com to see if there are any problems.