### PR TITLE
deps: upgrade to cssstats@3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8004,98 +8004,62 @@
       "dev": true
     },
     "cssstats": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cssstats/-/cssstats-3.2.0.tgz",
-      "integrity": "sha1-m0sU6I7b1vltayRgzcyeNLNhkAY=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/cssstats/-/cssstats-3.3.0.tgz",
+      "integrity": "sha512-IMWt7iU9zqz2GuSYJaaR6p9TCFutcDg308+DN/haGhkQMX1uSLUymJ0IxV+oXyLSqs+/wNNKsF9RaRQC4IOrOQ==",
       "dev": true,
       "requires": {
-        "bytes": "^2.4.0",
+        "bytes": "^3.0.0",
         "css-selector-tokenizer": "^0.7.0",
         "css-shorthand-expand": "^1.1.0",
-        "gzip-size": "^3.0.0",
-        "has-class-selector": "1.0.0",
-        "has-element-selector": "^1.0.0",
-        "has-id-selector": "1.0.0",
-        "has-pseudo-class": "1.0.1",
-        "has-pseudo-element": "1.0.0",
-        "is-blank": "^1.1.0",
+        "gzip-size": "^4.1.0",
+        "has-class-selector": "^3.3.0",
+        "has-element-selector": "^3.3.0",
+        "has-id-selector": "^3.3.0",
+        "has-pseudo-class": "^3.3.0",
+        "has-pseudo-element": "^3.3.0",
+        "is-blank": "^2.1.0",
         "is-css-shorthand": "^1.0.1",
         "is-present": "^1.0.0",
-        "is-vendor-prefixed": "0.0.1",
-        "lodash": "^4.16.6",
-        "postcss": "^5.2.5",
-        "postcss-safe-parser": "^2.0.0",
-        "specificity": "^0.3.0"
+        "is-vendor-prefixed": "^3.3.0",
+        "lodash": "^4.17.5",
+        "postcss": "^6.0.21",
+        "postcss-safe-parser": "^3.0.1",
+        "specificity": "^0.3.2"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "bytes": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
-          "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
         "gzip-size": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
-          "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-4.1.0.tgz",
+          "integrity": "sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=",
           "dev": true,
           "requires": {
-            "duplexer": "^0.1.1"
+            "duplexer": "^0.1.1",
+            "pify": "^3.0.0"
           }
         },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "postcss": {
-          "version": "5.2.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
           }
         },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -12221,9 +12185,9 @@
       }
     },
     "has-class-selector": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-class-selector/-/has-class-selector-1.0.0.tgz",
-      "integrity": "sha1-p79Rvs3C133/JQkgPtafNEUODC0=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/has-class-selector/-/has-class-selector-3.3.0.tgz",
+      "integrity": "sha512-xxC3FqoqmX2F1EMGiknV9h1OjPd6bocrubuK2RUkjvROMhkmy0MceYM7pMVQ4a/Y2PRO1qPaIVSX8SnTruib+Q==",
       "dev": true
     },
     "has-color": {
@@ -12233,30 +12197,12 @@
       "dev": true
     },
     "has-element-selector": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-element-selector/-/has-element-selector-1.0.0.tgz",
-      "integrity": "sha1-JohCJeEjQ36N+WBMATWB0p0ZC5c=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/has-element-selector/-/has-element-selector-3.3.0.tgz",
+      "integrity": "sha512-+Xd0Q+gE9wndkYPzKkPxGa9W5/Ko8HuBrP1DhsRg6jJEHy0nU3NU1p1ivVL2hqBITaD/fV0l7AX3hU9NlGhdFQ==",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "^0.5.4"
-      },
-      "dependencies": {
-        "css-selector-tokenizer": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
-          "integrity": "sha1-E5uv00o1/QwUKEhwSeBpnm9qLCE=",
-          "dev": true,
-          "requires": {
-            "cssesc": "^0.1.0",
-            "fastparse": "^1.1.1"
-          }
-        },
-        "cssesc": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-          "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
-          "dev": true
-        }
+        "css-selector-tokenizer": "^0.7.0"
       }
     },
     "has-flag": {
@@ -12272,24 +12218,24 @@
       "dev": true
     },
     "has-id-selector": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-id-selector/-/has-id-selector-1.0.0.tgz",
-      "integrity": "sha1-1BtC6SKFhub+xWZyjOszqucay0U=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/has-id-selector/-/has-id-selector-3.3.0.tgz",
+      "integrity": "sha512-JM9eFjdenfSPoXRucfL+m4h8VZAqsvw0Q7f3Jg4v3kHzkfdNvDeOmf5imigT/EjOcEWZcVHBAVoB+6Wk6Nbhag==",
       "dev": true
     },
     "has-pseudo-class": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-pseudo-class/-/has-pseudo-class-1.0.1.tgz",
-      "integrity": "sha1-Bj7cjp9ZRpdq9P9OuzLDMNVW4Ac=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/has-pseudo-class/-/has-pseudo-class-3.3.0.tgz",
+      "integrity": "sha512-zkHGV9xlr04GBcBoJPT6Xaw3hT335ioljkpcC3rTYB0PWs9ybR98xsWACwt+et9x5qtTaA/1eUKlA8LkWhYOng==",
       "dev": true,
       "requires": {
-        "pseudo-classes": "0.0.1"
+        "pseudo-classes": "1.0.0"
       }
     },
     "has-pseudo-element": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-pseudo-element/-/has-pseudo-element-1.0.0.tgz",
-      "integrity": "sha1-NMoZEgHAFDcJ9CtLc/HcY7dg8D8=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/has-pseudo-element/-/has-pseudo-element-3.3.0.tgz",
+      "integrity": "sha512-d0BUyTU8UwAgx7KJQ5d33oCRrwRB42I7cHYNhetzvNBEQURMHNRHk+c3FenkqFcvHM44mL3RFb7FoQqORV1fcQ==",
       "dev": true,
       "requires": {
         "pseudo-elements": "1.0.0"
@@ -13217,12 +13163,12 @@
       }
     },
     "is-blank": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-blank/-/is-blank-1.1.0.tgz",
-      "integrity": "sha1-knTdvUY2PLdnB1w4XUq4jGpk3Bc=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-blank/-/is-blank-2.1.0.tgz",
+      "integrity": "sha1-aac9PA1PQX3/+yB6J5XA8OV23gQ=",
       "dev": true,
       "requires": {
-        "is-empty": "0.0.1",
+        "is-empty": "^1.2.0",
         "is-whitespace": "^0.3.0"
       }
     },
@@ -13332,9 +13278,9 @@
       "dev": true
     },
     "is-empty": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/is-empty/-/is-empty-0.0.1.tgz",
-      "integrity": "sha1-Cf3D1kndpZaRVsCFOpt2vXgcWjM=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-empty/-/is-empty-1.2.0.tgz",
+      "integrity": "sha1-3pu1snhzigWgsJpX4ftNSjQan2s=",
       "dev": true
     },
     "is-equal-shallow": {
@@ -13546,6 +13492,12 @@
             "is-empty": "0.0.1",
             "is-whitespace": "^0.3.0"
           }
+        },
+        "is-empty": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/is-empty/-/is-empty-0.0.1.tgz",
+          "integrity": "sha1-Cf3D1kndpZaRVsCFOpt2vXgcWjM=",
+          "dev": true
         }
       }
     },
@@ -13664,12 +13616,12 @@
       "dev": true
     },
     "is-vendor-prefixed": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/is-vendor-prefixed/-/is-vendor-prefixed-0.0.1.tgz",
-      "integrity": "sha1-Bc8NhTxidNf7K/htU+EHgguca0Q=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is-vendor-prefixed/-/is-vendor-prefixed-3.3.0.tgz",
+      "integrity": "sha512-P8aQoDqlPI2E+zpqsKWf0+KBDNVdVYgfPXsIBDGDQ7oRaSEPsSEKkbHM8ZbKlsDZh8NgCWwjK6Ks4X7ONK7VpQ==",
       "dev": true,
       "requires": {
-        "vendor-prefixes": "0.0.1"
+        "vendor-prefixes": "1.0.0"
       }
     },
     "is-whitespace": {
@@ -19027,67 +18979,30 @@
       "dev": true
     },
     "postcss-safe-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-2.0.1.tgz",
-      "integrity": "sha1-Oz0cS0OiTDlC4vC+eWE4KzSLOxM=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-3.0.1.tgz",
+      "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
       "dev": true,
       "requires": {
-        "postcss": "^5.2.16"
+        "postcss": "^6.0.6"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
-          "version": "5.2.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
           }
         },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -19640,9 +19555,9 @@
       "dev": true
     },
     "pseudo-classes": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/pseudo-classes/-/pseudo-classes-0.0.1.tgz",
-      "integrity": "sha1-3smD2Upo0D3f3vPwfESvn2wiOls=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pseudo-classes/-/pseudo-classes-1.0.0.tgz",
+      "integrity": "sha1-YKabZzlcNv8RnE0chuGYF4Uga5Y=",
       "dev": true
     },
     "pseudo-elements": {
@@ -25795,9 +25710,9 @@
       "dev": true
     },
     "vendor-prefixes": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/vendor-prefixes/-/vendor-prefixes-0.0.1.tgz",
-      "integrity": "sha1-mLQ2f4y3CZIw78IOBA9UrtAY0G0=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vendor-prefixes/-/vendor-prefixes-1.0.0.tgz",
+      "integrity": "sha1-HHuS7ORuLxoGxakHYT9dUARd9TE=",
       "dev": true
     },
     "vendors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10838,12 +10838,6 @@
         "readable-stream": "^2.0.0"
       }
     },
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ=",
-      "dev": true
-    },
     "fs-extra": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
@@ -10906,7 +10900,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10930,13 +10925,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10953,19 +10950,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11096,7 +11096,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11110,6 +11111,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11126,6 +11128,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11134,13 +11137,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11161,6 +11166,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11249,7 +11255,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11263,6 +11270,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11358,7 +11366,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11400,6 +11409,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11421,6 +11431,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11469,13 +11480,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@mdx-js/tag": "0.15.0",
     "@primer/blueprints": "3.0.1",
     "@primer/components": "12.0.1",
-    "@primer/next-pages": "0.0.3",
     "@storybook/addon-viewport": "5.0.0",
     "@storybook/react": "5.0.0",
     "@svgr/webpack": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "@githubprimer/octicons-react": "^8.1.3",
     "@mdx-js/mdx": "^0.16.6",
     "@mdx-js/tag": "0.15.0",
+    "@primer/blueprints": "3.0.1",
+    "@primer/components": "12.0.1",
+    "@primer/next-pages": "0.0.3",
     "@storybook/addon-viewport": "5.0.0",
     "@storybook/react": "5.0.0",
     "@svgr/webpack": "2.4.1",
@@ -74,6 +77,7 @@
     "gray-matter": "^4.0.1",
     "hast-util-to-html": "^5.0.0",
     "hast-util-to-string": "^1.0.1",
+    "html-2-jsx": "0.5.1-dev",
     "html-to-react": "^1.2.11",
     "klaw": "3.0.0",
     "loader-utils": "^1.1.0",
@@ -94,7 +98,9 @@
     "prism-github": "^1.1.0",
     "prop-types": "^15.6.2",
     "raw-loader": "^0.5.1",
+    "react": "16.8.1",
     "react-bodymovin": "2.0.0",
+    "react-dom": "16.8.1",
     "react-live": "1.12.0",
     "react-measure": "^2.2.2",
     "refractor": "^2.6.2",
@@ -117,13 +123,6 @@
     "unist-util-select": "^2.0.0",
     "unist-util-stringify-position": "^2.0.0",
     "unist-util-visit": "^1.4.0",
-    "webpack": "4.20.2",
-    "@primer/components": "12.0.1",
-    "@primer/next-pages": "0.0.3",
-    "fs": "0.0.1-security",
-    "html-2-jsx": "0.5.1-dev",
-    "react": "16.8.1",
-    "react-dom": "16.8.1",
-    "@primer/blueprints": "3.0.1"
+    "webpack": "4.20.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "code-blocks": "^1.1.0",
     "colorette": "^1.0.7",
     "css-loader": "^0.28.4",
-    "cssstats": "3.2.0",
+    "cssstats": "3.3.0",
     "details-dialog-element": "^1.4.0",
     "eslint": "4.19.1",
     "eslint-plugin-github": "1.0.0",


### PR DESCRIPTION
The latest release of cssstats fixes a bug with the selector stats that was mistakenly including _selector-like_ `@keyframes` declarations. Running `script/selector-diff-report` generates this diff:

```diff
788,789d787
< from
< to
852,853d849
< 0%
< 100%
856,857d851
< 0%
< 100%
859,860d852
< 0%
< 100%
862,863d853
< 0%
< 100%
865d854
< to
867d855
< to
869,870d856
< 0%
< 100%
872,874d857
< 0%
< 10%
< 100%
876,878d858
< 0%
< 50%
< 100%
```

This is a prerequisite of https://github.com/primer/stylelint-config-primer/pull/25, because that will throw errors for any keyframe animation with matching breakpoints.