### PR TITLE
Improve monospaced font on Chrome Android

### DIFF
--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -36,7 +36,7 @@ $lh-default: 1.5 !default;
 $body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
 
 // Monospace font stack
-$mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace, Courier !default;
+$mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace !default;
 
 // The base body size
 $body-font-size: 14px !default;

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -36,7 +36,7 @@ $lh-default: 1.5 !default;
 $body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
 
 // Monospace font stack
-$mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace !default;
+$mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace, Courier !default;
 
 // The base body size
 $body-font-size: 14px !default;

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -36,7 +36,7 @@ $lh-default: 1.5 !default;
 $body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
 
 // Monospace font stack
-$mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace !default;
+$mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace !default;
 
 // The base body size
 $body-font-size: 14px !default;


### PR DESCRIPTION
This improves the monospaced font on Chrome Android.

### Problem

It seems that Chrome on Android skips the first 4 fonts from Primer's mono font stack and uses `Courier`. Which is very thin and probably not meant for smaller text sizes.  Interestingly Firefox skips `Courier` and uses the fallback `monospace` font.

```scss
$mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace !default;
```

Chrome | Firefox
--- | ---
![chrome](https://user-images.githubusercontent.com/378023/58630090-51b8d700-8319-11e9-8338-3548729e00bd.png) | ![firefox](https://user-images.githubusercontent.com/378023/58630091-51b8d700-8319-11e9-82d3-d8f2de9c8afb.png)

### Fix

By switching the order, Chrome now also uses the browser's fallback `monospace` font before using `Courier`. This should translate to:

- Chrome Android: `monospace` -> `Monaco`
- Firefox Android: `monospace` -> `Droid Sans Mono`

### Alternatives

We _could_ add `Monaco` and `Droid Sans Mono` to the font stack. Which would have the same result. But maybe it's ok to leave it up to the browser to pick the "best" monospaced font. In case we don't like it whenever it gets changed, we can override it again.

/cc @primer/ds-core
