### PR TITLE
Fix .hide utilities

### DIFF
--- a/pages/css/utilities/layout.md
+++ b/pages/css/utilities/layout.md
@@ -85,9 +85,9 @@ Hide utilities are able to be applied or changed per breakpoint using the follow
 
 | Shorthand | Range |
 | --- | --- |
-| -sm | 0—544px |
-| -md | 544px—768px |
-| -lg | 768px—1004px |
+| -sm | 0—543px |
+| -md | 544px—767px |
+| -lg | 768px—1003px |
 | -xl | 1004px and above |
 
 ```html

--- a/src/utilities/visibility-display.scss
+++ b/src/utilities/visibility-display.scss
@@ -27,19 +27,19 @@ $display-values: (
 
 // Hide utilities for each breakpoint
 // Each hide utility only applies to one breakpoint range.
-@media (max-width: $width-sm) {
+@media (max-width: $width-sm - 1px) {
   .hide-sm {
     display: none !important;
   }
 }
 
-@media (min-width: $width-sm) and (max-width: $width-md) {
+@media (min-width: $width-sm) and (max-width: $width-md - 1px) {
   .hide-md {
     display: none !important;
   }
 }
 
-@media (min-width: $width-md) and (max-width: $width-lg) {
+@media (min-width: $width-md) and (max-width: $width-lg - 1px) {
   .hide-lg {
     display: none !important;
   }


### PR DESCRIPTION
This fixes the `hide-xx` utilities when used to toggle two elements at different breakpoints.

Before | After
--- | ---
![hide-b](https://user-images.githubusercontent.com/378023/55628224-1f906a80-57eb-11e9-9f05-9033317bbb9d.gif) | ![hide-a](https://user-images.githubusercontent.com/378023/55628076-b872b600-57ea-11e9-8dde-b096d58b59e7.gif)

## Problem

The `.hide-xx` utilities overlap by 1 px at each break point. Currently the values are like this:

```
.hide-sm: 0 - 544px
.hide-md:     544px - 768px
.hide-lg:             768px - 1012px
.hide-xl:                     1012px - infinite
```

So if two elements get toggled like with:

```html
<div class="hide-md"></div>
<div class="hide-lg"></div>
```

At exactly `768px` both elements are hidden.

## Fix

By removing `1px` from all the `max-width`s, e.g. `max-width: $width-sm - 1px`, they don't overlap anymore and continue seamless:

```
.hide-sm: 0 - 543px
.hide-md:          544px - 767px
.hide-lg:                       768px - 1011px
.hide-xl:                                     1012px - infinite
```
