### PR TITLE
Add overflow: visible utilities

### DIFF
--- a/pages/css/utilities/layout.md
+++ b/pages/css/utilities/layout.md
@@ -105,16 +105,18 @@ Hide utilities are able to be applied or changed per breakpoint using the follow
 Adjust the visibility of an element with `.v-hidden` and `.v-visible`.
 
 ## Overflow
-Adjust element overflow with `.overflow-hidden`, `.overflow-scroll`, and `.overflow-auto`. `.overflow-hidden` can also be used to create a new [block formatting context](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context) or clear floats.
+Adjust element overflow with `.overflow-hidden`, `.overflow-scroll`, and `.overflow-auto`, or use `.overflow-visible` to undo the effects of CSS with overflow issues. `.overflow-hidden` can also be used to create a new [block formatting context](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context) or clear floats.
 
 Overflow utilities can also target x- and y-axes independently via:
 
 * `.overflow-x-auto`
 * `.overflow-x-hidden`
 * `.overflow-x-scroll`
+* `.overflow-x-visible`
 * `.overflow-y-auto`
 * `.overflow-y-hidden`
 * `.overflow-y-scroll`
+* `.overflow-y-visible`
 
 ## Floats
 Use `.float-left` and `.float-right` to set floats, and `.clearfix` to clear.

--- a/src/utilities/layout.scss
+++ b/src/utilities/layout.scss
@@ -36,17 +36,11 @@
 .v-align-baseline    { vertical-align: baseline !important; }
 
 // Overflow utilities
-.overflow-hidden { overflow: hidden !important; }
-.overflow-x-hidden { overflow-x: hidden !important; }
-.overflow-y-hidden { overflow-y: hidden !important; }
-
-.overflow-auto { overflow: auto !important; }
-.overflow-x-auto { overflow-x: auto !important; }
-.overflow-y-auto { overflow-y: auto !important; }
-
-.overflow-scroll { overflow: scroll !important; }
-.overflow-x-scroll { overflow-x: scroll !important; }
-.overflow-y-scroll { overflow-y: scroll !important; }
+@each $overflow in (visible, hidden, auto, scroll) {
+  .overflow-#{$overflow} { overflow: $overflow !important; }
+  .overflow-x-#{$overflow} { overflow-x: $overflow !important; }
+  .overflow-y-#{$overflow} { overflow-y: $overflow !important; }
+}
 
 // Clear floats
 /* Clear floats around the element */


### PR DESCRIPTION
This adds utilities to set `overflow: visible`, which is helpful in "undoing" CSS that messes with overflow in undesirable ways, and rounds out our overflow utility suite. Here's `script/bundle-size-report --version=next`, which compares this branch with the latest release candidate of #793:

```
┌─────────────────────┬───────────┬─────┬───────────┬────────┬──────────┬─────────┬──────────────────────────────┐
│ name                │ selectors │   ± │ gzip size │      ± │ raw size │       ± │ path                         │
├─────────────────────┼───────────┼─────┼───────────┼────────┼──────────┼─────────┼──────────────────────────────┤
│ utilities           │      1327 │ + 3 │    8.46 K │ + 21 B │  64.24 K │ + 146 B │ dist/utilities.css           │
```