### PR TITLE
Prefer FOUT over FOIT with custom @font-face marketing font

### DIFF
--- a/src/marketing/support/variables.scss
+++ b/src/marketing/support/variables.scss
@@ -6,6 +6,7 @@ $marketing-font-path: "/primer-marketing-support/fonts/" !default;
   font-style: normal;
   font-weight: $font-weight-normal;
   src: local("Inter"), local("Inter-Regular"), url("#{$marketing-font-path}Inter-Regular.woff") format("woff");
+  font-display: swap;
 }
 
 @font-face {
@@ -13,6 +14,7 @@ $marketing-font-path: "/primer-marketing-support/fonts/" !default;
   font-style: normal;
   font-weight: $font-weight-semibold;
   src: local("Inter Medium"), local("Inter-Medium"), url("#{$marketing-font-path}Inter-Medium.woff") format("woff");
+  font-display: swap;
 }
 
 $font-mktg: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;


### PR DESCRIPTION
This addresses https://github.com/github/site-design/issues/700~ 🔤  [`font-display: swap`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) will immediately render a fallback font until the custom font successfully loads. 

[Can I Use? browser coverage](https://caniuse.com/#feat=css-font-rendering-controls) ✨ [W3 Spec](https://www.w3.org/TR/css-fonts-4/#font-display-desc)