### PR TITLE
Remove primer/deploy action

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,11 +1,6 @@
-workflow "lint, test, deploy, publish" {
+workflow "lint, test, publish" {
   on = "push"
-  resolves = [
-    "lint",
-    "test",
-    "publish",
-    "deploy",
-  ]
+  resolves = ["lint", "test", "publish"]
 }
 
 action "install" {
@@ -30,13 +25,4 @@ action "publish" {
   uses = "primer/publish@v1.0.0"
   args = ["--", "--unsafe-perm"]
   secrets = ["GITHUB_TOKEN", "NPM_AUTH_TOKEN"]
-}
-
-action "deploy" {
-  needs = "install"
-  uses = "primer/deploy@v3.0.0"
-  secrets = [
-    "GITHUB_TOKEN",
-    "NOW_TOKEN",
-  ]
 }


### PR DESCRIPTION
This removes the `primer/deploy` action in favor of using [Now's GitHub integration](https://zeit.co/docs/v2/integrations/now-for-github/), which has some distinct advantages:

1. It uses the GitHub Deployments API, so the deployment links aren't buried in commit statuses.

1. It handles canceling in-progress builds if you push before they're done:
    > With each new push, if Now is already building a previous commit, Now will cancel that current build to start the most recent commit so that you always have the latest changes deployed as quickly as possible.

1. It _apparently_ creates [automatic staging aliases](https://zeit.co/docs/v2/integrations/now-for-github/#staging-aliases-for-the-latest-changes-for-each-pull-request) for each pull request. I'm curious to see if this PR gets one, because #808 didn't. 🤔 

Let's see how this goes!