### PR TITLE
Update blueprints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1366,9 +1366,9 @@
       }
     },
     "@primer/blueprints": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@primer/blueprints/-/blueprints-3.0.3.tgz",
-      "integrity": "sha512-HgLiAt/G2jyiM6bTNnA3pXCM1CBBOJDFjz3FA5hsLMIZ3YaRieI3m5Ay7oqNHSx6KtiLiDQUe975x1lejdyJiA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@primer/blueprints/-/blueprints-3.0.4.tgz",
+      "integrity": "sha512-jmIBWhadXR7rXZDaTxNDpPzD+G0TPwKXrx4cNOdAw55HVR/t3PRMjyvkJYuyYntcJG4fegZaqbtoxXYbPBYnEA==",
       "dev": true,
       "requires": {
         "@githubprimer/octicons-react": "^8.1.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@githubprimer/octicons-react": "^8.1.3",
     "@mdx-js/mdx": "^0.16.6",
     "@mdx-js/tag": "0.15.0",
-    "@primer/blueprints": "3.0.3",
+    "@primer/blueprints": "3.0.4",
     "@primer/components": "12.0.1",
     "@primer/next-pages": "0.0.3",
     "@storybook/addon-viewport": "5.0.0",


### PR DESCRIPTION
This PR upgrades @primer/blueprints to 3.0.4 to get the new syntax highlighting theme