### PR TITLE
Adios purple buttons

### DIFF
--- a/docs/content/components/buttons.md
+++ b/docs/content/components/buttons.md
@@ -59,7 +59,7 @@ Use `.btn-large` to increase the padding and border radius of a button. This is 
 
 ```html live
 <p>
-  <a class="btn btn-large btn-purple" href="#url" role="button">Large link button</a>
+  <a class="btn btn-large" href="#url" role="button">Large link button</a>
   <button class="btn btn-large" type="button">Large button button</button>
 </p>
 ```
@@ -68,7 +68,7 @@ Use `.btn-large` with a type scale utility to transform the text to a bigger siz
 
 ```html live
 <p class="f3">
-  <a class="btn btn-large btn-purple" href="#url" role="button">Large link button</a>
+  <a class="btn btn-large" href="#url" role="button">Large link button</a>
   <button class="btn btn-large btn-outline-blue" type="button">Large button button</button>
 </p>
 ```

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -60,8 +60,6 @@
 
 .btn         { @include btn-solid($text-gray-dark, $gray-000, darken($gray-100, 2%)); }
 .btn-primary { @include btn-solid($text-white, $green-400, $green-500); }
-@warn ".btn-purple will be removed in 13.0.0. Please don't make buttons purple.";
-.btn-purple  { @include btn-solid($text-white, lighten($purple-500, 5%), darken($purple-500, 5%)); }
 .btn-blue    { @include btn-solid($text-white, lighten($blue-500, 8%), darken($blue-500, 2%)); }
 .btn-danger  { @include btn-inverse($red-600, $gray-000, darken($gray-100, 2%)); }
 


### PR DESCRIPTION
This removes the purple buttons from primer and mentions of them in the docs.

It solves the first half of https://github.com/primer/css/issues/734. Turns out there aren't any orange buttons in Primer.

I'll follow up with a PR removing blue buttons once we've removed them from `github/github`.

/cc @primer/ds-core
