### PR TITLE
Side Nav component

### DIFF
--- a/pages/css/components/navigation.md
+++ b/pages/css/components/navigation.md
@@ -214,6 +214,46 @@ Any kind of content can be added inside a Side Nav item. Use utility classes to 
 </nav>
 ```
 
+### Side Sub Nav
+
+A more lightweight version, without borders and more condensed.
+
+```html
+<aside class="bg-gray-light border" style="max-width: 360px">
+  <nav class="SideSubNav">
+    <h5 class="text-gray mb-2 pb-1 border-bottom">Menu</h5>
+    <a class="SideSubNav-item" href="#url">Account</a>
+    <a class="SideSubNav-item" href="#url" aria-current="page">Profile</a>
+    <a class="SideSubNav-item" href="#url">Emails</a>
+    <a class="SideSubNav-item" href="#url">Notifications</a>
+  </nav>
+<aside>
+```
+
+The `.SideSubNav` can also be nested.
+
+```html
+<nav class="SideNav bg-gray-light border" style="max-width: 360px">
+  <a class="SideNav-item" href="#url">
+    <svg class="SideNav-squareIcon octicon octicon-person mr-2" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 14.002a.998.998 0 0 1-.998.998H1.001A1 1 0 0 1 0 13.999V13c0-2.633 4-4 4-4s.229-.409 0-1c-.841-.62-.944-1.59-1-4 .173-2.413 1.867-3 3-3s2.827.586 3 3c-.056 2.41-.159 3.38-1 4-.229.59 0 1 0 1s4 1.367 4 4v1.002z"></path></svg>
+    Account
+  </a>
+  <a class="SideNav-item" href="#url" aria-current="page">
+    <svg class="SideNav-squareIcon octicon octicon-octoface mr-2" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
+    Profile
+  </a>
+  <nav class="SideSubNav border-y pl-6">
+    <a class="SideSubNav-item pl-1" href="#url" aria-current="page">Sub item 1</a>
+    <a class="SideSubNav-item pl-1" href="#url">Sub item 2</a>
+    <a class="SideSubNav-item pl-1" href="#url">Sub item 3</a>
+  </nav>
+  <a class="SideNav-item" href="#url">
+    <svg class="SideNav-squareIcon octicon octicon-mail mr-2" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 4v8c0 .55.45 1 1 1h12c.55 0 1-.45 1-1V4c0-.55-.45-1-1-1H1c-.55 0-1 .45-1 1zm13 0L7 9 1 4h12zM1 5.5l4 3-4 3v-6zM2 12l3.5-3L7 10.5 8.5 9l3.5 3H2zm11-.5l-4-3 4-3v6z"></path></svg>
+    Emails
+  </a>
+</nav>
+```
+
 ## Tabnav
 
 When you need to toggle between different views, consider using a tabnav. It'll give you a left-aligned horizontal row of... tabs!

--- a/pages/css/components/navigation.md
+++ b/pages/css/components/navigation.md
@@ -235,7 +235,7 @@ The `.SideSubNav` can also be nested.
 ```html
 <nav class="SideNav bg-gray-light border" style="max-width: 360px">
   <a class="SideNav-item" href="#url">
-    <svg class="SideNav-squareIcon octicon octicon-person mr-2" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 14.002a.998.998 0 0 1-.998.998H1.001A1 1 0 0 1 0 13.999V13c0-2.633 4-4 4-4s.229-.409 0-1c-.841-.62-.944-1.59-1-4 .173-2.413 1.867-3 3-3s2.827.586 3 3c-.056 2.41-.159 3.38-1 4-.229.59 0 1 0 1s4 1.367 4 4v1.002z"></path></svg>
+    <svg class="SideNav-icon octicon octicon-person mr-2" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 14.002a.998.998 0 0 1-.998.998H1.001A1 1 0 0 1 0 13.999V13c0-2.633 4-4 4-4s.229-.409 0-1c-.841-.62-.944-1.59-1-4 .173-2.413 1.867-3 3-3s2.827.586 3 3c-.056 2.41-.159 3.38-1 4-.229.59 0 1 0 1s4 1.367 4 4v1.002z"></path></svg>
     Account
   </a>
   <a class="SideNav-item" href="#url" aria-current="page">

--- a/pages/css/components/navigation.md
+++ b/pages/css/components/navigation.md
@@ -239,16 +239,16 @@ The `.SideSubNav` can also be nested.
     Account
   </a>
   <a class="SideNav-item" href="#url" aria-current="page">
-    <svg class="SideNav-squareIcon octicon octicon-octoface mr-2" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
+    <svg class="SideNav-icon octicon octicon-octoface mr-2" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
     Profile
   </a>
-  <nav class="SideSubNav border-y pl-6">
+  <nav class="SideSubNav border-top pl-6">
     <a class="SideSubNav-item pl-1" href="#url" aria-current="page">Sub item 1</a>
     <a class="SideSubNav-item pl-1" href="#url">Sub item 2</a>
     <a class="SideSubNav-item pl-1" href="#url">Sub item 3</a>
   </nav>
   <a class="SideNav-item" href="#url">
-    <svg class="SideNav-squareIcon octicon octicon-mail mr-2" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 4v8c0 .55.45 1 1 1h12c.55 0 1-.45 1-1V4c0-.55-.45-1-1-1H1c-.55 0-1 .45-1 1zm13 0L7 9 1 4h12zM1 5.5l4 3-4 3v-6zM2 12l3.5-3L7 10.5 8.5 9l3.5 3H2zm11-.5l-4-3 4-3v6z"></path></svg>
+    <svg class="SideNav-icon octicon octicon-mail mr-2" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 4v8c0 .55.45 1 1 1h12c.55 0 1-.45 1-1V4c0-.55-.45-1-1-1H1c-.55 0-1 .45-1 1zm13 0L7 9 1 4h12zM1 5.5l4 3-4 3v-6zM2 12l3.5-3L7 10.5 8.5 9l3.5 3H2zm11-.5l-4-3 4-3v6z"></path></svg>
     Emails
   </a>
 </nav>

--- a/pages/css/components/navigation.md
+++ b/pages/css/components/navigation.md
@@ -172,7 +172,7 @@ Use `.UnderlineNav--full` in combination with container styles and `.UnderlineNa
 The Side Nav is a vertical list of navigational links, typically used on the left side of a page. **Width and placement must be set by you.** For example by using our grid columns or by applying an inline `width`.
 
 - You can use a **light gray background** and a **border** if the parent element doesn't have it already.
-- To add a "selected" state add `aria-current="page"`.
+- To add a "selected" state use `aria-current="page"`. If it should act more like a "tab menu" with button elements, use `aria-selected="true"` instead.
 
 ```html
 <nav class="SideNav bg-gray-light border" style="max-width: 360px">

--- a/pages/css/components/navigation.md
+++ b/pages/css/components/navigation.md
@@ -167,6 +167,53 @@ Use `.UnderlineNav--full` in combination with container styles and `.UnderlineNa
 </nav>
 ```
 
+## Side Nav
+
+The Side Nav is a vertical list of navigational links, typically used on the left side of a page. **Width and placement must be set by you.** For example by using our grid columns or by applying an inline `width`.
+
+- You can use a **light gray background** and a **border** if the parent element doesn't have it already.
+- To add a "selected" state add `aria-current="page"`.
+
+```html
+<nav class="SideNav bg-gray-light border" style="max-width: 360px">
+  <a class="SideNav-item" href="#url">Account</a>
+  <a class="SideNav-item" href="#url" aria-current="page">Profile</a>
+  <a class="SideNav-item" href="#url">Emails</a>
+  <a class="SideNav-item" href="#url">Notifications</a>
+</nav>
+```
+
+Any kind of content can be added inside a Side Nav item. Use utility classes to further style them if needed.
+
+```html
+<nav class="SideNav bg-gray-light border" style="max-width: 360px">
+  <a class="SideNav-item" href="#url">
+    Text only
+  </a>
+  <a class="SideNav-item" href="#url">
+    <img class="avatar avatar-small mr-2" src="https://avatars.githubusercontent.com/hubot?s=40" alt="hubot" height="20" width="20">
+    With an avatar
+  </a>
+  <a class="SideNav-item" href="#url">
+    <svg class="octicon octicon-octoface mr-2" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
+    With an icon
+  </a>
+  <a class="SideNav-item d-flex flex-items-center flex-justify-between" href="#url">
+    With a status icon <svg class="octicon octicon-primitive-dot color-green-5 ml-2 float-right" viewBox="0 0 8 16" version="1.1" width="8" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 8c0-2.2 1.8-4 4-4s4 1.8 4 4-1.8 4-4 4-4-1.8-4-4z"></path></svg>
+  </a>
+  <a class="SideNav-item d-flex flex-items-center flex-justify-between" href="#url">
+    With a label <span class="Label bg-blue" title="Label: label">label</span>
+  </a>
+  <a class="SideNav-item d-flex flex-items-center flex-justify-between" href="#url">
+    With a counter <span class="Counter bg-gray-2 ml-1">16</span>
+  </a>
+  <a class="SideNav-item" href="#url">
+    <h5>With a heading</h5>
+    <span>and some longer description</span>
+  </a>
+</nav>
+```
+
 ## Tabnav
 
 When you need to toggle between different views, consider using a tabnav. It'll give you a left-aligned horizontal row of... tabs!

--- a/pages/css/components/navigation.md
+++ b/pages/css/components/navigation.md
@@ -172,7 +172,7 @@ Use `.UnderlineNav--full` in combination with container styles and `.UnderlineNa
 The Side Nav is a vertical list of navigational links, typically used on the left side of a page. For maximum flexibility, **Side Nav elements have no default width or positioning**. We suggest using [column grid](../../objects/grid) classes or an inline `width` style for sizing, and [flexbox utilities](../../utilities/flexbox) for positioning alongside content.
 
 - You can use a **light gray background** and a **border** if the parent element doesn't have it already.
-- To add a "selected" state use `aria-current="page"`. If it should act more like a "tab menu" with button elements, use `aria-selected="true"` instead.
+- Add `aria-current="page"` to show a link as selected. Selected button elements in tab-like UIs should instead have `aria-selected="true"`.
 
 ```html
 <nav class="SideNav bg-gray-light border" style="max-width: 360px">

--- a/pages/css/components/navigation.md
+++ b/pages/css/components/navigation.md
@@ -169,7 +169,7 @@ Use `.UnderlineNav--full` in combination with container styles and `.UnderlineNa
 
 ## Side Nav
 
-The Side Nav is a vertical list of navigational links, typically used on the left side of a page. **Width and placement must be set by you.** For example by using our grid columns or by applying an inline `width`.
+The Side Nav is a vertical list of navigational links, typically used on the left side of a page. For maximum flexibility, **Side Nav elements have no default width or positioning**. We suggest using [column grid](../../objects/grid) classes or an inline `width` style for sizing, and [flexbox utilities](../../utilities/flexbox) for positioning alongside content.
 
 - You can use a **light gray background** and a **border** if the parent element doesn't have it already.
 - To add a "selected" state use `aria-current="page"`. If it should act more like a "tab menu" with button elements, use `aria-selected="true"` instead.

--- a/pages/css/components/navigation.md
+++ b/pages/css/components/navigation.md
@@ -240,7 +240,7 @@ Or also appear nested, as a sub navigation. Use margin/padding utility classes t
     <svg class="SideNav-icon octicon octicon-octoface mr-2" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
     <span>Profile</span>
   </a>
-  <nav class="SideNav border-top py-3 pl-6">
+  <nav class="SideNav bg-white border-top py-3 pl-6">
     <a class="SideNav-subItem" href="#url" aria-current="page">Sub item 1</a>
     <a class="SideNav-subItem" href="#url">Sub item 2</a>
     <a class="SideNav-subItem" href="#url">Sub item 3</a>

--- a/pages/css/components/navigation.md
+++ b/pages/css/components/navigation.md
@@ -183,7 +183,7 @@ The Side Nav is a vertical list of navigational links, typically used on the lef
 </nav>
 ```
 
-Any kind of content can be added inside a Side Nav item. Use utility classes to further style them if needed.
+Different kind of content can be added inside a Side Nav item. Use utility classes to further style them if needed.
 
 ```html
 <nav class="SideNav bg-gray-light border" style="max-width: 360px">
@@ -214,45 +214,45 @@ Any kind of content can be added inside a Side Nav item. Use utility classes to 
 </nav>
 ```
 
-### Side Sub Nav
-
-A more lightweight version, without borders and more condensed.
+The `.SideNav-subItem` is an alternative, more lightweight version without borders and more condensed. It can be used stand-alone.
 
 ```html
-<aside class="bg-gray-light border" style="max-width: 360px">
-  <nav class="SideSubNav">
-    <h5 class="text-gray mb-2 pb-1 border-bottom">Menu</h5>
-    <a class="SideSubNav-item" href="#url">Account</a>
-    <a class="SideSubNav-item" href="#url" aria-current="page">Profile</a>
-    <a class="SideSubNav-item" href="#url">Emails</a>
-    <a class="SideSubNav-item" href="#url">Notifications</a>
+<aside class="bg-gray-light border p-3" style="max-width: 360px">
+  <h5 class="text-gray mb-2 pb-1 border-bottom">Menu</h5>
+  <nav class="SideNav">
+    <a class="SideNav-subItem" href="#url">Account</a>
+    <a class="SideNav-subItem" href="#url" aria-current="page">Profile</a>
+    <a class="SideNav-subItem" href="#url">Emails</a>
+    <a class="SideNav-subItem" href="#url">Notifications</a>
   </nav>
 <aside>
 ```
 
-The `.SideSubNav` can also be nested.
+Or also appear nested, as a sub navigation. Use margin/padding utility classes to add indentation.
 
 ```html
 <nav class="SideNav bg-gray-light border" style="max-width: 360px">
   <a class="SideNav-item" href="#url">
     <svg class="SideNav-icon octicon octicon-person mr-2" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 14.002a.998.998 0 0 1-.998.998H1.001A1 1 0 0 1 0 13.999V13c0-2.633 4-4 4-4s.229-.409 0-1c-.841-.62-.944-1.59-1-4 .173-2.413 1.867-3 3-3s2.827.586 3 3c-.056 2.41-.159 3.38-1 4-.229.59 0 1 0 1s4 1.367 4 4v1.002z"></path></svg>
-    Account
+    <span>Account</span>
   </a>
   <a class="SideNav-item" href="#url" aria-current="page">
     <svg class="SideNav-icon octicon octicon-octoface mr-2" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
-    Profile
+    <span>Profile</span>
   </a>
-  <nav class="SideSubNav border-top pl-6">
-    <a class="SideSubNav-item pl-1" href="#url" aria-current="page">Sub item 1</a>
-    <a class="SideSubNav-item pl-1" href="#url">Sub item 2</a>
-    <a class="SideSubNav-item pl-1" href="#url">Sub item 3</a>
+  <nav class="SideNav border-top py-3 pl-6">
+    <a class="SideNav-subItem" href="#url" aria-current="page">Sub item 1</a>
+    <a class="SideNav-subItem" href="#url">Sub item 2</a>
+    <a class="SideNav-subItem" href="#url">Sub item 3</a>
   </nav>
   <a class="SideNav-item" href="#url">
     <svg class="SideNav-icon octicon octicon-mail mr-2" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 4v8c0 .55.45 1 1 1h12c.55 0 1-.45 1-1V4c0-.55-.45-1-1-1H1c-.55 0-1 .45-1 1zm13 0L7 9 1 4h12zM1 5.5l4 3-4 3v-6zM2 12l3.5-3L7 10.5 8.5 9l3.5 3H2zm11-.5l-4-3 4-3v6z"></path></svg>
-    Emails
+    <span>Emails</span>
   </a>
 </nav>
 ```
+
+
 
 ## Tabnav
 

--- a/src/navigation/index.scss
+++ b/src/navigation/index.scss
@@ -3,5 +3,6 @@
 @import "./menu.scss";
 @import "./tabnav.scss";
 @import "./filter-list.scss";
+@import "./sidenav.scss";
 @import "./subnav.scss";
 @import "./underline-nav.scss";

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -5,8 +5,12 @@
 .SideNav-item {
   position: relative;
   display: block;
+  width: 100%;
   padding: $spacer-2+$spacer-1 $spacer-3;
   color: $text-gray;
+  text-align: left;
+  background-color: transparent;
+  border: 0;
 
   & + & {
     border-top: $border;

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -11,9 +11,10 @@
   text-align: left;
   background-color: transparent;
   border: 0;
+  border-top: $border;
 
-  & + & {
-    border-top: $border;
+  &:first-child {
+    border-top: 0;
   }
 
   &:last-child {
@@ -70,12 +71,13 @@
   }
 }
 
-// Square Icon
+// Icon
 //
 // Makes sure multiple icons are vertically aligned
 
-.SideNav-squareIcon {
+.SideNav-icon {
   width: 16px;
+  color: $text-gray-light;
 }
 
 // Side Sub Nav

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -6,7 +6,7 @@
   position: relative;
   display: block;
   width: 100%;
-  padding: $spacer-2+$spacer-1 $spacer-3;
+  padding: $spacer-3;
   color: $text-gray;
   text-align: left;
   background-color: transparent;
@@ -40,30 +40,22 @@
 
 // States
 
-.SideNav-item:hover {
-  text-decoration: none;
-}
-
 .SideNav-item:hover,
 .SideNav-item:focus {
+  outline: none;
+  text-decoration: none;
+  color: $text-gray-dark;
+
+  // Bar on the left
   &::before {
     transition: transform 0.12s ease-out;
     transform: scaleX(1);
   }
 }
 
-.SideNav-item:focus {
-  outline: none;
-}
-
 .SideNav-item:active {
   background-color: $bg-white;
 }
-
-// Selected
-//
-// Use aria-current="page" for links
-// Use aria-selected="true" for tabs (button)
 
 .SideNav-item[aria-current="page"],
 .SideNav-item[aria-selected="true"] {
@@ -76,4 +68,44 @@
     background-color: $orange-600;
     transform: scaleX(1);
   }
+}
+
+// Square Icon
+//
+// Makes sure multiple icons are vertically aligned
+
+.SideNav-squareIcon {
+  width: 16px;
+}
+
+// Side Sub Nav
+//
+// A more lightweight version, suited as sub nav
+
+.SideSubNav {
+  padding: $spacer-3;
+}
+
+.SideSubNav-item {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: $spacer-1 0;
+  color: $text-gray;
+  text-align: left;
+  background-color: transparent;
+  border: 0;
+}
+
+.SideSubNav-item:hover,
+.SideSubNav-item:focus {
+  outline: none;
+  text-decoration: none;
+  color: $text-gray-dark;
+}
+
+.SideSubNav-item[aria-current="page"],
+.SideSubNav-item[aria-selected="true"] {
+  font-weight: $font-weight-semibold;
+  color: $text-gray-dark;
 }

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -1,0 +1,75 @@
+// Side Nav
+//
+// A vertical list of navigational links, typically used on the left side of a page.
+
+.SideNav-item {
+  position: relative;
+  display: block;
+  padding: $spacer-2+$spacer-1 $spacer-3;
+  color: $text-gray;
+
+  & + & {
+    border-top: $border;
+  }
+
+  &:last-child {
+    // makes sure there is a "bottom border" in case the list is not long enough
+    box-shadow: 0 $border-width 0 $border-color;
+  }
+
+  // Bar on the left
+  &::before {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    width: 3px;
+    pointer-events: none;
+    content: "";
+    background-color: $gray-300;
+    transition: transform 0.24s ease-in;
+    transform: scaleX(0);
+    transform-origin: center left;
+  }
+}
+
+// States
+
+.SideNav-item:hover {
+  text-decoration: none;
+}
+
+.SideNav-item:hover,
+.SideNav-item:focus {
+  &::before {
+    transition: transform 0.12s ease-out;
+    transform: scaleX(1);
+  }
+}
+
+.SideNav-item:focus {
+  outline: none;
+}
+
+.SideNav-item:active {
+  background-color: $bg-white;
+}
+
+// Selected
+//
+// Use aria-current="page" for links
+// Use aria-selected="true" for tabs (button)
+
+.SideNav-item[aria-current="page"],
+.SideNav-item[aria-selected="true"] {
+  font-weight: $font-weight-semibold;
+  color: $text-gray-dark;
+  background-color: $bg-white;
+
+  // Bar on the left
+  &::before {
+    background-color: $orange-600;
+    transform: scaleX(1);
+  }
+}

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -80,15 +80,11 @@
   color: $text-gray-light;
 }
 
-// Side Sub Nav
+// Sub Nav
 //
-// A more lightweight version, suited as sub nav
+// A more lightweight version, suited as a sub nav
 
-.SideSubNav {
-  padding: $spacer-3;
-}
-
-.SideSubNav-item {
+.SideNav-subItem {
   position: relative;
   display: block;
   width: 100%;
@@ -99,15 +95,15 @@
   border: 0;
 }
 
-.SideSubNav-item:hover,
-.SideSubNav-item:focus {
+.SideNav-subItem:hover,
+.SideNav-subItem:focus {
   outline: none;
   text-decoration: none;
   color: $text-gray-dark;
 }
 
-.SideSubNav-item[aria-current="page"],
-.SideSubNav-item[aria-selected="true"] {
+.SideNav-subItem[aria-current="page"],
+.SideNav-subItem[aria-selected="true"] {
   font-weight: $font-weight-semibold;
   color: $text-gray-dark;
 }

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -46,6 +46,7 @@
   outline: none;
   text-decoration: none;
   color: $text-gray-dark;
+  background-color: $gray-100;
 
   // Bar on the left
   &::before {

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -93,7 +93,7 @@
   display: block;
   width: 100%;
   padding: $spacer-1 0;
-  color: $text-gray;
+  color: $blue-500;
   text-align: left;
   background-color: transparent;
   border: 0;

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -43,10 +43,10 @@
 
 .SideNav-item:hover,
 .SideNav-item:focus {
-  outline: none;
-  text-decoration: none;
   color: $text-gray-dark;
+  text-decoration: none;
   background-color: $gray-100;
+  outline: none;
 
   // Bar on the left
   &::before {
@@ -98,9 +98,9 @@
 
 .SideNav-subItem:hover,
 .SideNav-subItem:focus {
-  outline: none;
-  text-decoration: none;
   color: $text-gray-dark;
+  text-decoration: none;
+  outline: none;
 }
 
 .SideNav-subItem[aria-current="page"],


### PR DESCRIPTION
This adds a "Side Nav" component to Primer CSS.

Basic | With different content types
--- | ---
![image](https://user-images.githubusercontent.com/378023/59920303-12d3f800-9465-11e9-947e-8eca32ecc2b5.png) | ![image](https://user-images.githubusercontent.com/378023/59920304-12d3f800-9465-11e9-9c38-17f6cbb71cfb.png)

## Basic markup

```html
<nav class="SideNav">
  <a class="SideNav-item" href="#url">Account</a>
  <a class="SideNav-item" href="#url" aria-current="page">Profile</a>
  <a class="SideNav-item" href="#url">Emails</a>
  <a class="SideNav-item" href="#url">Notifications</a>
</nav>
```

Utility and inline styles are optional and depend a bit where the component gets used. There could be modifier classes, but using utilities seems just as simple and allows for more flexibility without the maintenance cost.

## Next steps
- [x] Create component
- [x] Add documentation
- [x] Test on .com
- [x] Change Sub Nav text to blue
- [x] Cleanup
- [x] Finalize documentation

## .com tests
- [x] COC and license picker https://github.com/github/github/pull/119242
- [ ] Enterprise navigation https://github.com/github/github/pull/118177

---

Issue: https://github.com/github/design-systems/issues/624