### PR TITLE
Fix UnderlineNav border

### DIFF
--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -2,7 +2,7 @@
   display: flex;
   overflow-x: auto;
   overflow-y: hidden;
-  border-bottom: 1px solid $gray-200;
+  border-bottom: $border;
   justify-content: space-between;
 }
 
@@ -17,7 +17,7 @@
   line-height: $lh-default;
   color: $text-gray;
   text-align: center;
-  border-bottom: 2px solid transparent;
+  border-bottom: 2px $border-style transparent;
 
   &:hover,
   &:focus {

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -8,7 +8,6 @@
 
 .UnderlineNav-body {
   display: flex;
-  margin-bottom: -1px;
 }
 
 .UnderlineNav-item {


### PR DESCRIPTION
This removes the `margin-bottom: -1px` rule from `.UnderlineNav`, fixing #732.

While I was in there, I replaced some static values with `$border` and `$border-style` variables. Here it is [on the branch deployment](https://primer-css-fix-underlinenav-border.now.sh/css/components/navigation):

![image](https://user-images.githubusercontent.com/113896/54555532-32deb180-4974-11e9-8b9a-1ddba9cbdcff.png)
