### PR TITLE
Fix Ruby Sass compiler warnings

### DIFF
--- a/src/support/variables/color-system.scss
+++ b/src/support/variables/color-system.scss
@@ -232,12 +232,12 @@ $pinks: (
 ) !default;
 
 $hue-maps: (
-  gray: $grays,
-  blue: $blues,
-  green: $greens,
-  yellow: $yellows,
-  orange: $oranges,
-  red: $reds,
-  purple: $purples,
-  pink: $pinks,
+  "gray": $grays,
+  "blue": $blues,
+  "green": $greens,
+  "yellow": $yellows,
+  "orange": $oranges,
+  "red": $reds,
+  "purple": $purples,
+  "pink": $pinks,
 ) !default;


### PR DESCRIPTION
Fixes #783 by quoting the color name keys in our `$hue-maps` declaration.

/cc @gladwearefriends @tarebyte 