### PR TITLE
Add aria-selected="true" support to tabnav

### DIFF
--- a/src/navigation/tabnav.scss
+++ b/src/navigation/tabnav.scss
@@ -25,6 +25,7 @@
   border: 1px solid transparent;
   border-bottom: 0;
 
+  &[aria-selected=true],
   &.selected {
     color: $text-gray-dark;
     background-color: $bg-white;


### PR DESCRIPTION
This gives the selected tab styles to `.tabnav-tab` elements with `aria-selected="true"` so that it can be used seamlessly with [`<tab-container>`](https://github.com/github/tab-container-element), as in [this CodePen](https://codepen.io/team/GitHub/pen/KLdBXO?editors=1000):

```html
<tab-container class="d-block container-md my-4">
  <div class="tabnav mb-3">
    <div class="tabnav-tabs" role="tablist">
      <button class="tabnav-tab" role="tab" aria-selected="true">Tab 1</button>
      <button class="tabnav-tab" role="tab">Tab 2</button>
    </div>
  </div>

  <div class="px-3">
    <div role="tabpanel">Tab 1 content</div>
    <div role="tabpanel" hidden>Tab 2 content</div>
  </div>
</tab-container>
```

/cc @muan