### PR TITLE
More color utilities!

### DIFF
--- a/src/support/variables/color-system.scss
+++ b/src/support/variables/color-system.scss
@@ -126,7 +126,7 @@ $grays: (
   7: $gray-700,
   8: $gray-800,
   9: $gray-900,
-);
+) !default;
 
 $blues: (
   0: $blue-000,
@@ -139,7 +139,7 @@ $blues: (
   7: $blue-700,
   8: $blue-800,
   9: $blue-900,
-);
+) !default;
 
 $greens: (
   0: $green-000,
@@ -152,7 +152,7 @@ $greens: (
   7: $green-700,
   8: $green-800,
   9: $green-900,
-);
+) !default;
 
 $yellows: (
   0: $yellow-000,
@@ -165,7 +165,7 @@ $yellows: (
   7: $yellow-700,
   8: $yellow-800,
   9: $yellow-900,
-);
+) !default;
 
 $oranges: (
   0: $orange-000,
@@ -178,7 +178,7 @@ $oranges: (
   7: $orange-700,
   8: $orange-800,
   9: $orange-900,
-);
+) !default;
 
 $reds: (
   0: $red-000,
@@ -191,7 +191,7 @@ $reds: (
   7: $red-700,
   8: $red-800,
   9: $red-900,
-);
+) !default;
 
 $purples: (
   0: $purple-000,
@@ -204,4 +204,14 @@ $purples: (
   7: $purple-700,
   8: $purple-800,
   9: $purple-900,
-);
+) !default;
+
+$hue-maps: (
+  gray: $grays,
+  blue: $blues,
+  green: $greens,
+  yellow: $yellows,
+  orange: $oranges,
+  red: $reds,
+  purple: $purples,
+) !default;

--- a/src/support/variables/color-system.scss
+++ b/src/support/variables/color-system.scss
@@ -112,3 +112,96 @@ $orange:      $orange-500 !default;
 $gray-dark:   $gray-900 !default;
 $gray-light:  $gray-400 !default;
 $gray:        $gray-500 !default;
+
+// -------- Color gradient maps --------
+
+$grays: (
+  0: $gray-000,
+  1: $gray-100,
+  2: $gray-200,
+  3: $gray-300,
+  4: $gray-400,
+  5: $gray-500,
+  6: $gray-600,
+  7: $gray-700,
+  8: $gray-800,
+  9: $gray-900,
+);
+
+$blues: (
+  0: $blue-000,
+  1: $blue-100,
+  2: $blue-200,
+  3: $blue-300,
+  4: $blue-400,
+  5: $blue-500,
+  6: $blue-600,
+  7: $blue-700,
+  8: $blue-800,
+  9: $blue-900,
+);
+
+$greens: (
+  0: $green-000,
+  1: $green-100,
+  2: $green-200,
+  3: $green-300,
+  4: $green-400,
+  5: $green-500,
+  6: $green-600,
+  7: $green-700,
+  8: $green-800,
+  9: $green-900,
+);
+
+$yellows: (
+  0: $yellow-000,
+  1: $yellow-100,
+  2: $yellow-200,
+  3: $yellow-300,
+  4: $yellow-400,
+  5: $yellow-500,
+  6: $yellow-600,
+  7: $yellow-700,
+  8: $yellow-800,
+  9: $yellow-900,
+);
+
+$oranges: (
+  0: $orange-000,
+  1: $orange-100,
+  2: $orange-200,
+  3: $orange-300,
+  4: $orange-400,
+  5: $orange-500,
+  6: $orange-600,
+  7: $orange-700,
+  8: $orange-800,
+  9: $orange-900,
+);
+
+$reds: (
+  0: $red-000,
+  1: $red-100,
+  2: $red-200,
+  3: $red-300,
+  4: $red-400,
+  5: $red-500,
+  6: $red-600,
+  7: $red-700,
+  8: $red-800,
+  9: $red-900,
+);
+
+$purples: (
+  0: $purple-000,
+  1: $purple-100,
+  2: $purple-200,
+  3: $purple-300,
+  4: $purple-400,
+  5: $purple-500,
+  6: $purple-600,
+  7: $purple-700,
+  8: $purple-800,
+  9: $purple-900,
+);

--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -35,7 +35,7 @@
 // Generate a foreground and background utility for every shade of every hue
 @each $hue, $shades in $hue-maps {
   @each $index, $color in $shades {
-    .fg-#{$hue}-#{$index} { color: $color !important; }
+    .color-#{$hue}-#{$index} { color: $color !important; }
     .bg-#{$hue}-#{$index} { background-color: $color !important; }
   }
 }

--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -32,6 +32,14 @@
 /* Set the background to $bg-purple-light */
 .bg-purple-light     { background-color: $bg-purple-light !important; }
 
+// Generate a foreground and background utility for every shade of every hue
+@each $hue, $shades in $hue-maps {
+  @each $index, $color in $shades {
+    .fg-#{$hue}-#{$index} { color: $color !important; }
+    .bg-#{$hue}-#{$index} { background-color: $color !important; }
+  }
+}
+
 .bg-shade-gradient {
   background-image: linear-gradient(180deg, rgba($black, 0.065), rgba($black, 0)) !important;
   background-repeat: no-repeat !important;


### PR DESCRIPTION
This PR adds _140 new utility classes_ — a foreground and background utility for each shade (10) of every hue (of which there are 7).

There is some redundancy with existing utilities, and GitHub's postcss config combines selectors with the same style (for instance, `.text-blue` and `.fg-blue-5` are combined), but the size difference is ~not~ actually pretty insignificant: **less than 1K gzipped**!

```
┌─────────────────────┬───────────┬───────┬───────────┬─────────┬──────────┬───────┬──────────────────────────────┐
│ name                │ selectors │     ± │ gzip size │       ± │ raw size │     ± │ path                         │
├─────────────────────┼───────────┼───────┼───────────┼─────────┼──────────┼───────┼──────────────────────────────┤
│ primer              │      3096 │ + 140 │   23.88 K │ + 991 B │ 151.95 K │ + 6 K │ dist/primer.css              │
│ core                │      2139 │ + 140 │   17.12 K │ + 998 B │ 108.09 K │ + 6 K │ dist/core.css                │
│ utilities           │      1292 │ + 140 │    8.23 K │ + 998 B │  62.73 K │ + 6 K │ dist/utilities.css           │
```

I am swapping out the `text-` prefix used in our "old" color utilities for ~`fg-`~ `color-` because we often use utilities to give color to octicons rather than text specifically.