### PR TITLE
Responsive tooltips

### DIFF
--- a/pages/css/components/tooltips.md
+++ b/pages/css/components/tooltips.md
@@ -118,3 +118,22 @@ By default the tooltips have a slight delay before appearing. This is to keep mu
   </span>
 </div>
 ```
+
+## Tooltips for touch input
+
+**Note**: We hide tooltips when the primary input mechanism cannot hover. For example on mobile phones or tablets where the primary input method is touch.
+
+Use the `tooltipped-touch` modifier class to enable tooltips also for touch input. Most mobile browsers mimick hovering by tapping once. Try to avoid using tooltips on mobile where a user performs a certain action (buttons, links), because the tooltip will only show up after the action already happened.
+
+```html
+<div>
+  <span class="tooltipped tooltipped-e d-inline-block border p-2" aria-label="Hidden on mobile">
+    .tooltipped
+  </span>
+</div>
+<div class="mt-3">
+  <span class="tooltipped tooltipped-touch tooltipped-n d-inline-block border p-2" aria-label="Shows on mobile">
+    .tooltipped .tooltipped-touch
+  </span>
+</div>
+```

--- a/src/tooltips/tooltips.scss
+++ b/src/tooltips/tooltips.scss
@@ -277,3 +277,15 @@
     }
   }
 }
+
+// Responsive tooltips
+//
+// Hide tooltips when primary input mechanism cannot hover
+@media (hover: none) {
+  .tooltipped:hover {
+    &::before,
+    &::after {
+      display: none;
+    }
+  }
+}

--- a/src/tooltips/tooltips.scss
+++ b/src/tooltips/tooltips.scss
@@ -280,9 +280,10 @@
 
 // Responsive tooltips
 //
-// Hide tooltips when primary input mechanism cannot hover
+// Hide tooltips when primary input mechanism cannot hover (default)
+// Enable tooltips for touch input with .tooltipped-touch
 @media (hover: none) {
-  .tooltipped:hover {
+  .tooltipped:not(.tooltipped-touch):hover {
     &::before,
     &::after {
       display: none;


### PR DESCRIPTION
This makes the tooltips "responsive". More specifically:

- By default all tooltips are **hidden** when the primary input mechanism **cannot hover** (touch input on mobile, tablets)
- You can still **enable** tooltips for touch input with the `.tooltipped-touch` modifier class.

For example the `info` icon does nothing except showing more information with a tooltip. In this case it would be ok to use `.tooltipped-touch` so that you can tap on it also on a phone/tablet to make the tooltip appear.

![Screen Shot 2019-04-25 at 10 58 12 AM](https://user-images.githubusercontent.com/378023/56704846-ae890680-6749-11e9-93c6-c29cd356f2b6.png)

## Tested on

- [x] iOS Safari
- [x] iOS Chrome
- [x] iOS Firefox
- [x] Android Chrome
- [x] Android Firefox

## Concerns

We have been testing part of this with https://github.com/github/github/pull/113518. A problem [reported](https://github.com/github/github/issues/68989#issuecomment-513147535) by a user is that:

- a laptop with a touch screen
- connected to an external monitor (probably not relevant)
- and using an external mouse

is currently broken. The browser thinks that the "primary" input device is touch so hovering with the mouse does not work. An alternative might be to use `any-hover:none` instead of `hover:none`. But that would probably mean that when the user would use the touchscreen, the hover effects are not disabled because the media query only reacts to "what input device is available" and not "what input device is currently in use".

/cc @primer/ds-core

---

Issue https://github.com/github/design-systems/issues/558
Test on .com: https://github.com/github/github/pull/113518