### PR TITLE
Upgrade stylelint config

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -34,7 +34,7 @@ action "publish" {
 
 action "deploy" {
   needs = "install"
-  uses = "primer/deploy@v2.2.0"
+  uses = "primer/deploy@v3.0.0"
   secrets = [
     "GITHUB_TOKEN",
     "NOW_TOKEN",

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,9 @@
 {
   "extends": [
     "stylelint-config-primer"
-  ]
+  ],
+  "rules": {
+    "primer/no-override": false,
+    "primer/selector-no-utility": false
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8455,9 +8455,9 @@
           "dev": true
         },
         "camelcase": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
-          "integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==",
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         },
         "cliui": {
@@ -10831,7 +10831,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10855,13 +10856,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10878,19 +10881,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11021,7 +11027,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11035,6 +11042,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11051,6 +11059,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11059,13 +11068,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11086,6 +11097,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11174,7 +11186,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11188,6 +11201,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11283,7 +11297,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11325,6 +11340,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11346,6 +11362,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11394,13 +11411,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -19355,23 +19374,6 @@
       "integrity": "sha512-9f1MNOMYOWemosmJIG8FToqZoL7YKQW3KHNsMS3DddTUzJefnVzeqmiiTBPc2ok0yE7fE2PgobG9iRY+itgdVg==",
       "dev": true
     },
-    "primer-utilities": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/primer-utilities/-/primer-utilities-4.14.2.tgz",
-      "integrity": "sha512-KE5JYqQB9Gf/3RIMj97jgfr1ArtlPoPTb4kuuia18xTz8gJ+Bek7jphNKsN+WuwhgZo8c0OSox2bn/Y89LDKvg==",
-      "dev": true,
-      "requires": {
-        "primer-support": "4.7.1"
-      },
-      "dependencies": {
-        "primer-support": {
-          "version": "4.7.1",
-          "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.7.1.tgz",
-          "integrity": "sha512-BruDzdeTQW7UVsyR2eKxTWMHRzumCTs+Sc6I5reOwTmBIJ2o9CWtj1DvAO8l97+rzQiyajJWi/fJ7i2Zr9Uupg==",
-          "dev": true
-        }
-      }
-    },
     "prism-github": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/prism-github/-/prism-github-1.1.0.tgz",
@@ -23014,15 +23016,15 @@
       }
     },
     "stylelint-config-primer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-primer/-/stylelint-config-primer-4.0.0.tgz",
-      "integrity": "sha512-mxJj83zo28cIZGr8/dj0ykP5Ms3jVVZEWGaLd2w5wXoDm3jREozJgVFA0vvOeFe5G2E98KWgLBQIlcctd7ldOg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-primer/-/stylelint-config-primer-7.0.0.tgz",
+      "integrity": "sha512-PpQTJK9WYEoPRIpQtshKeslcloxLwRWTrF+lLgWKxRNsD/J0xuW+ucykqHYeO5+fJALWgFS06MdKQD/eg0Iycw==",
       "dev": true,
       "requires": {
         "stylelint-no-unsupported-browser-features": "^1.0.0",
         "stylelint-order": "^2.0.0",
-        "stylelint-scss": "^3.5.2",
-        "stylelint-selector-no-utility": "2.0.2"
+        "stylelint-scss": "3.5.2",
+        "stylelint-selector-no-utility": "4.0.0"
       }
     },
     "stylelint-no-unsupported-browser-features": {
@@ -23057,9 +23059,9 @@
       }
     },
     "stylelint-order": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-2.1.0.tgz",
-      "integrity": "sha512-8oX4Y3Bh4e3s9e7nnYJkeyYg5yx8Fa7wwTNXJcabPrNqavK9FqZ3zNJFvCJFn+v5qTngvVWsh33DpOP2BdroBg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-2.2.1.tgz",
+      "integrity": "sha512-019KBV9j8qp1MfBjJuotse6MgaZqGVtXMc91GU9MsS9Feb+jYUvUU3Z8XiClqPdqJZQ0ryXQJGg3U3PcEjXwfg==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.10",
@@ -23068,9 +23070,9 @@
       }
     },
     "stylelint-scss": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.5.4.tgz",
-      "integrity": "sha512-hEdEOfFXVqxWcUbenBONW/cAw5cJcEDasY8tGwKNAAn1GDHoZO1ATdWpr+iIk325mPGIQqVb1sUxsRxuL70trw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.5.2.tgz",
+      "integrity": "sha512-HL95s8Q6wihbJe7c7z6rL9GHVHOF3H3tXkVmGutitwn14LYR52JYMwCkcifqlf4nRsvXrUDaoH6OHOdilifyjw==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.11",
@@ -23100,12 +23102,11 @@
       }
     },
     "stylelint-selector-no-utility": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stylelint-selector-no-utility/-/stylelint-selector-no-utility-2.0.2.tgz",
-      "integrity": "sha512-xvaDl20+NkuK9CeNtsBuuTHSSHb6QXZX5nBwzkvNc5gccArJddB0sUedYIF9ZgT2o5T0jI6KwOu/xb4xy6LKvA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-selector-no-utility/-/stylelint-selector-no-utility-4.0.0.tgz",
+      "integrity": "sha512-C3o1nTwTiRldiLwnN7H99GUJU3xjHGFY1SKc5d87Gljxr1I5EfD7V0/I6UNU/hxd5wWJg5o0XiqFEor+Rbwf1Q==",
       "dev": true,
       "requires": {
-        "primer-utilities": "4.14.2",
         "stylelint": "^7.13.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "style-loader": "^0.18.2",
     "styled-components": "4.1.2",
     "stylelint": "9.10.1",
-    "stylelint-config-primer": "4.0.0",
+    "stylelint-config-primer": "7.0.0",
     "title-case": "^2.1.1",
     "tree-model": "^1.0.7",
     "typographic-base": "^1.0.4",


### PR DESCRIPTION
This PR is a placeholder for upgrading to `stylelint-config-primer@6.0.0` once https://github.com/primer/stylelint-config-primer/pull/27 is ready. For now, let's see if the canary release of https://github.com/primer/stylelint-config-primer/pull/25 plays nicely.