### PR TITLE
Primer 12.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+# 12.5.0
+
+### :rocket: Enhancement
+- Add `.Toast` component [#831](https://github.com/primer/css/pull/831)
+- Add `.SideNav` component [#827](https://github.com/primer/css/pull/827)
+- Add `.SelectMenu` component [#808](https://github.com/primer/css/pull/808)
+- Add `font-display: swap` to `@font-face` declarations [#780](https://github.com/primer/css/pull/780)
+- Add `flex-grow-0`, `flex-order-[1,2,none]` and `width-auto` utilities [#763](https://github.com/primer/css/pull/763)
+- Change default for `$marketing-font-path` to `/fonts/` [#837](https://github.com/primer/css/pull/837)
+
+### :bug: Bug Fix
+- Improve monospaced font on Chrome Android [#812](https://github.com/primer/css/pull/812)
+
+### :memo: Documentation
+- Add multi-word naming conventions to BEM docs [#836](https://github.com/primer/css/pull/836)
+- Color system docs updates [#811](https://github.com/primer/css/pull/811)
+- Color utility table tweaks [#842](https://github.com/primer/css/pull/842)
+- Fix markdown typos in Contributing docs page [#846](https://github.com/primer/css/pull/846)
+
+### Committers
+- [@ampinsk](https://github.com/ampinsk)
+- [@emilybrick](https://github.com/emilybrick)
+- [@emplums](https://github.com/emplums)
+- [@jonrohan](https://github.com/jonrohan)
+- [@shawnbot](https://github.com/shawnbot)
+- [@simurai](https://github.com/simurai)
+- [@skullface](https://github.com/skullface)
+- [@vdepizzol](https://github.com/vdepizzol)
+
 # 12.4.1
 
 ### :bug: Bug fixes
@@ -87,7 +116,7 @@
 # 12.2.2
 
 ### :bug: Bug Fix
-- Fix hide utilities when toggling between breakpoints [#746](https://github.com/primer/css/pull/746) 
+- Fix hide utilities when toggling between breakpoints [#746](https://github.com/primer/css/pull/746)
 
 ### :house: Internal
 - Prevent Storybook publish failures from breaking builds on `master` [#728](https://github.com/primer/css/pull/728)

--- a/docs/Table.js
+++ b/docs/Table.js
@@ -1,0 +1,45 @@
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+import {Box} from '@primer/components'
+import {fontSize} from 'styled-system'
+
+const Table = styled.table`
+  display: table !important;
+  border-collapse: separate;
+  border-spacing: ${props => props.borderSpacing};
+  ${fontSize};
+
+  tr,
+  td,
+  th {
+    border: 0 !important;
+  }
+
+  caption,
+  td,
+  th {
+    padding: ${props => props.cellPadding} !important;
+    text-align: left;
+  }
+
+  tr {
+    background-color: transparent !important;
+  }
+`
+
+Table.propTypes = {
+  borderSpacing: PropTypes.any,
+  cellPadding: PropTypes.any,
+  ...fontSize.propTypes
+}
+
+Table.defaultProps = {
+  borderSpacing: 0,
+  cellPadding: '4px 8px',
+  fontSize: [1, 1, 2]
+}
+
+Table.Row = styled(Box).attrs({as: 'tr'})``
+Table.Cell = styled(Box).attrs({as: 'td'})``
+
+export default Table

--- a/docs/color-system.js
+++ b/docs/color-system.js
@@ -1,184 +1,224 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import chroma from 'chroma-js'
-import colors from 'primer-colors'
-import titleCase from 'title-case'
-import {BorderBox, Box, Flex, Heading, Text} from '@primer/components'
+import styled from 'styled-components'
+import {Box, StyledOcticon, Text} from '@primer/components'
+import {Zap} from '@githubprimer/octicons-react'
+import {colors, getPaletteByName} from './color-variables'
+import Table from './Table'
 
-const gradientHues = ['gray', 'blue', 'green', 'purple', 'yellow', 'orange', 'red']
-
-const {black: BLACK, white: WHITE} = colors
-
-export function ColorPalette(props) {
+export function PaletteTable(props) {
+  const {columns = [], hasHeader, ...rest} = props
+  const {children = <PaletteTableFragment columns={columns} {...rest} />} = rest
   return (
-    <Flex mb={6} className="markdown-no-margin" {...props}>
-      {gradientHues.map(hue => {
-        const color = colors[hue][5]
+    <Table {...rest}>
+      {hasHeader ? (
+        <thead>
+          <tr>
+            {getColumns(columns).map(col => (
+              <th key={col.title}>{col.title}</th>
+            ))}
+          </tr>
+        </thead>
+      ) : null}
+      {children}
+    </Table>
+  )
+}
+
+export function PaletteTableFragment(props) {
+  const {children, columns = [], name, type, sparse, prefix = type, ...rest} = props
+  let values = props.values
+  if (name) {
+    values = getPaletteByName(name).values
+  }
+  if (type && sparse) {
+    values = values.filter(v => v.aliases[type])
+  }
+  if (!values || values.length === 0) {
+    return null
+  }
+  const cols = getColumns(columns)
+  return (
+    <tbody {...rest}>
+      {children}
+      {values.map(row => {
+        const cellProps = {type, ...row}
+        const valueProps = {prefix, type, ...row}
         return (
-          <Box bg={color} p={3} width={200} mr={2} key={hue}>
-            <Text fontWeight="bold" color={overlayColor(color)}>
-              {titleCase(hue)}
-            </Text>
-          </Box>
+          <tr key={row.value}>
+            {cols.map(({Cell = PaletteCell, Value = PaletteValue, title}) => (
+              <Cell key={title} {...cellProps}>
+                <Value {...valueProps} />
+              </Cell>
+            ))}
+          </tr>
         )
       })}
-      <BorderBox bg="white" p={3} width={200} borderRadius={0}>
-        <Text fontWeight="bold" color="black">
-          White
-        </Text>
-      </BorderBox>
-    </Flex>
+    </tbody>
   )
 }
 
-export function ColorVariables(props) {
-  return (
-    <>
-      <Flex flexWrap="wrap" className="gutter" {...props}>
-        {gradientHues.map(hue => (
-          <ColorVariable id={hue} hue={hue} key={hue} />
-        ))}
-      </Flex>
-      <Flex flexWrap="wrap" {...props}>
-        <FadeVariables id="black" hue="black" bg="black" color="white">
-          <BorderBox border={0} borderRadius={0} borderTop={1} borderColor="gray.5" mt={1}>
-            <Text is="div" fontSize={2} pt={3} mb={0}>
-              Black fades apply alpha transparency to the <Var>$black</Var> variable. The black color value has a slight
-              blue hue to match our grays.
-            </Text>
-          </BorderBox>
-        </FadeVariables>
-        <FadeVariables id="white" hue="white" over={BLACK}>
-          <BorderBox border={0} borderRadius={0} borderTop={1} mt={1}>
-            <Text is="div" fontSize={2} pt={3} mb={0}>
-              White fades apply alpha transparency to the <Var>$white</Var> variable, below these are shown overlaid on
-              a dark gray background.
-            </Text>
-          </BorderBox>
-        </FadeVariables>
-      </Flex>
-    </>
+PaletteTable.defaultProps = {
+  columns: ['alias', 'className', 'variable', 'value'],
+  hasHeader: true
+}
+
+PaletteTableFragment.defaultProps = {
+  type: 'bg',
+  columns: PaletteTable.defaultProps.columns
+}
+
+PaletteTable.propTypes = {
+  columns: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        title: PropTypes.string,
+        Cell: PropTypes.func
+      })
+    ])
+  ),
+  name: PropTypes.string,
+  prefix: PropTypes.string,
+  type: PropTypes.string,
+  values: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      aliases: PropTypes.object
+    })
   )
 }
 
-export function ColorVariable({hue, ...rest}) {
-  const values = colors[hue]
-  return (
-    <Flex.Item is={Box} pr={4} mb={6} className="col-6 markdown-no-margin" {...rest}>
-      {/* <Heading is="div">{titleCase(hue)}</Heading> */}
-      <Box bg={`${hue}.5`} my={2} p={3} color="white">
-        <Heading is="div" pb={3} fontSize={56} fontWeight="light">
-          {titleCase(hue)}
-        </Heading>
-        <Flex justifyContent="space-between">
-          <Flex.Item flex="1 1 auto" is={Var}>
-            ${hue}-500
-          </Flex.Item>
-          <Text fontFamily="mono">{values[5]}</Text>
-        </Flex>
-      </Box>
-      {values.map((value, i) => (
-        <Swatch name={`${hue}-${i}00`} value={value} key={value} />
-      ))}
-    </Flex.Item>
-  )
+export function PaletteCell(props) {
+  return <Box {...props} />
 }
 
-ColorVariable.propTypes = {
-  hue: PropTypes.oneOf(Object.keys(colors)).isRequired
+PaletteCell.defaultProps = {
+  as: 'td'
 }
 
-export function FadeVariables({hue, color, bg, over, children, ...rest}) {
-  const colorValue = colors[hue]
-  const alphas = [15, 30, 50, 70, 85]
-  const values = alphas.map(alpha => {
-    const value = chroma(colorValue)
-      .alpha(alpha / 100)
-      .css()
-    return {
-      name: `${hue}-fade-${alpha}`,
-      textColor: fadeTextColor(value, over),
-      value
-    }
-  })
-  const boxProps = {color, bg}
-  return (
-    <Flex.Item is={Box} pr={4} mb={6} width={1 / 2} className="markdown-no-margin" {...rest}>
-      {/* <Heading is="div">{titleCase(hue)}</Heading> */}
-      <Box my={2} p={3} {...boxProps}>
-        <Heading is="div" pb={3} fontSize={56} fontWeight="light">
-          {titleCase(hue)}
-        </Heading>
-        <Flex justifyContent="space-between">
-          <Flex.Item flex="1 1 auto" is={Var}>
-            ${hue}
-          </Flex.Item>
-          <Text fontFamily="mono">
-            {chroma(colorValue).css()}
-            {' / '}
-            {colorValue}
-          </Text>
-        </Flex>
-        {children}
-      </Box>
-      <Box bg={over}>
-        {values.map(swatchProps => (
-          <Swatch {...swatchProps} key={swatchProps.name} />
-        ))}
-      </Box>
-    </Flex.Item>
-  )
-}
-
-FadeVariables.propTypes = {
-  bg: Box.propTypes.color,
-  color: Box.propTypes.color,
-  hue: PropTypes.oneOf(['black', 'white']),
-  over: PropTypes.string
-}
-
-function Swatch(props) {
-  const {name, value, textColor = overlayColor(value), ...rest} = props
-  return (
-    <Box bg={value} color={textColor} {...rest}>
-      <Text is={Flex} fontSize={1} justifyContent="space-between">
-        <Box p={3}>
-          <Var>${name}</Var>
-        </Box>
-        <Box p={3}>
-          <Text fontFamily="mono">{value}</Text>
-        </Box>
-      </Text>
-    </Box>
-  )
-}
-
-Swatch.propTypes = {
-  name: PropTypes.string.isRequired,
-  textColor: PropTypes.string,
+PaletteCell.propTypes = {
   value: PropTypes.string.isRequired
 }
 
-function Var(props) {
-  // FIXME: fontStyle should be a prop, right?
-  return <Text is="var" fontWeight="bold" fontFamily="mono" style={{fontStyle: 'normal'}} {...props} />
+PaletteCell.Alias = ({aliases, type, ...rest}) =>
+  aliases && aliases[type] ? (
+    <PaletteCell.Smart type={type} {...rest}>
+      <StyledOcticon icon={Zap} mr={2} />
+      <Var>.{aliases[type]}</Var>
+    </PaletteCell.Smart>
+  ) : (
+    <td />
+  )
+PaletteCell.Alias.propTypes = {
+  aliases: PropTypes.object.isRequired,
+  type: PropTypes.string.isRequired
 }
 
-function overlayColor(bg) {
-  return chroma(bg).luminance() > 0.5 ? BLACK : WHITE
+PaletteCell.Smart = ({type, ...rest}) => {
+  switch (type) {
+    case 'fg':
+    case 'text':
+      return <PaletteCell.Text {...rest} />
+    case 'border':
+      return <PaletteCell.Border {...rest} />
+    case 'bg':
+    default:
+      return <PaletteCell.Background {...rest} />
+  }
+}
+PaletteCell.Smart.propTypes = {
+  type: PropTypes.string.isRequired
 }
 
-function fadeTextColor(fg, bg = WHITE) {
-  const rgb = compositeRGB(fg, bg)
-  return overlayColor(rgb)
+PaletteCell.Background = ({value, ...rest}) => <PaletteCell bg={value} color={overlayColor(value)} {...rest} />
+
+PaletteCell.Text = ({value, ...rest}) => <PaletteCell color={value} bg={overlayColor(value)} {...rest} />
+
+PaletteCell.Border = ({value, ...rest}) => (
+  <PaletteCell bg="white" style={{border: `1px solid ${value} !important`}} {...rest} />
+)
+
+export function PaletteValue({value, ...rest}) {
+  return <Var {...rest}>{value}</Var>
 }
 
-/**
- * Composite ("flatten") a foreground RGBA value with an RGB background into an
- * RGB color for the purposes of measuring contrast or luminance.
- */
-function compositeRGB(foreground, background) {
-  const [fr, fg, fb, fa] = chroma(foreground).rgba()
-  const [br, bg, bb] = chroma(background).rgb()
-  return chroma([(1 - fa) * br + fa * fr, (1 - fa) * bg + fa * fg, (1 - fa) * bb + fa * fb]).css()
+PaletteValue.Variable = ({variable}) => <Var>${variable}</Var>
+PaletteValue.Variable.propTypes = {
+  variable: PropTypes.string.isRequired
+}
+
+PaletteValue.PrefixedClass = ({prefix, slug}) => (
+  <Var>
+    .{prefix}-{slug}
+  </Var>
+)
+PaletteValue.PrefixedClass.propTypes = {
+  prefix: PropTypes.string.isRequired,
+  slug: PropTypes.string.isRequired
+}
+
+PaletteTable.columns = {
+  variable: {
+    title: 'Variable',
+    Cell: PaletteCell.Background,
+    Value: PaletteValue.Variable
+  },
+  value: {
+    title: 'Value',
+    Cell: PaletteCell.Background,
+    Value: PaletteValue
+  },
+  background: {
+    title: 'Background',
+    Cell: PaletteCell.Background,
+    Value: PaletteCell.PrefixedClass
+  },
+  foreground: {
+    title: 'Foreground',
+    Cell: PaletteCell.Text,
+    Value: PaletteCell.PrefixedClass
+  },
+  className: {
+    title: 'Class',
+    Cell: PaletteCell.Background,
+    Value: PaletteValue.PrefixedClass
+  },
+  alias: {
+    title: 'Alias',
+    Cell: PaletteCell.Alias
+  }
+}
+
+export const Var = styled(Text).attrs({
+  as: 'var',
+  fontFamily: 'mono',
+  fontStyle: 'normal'
+})`
+  white-space: nowrap;
+`
+
+export const PaletteHeading = ({indicatorColor, children, ...rest}) => (
+  <Text as="th" fontWeight="bold" {...rest} style={{borderBottom: `2px solid ${colors.black} !important`}}>
+    <Box pt={3}>{children}</Box>
+  </Text>
+)
+
+const $overlayColorCache = new Map()
+export function overlayColor(bg) {
+  if (!bg) {
+    throw new Error(`overlayColor() expects a color string, but got: ${JSON.stringify(bg)}`)
+  }
+  if ($overlayColorCache.has(bg)) {
+    return $overlayColorCache.get(bg)
+  } else {
+    const result = chroma(bg).luminance() > 0.5 ? colors.black : colors.white
+    $overlayColorCache.set(bg, result)
+    return result
+  }
+}
+
+function getColumns(columns) {
+  return columns.map(col => PaletteTable.columns[col] || col).filter(col => col)
 }

--- a/docs/color-system.js
+++ b/docs/color-system.js
@@ -2,8 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import chroma from 'chroma-js'
 import styled from 'styled-components'
-import {Box, StyledOcticon, Text} from '@primer/components'
-import {Zap} from '@githubprimer/octicons-react'
+import {Box, Text} from '@primer/components'
 import {colors, getPaletteByName} from './color-variables'
 import Table from './Table'
 
@@ -60,7 +59,7 @@ export function PaletteTableFragment(props) {
 }
 
 PaletteTable.defaultProps = {
-  columns: ['alias', 'className', 'variable', 'value'],
+  columns: ['alias', 'variable', 'value'],
   hasHeader: true
 }
 
@@ -105,12 +104,12 @@ PaletteCell.propTypes = {
 PaletteCell.Alias = ({aliases, type, ...rest}) =>
   aliases && aliases[type] ? (
     <PaletteCell.Smart type={type} {...rest}>
-      <StyledOcticon icon={Zap} mr={2} />
       <Var>.{aliases[type]}</Var>
     </PaletteCell.Smart>
   ) : (
     <td />
   )
+
 PaletteCell.Alias.propTypes = {
   aliases: PropTypes.object.isRequired,
   type: PropTypes.string.isRequired
@@ -128,6 +127,7 @@ PaletteCell.Smart = ({type, ...rest}) => {
       return <PaletteCell.Background {...rest} />
   }
 }
+
 PaletteCell.Smart.propTypes = {
   type: PropTypes.string.isRequired
 }
@@ -154,6 +154,7 @@ PaletteValue.PrefixedClass = ({prefix, slug}) => (
     .{prefix}-{slug}
   </Var>
 )
+
 PaletteValue.PrefixedClass.propTypes = {
   prefix: PropTypes.string.isRequired,
   slug: PropTypes.string.isRequired
@@ -200,7 +201,7 @@ export const Var = styled(Text).attrs({
 `
 
 export const PaletteHeading = ({indicatorColor, children, ...rest}) => (
-  <Text as="th" fontWeight="bold" {...rest} style={{borderBottom: `2px solid ${colors.black} !important`}}>
+  <Text as="th" fontWeight="bold" {...rest}>
     <Box pt={3}>{children}</Box>
   </Text>
 )

--- a/docs/color-variables.js
+++ b/docs/color-variables.js
@@ -1,0 +1,81 @@
+import titleCase from 'title-case'
+import primerColors from 'primer-colors'
+
+import colorSystemSCSS from '!!raw-loader?module!../src/support/variables/color-system.scss'
+import colorVariablesSCSS from '!!raw-loader?module!../src/support/variables/colors.scss'
+
+const variables = {}
+
+parseSCSSVariables(colorSystemSCSS, variables)
+parseSCSSVariables(colorVariablesSCSS, variables)
+
+// XXX we don't necessarily define them in this order in primer-colors,
+// so we define an array here just to be safe
+const gradientHues = ['gray', 'blue', 'green', 'purple', 'yellow', 'orange', 'red', 'pink']
+
+const colors = {
+  ...primerColors,
+  pink: Object.keys(variables)
+    .filter(key => key.startsWith('pink-'))
+    .sort()
+    .map(key => variables[key])
+}
+
+const aliases = {}
+
+const palettes = gradientHues.map(name => {
+  return {
+    name,
+    title: titleCase(name),
+    value: variables[name] || colors[name][5],
+    values: colors[name].map((value, index) => ({
+      value,
+      index,
+      variable: `${name}-${index}00`,
+      slug: `${name}-${index}`,
+      aliases: (aliases[value] = {})
+    }))
+  }
+})
+
+for (const key of Object.keys(variables)) {
+  const match = key.match(/^(bg|text|border)-(\w+)(-(dark|light))?$/)
+  const value = variables[key]
+  if (match && aliases[value]) {
+    // eslint-disable-next-line no-unused-vars
+    const [_, type, name, suffix] = match
+    aliases[value][type] = key
+  }
+}
+
+export {colors, gradientHues, palettes, getPaletteByName, variables}
+
+export const allColors = palettes.reduce((all, {values}) => all.concat(values), [])
+
+export const borders = Object.keys(variables)
+  .filter(key => key.startsWith('border-') && !variables[key].includes('$'))
+  .sort()
+  .map(key => ({
+    variable: key,
+    value: variables[key],
+    slug: key,
+    aliases: {border: key}
+  }))
+
+function getPaletteByName(name) {
+  return palettes.find(palette => palette.name === name)
+}
+
+function parseSCSSVariables(scssString, variables = {}) {
+  const variablePattern = /\$([-\w]+):\s*(.+)( !default);/g
+  let match
+  do {
+    match = variablePattern.exec(scssString)
+    if (match) {
+      // eslint-disable-next-line no-unused-vars
+      const [_, name, value] = match
+      variables[name] = value.startsWith('$') ? variables[value.substr(1)] : value
+    }
+  } while (match)
+  return variables
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/css",
-  "version": "12.4.1",
+  "version": "12.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/css",
-  "version": "12.4.1",
+  "version": "12.5.0",
   "description": "Primer is the CSS framework that powers GitHub's front-end design. primer includes 23 packages that are grouped into 3 core meta-packages for easy install. Each package and meta-package is independently versioned and distributed via npm, so it's easy to include all or part of Primer within your own project.",
   "homepage": "https://primer.style/css",
   "author": "GitHub, Inc.",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -34,7 +34,7 @@ export default class MyApp extends App {
     const pathname = this.props.router.pathname.replace(/\/$/, '')
     const {Component, page} = this.props
     const node = rootPage.first(node => node.path === pathname) || {}
-    const {file, meta = {}} = node || {}
+    const {file = '', meta = {}} = node || {}
     const isIndex = file.includes('index')
     const Hero = file ? requirePage(file).Hero : null
 
@@ -61,7 +61,7 @@ export default class MyApp extends App {
             <Box width={['auto', 'auto', '100%']}>
               {Hero ? <Hero /> : null}
               <Box color="gray.9" maxWidth={['auto', 'auto', 'auto', CONTENT_MAX_WIDTH]} px={6} mx="auto" my={6}>
-                <div className="markdown-body">
+                <div className="markdown-body overflow-x-hidden">
                   {!meta.hero && meta.title ? <MarkdownHeading>{meta.title}</MarkdownHeading> : null}
                   <PackageHeader {...meta} />
                   <MDXProvider components={components}>

--- a/pages/css/components/navigation.md
+++ b/pages/css/components/navigation.md
@@ -167,6 +167,93 @@ Use `.UnderlineNav--full` in combination with container styles and `.UnderlineNa
 </nav>
 ```
 
+## Side Nav
+
+The Side Nav is a vertical list of navigational links, typically used on the left side of a page. For maximum flexibility, **Side Nav elements have no default width or positioning**. We suggest using [column grid](../../objects/grid) classes or an inline `width` style for sizing, and [flexbox utilities](../../utilities/flexbox) for positioning alongside content.
+
+- You can use a **light gray background** and a **border** if the parent element doesn't have it already.
+- Add `aria-current="page"` to show a link as selected. Selected button elements in tab-like UIs should instead have `aria-selected="true"`.
+
+```html
+<nav class="SideNav bg-gray-light border" style="max-width: 360px">
+  <a class="SideNav-item" href="#url">Account</a>
+  <a class="SideNav-item" href="#url" aria-current="page">Profile</a>
+  <a class="SideNav-item" href="#url">Emails</a>
+  <a class="SideNav-item" href="#url">Notifications</a>
+</nav>
+```
+
+Different kind of content can be added inside a Side Nav item. Use utility classes to further style them if needed.
+
+```html
+<nav class="SideNav bg-gray-light border" style="max-width: 360px">
+  <a class="SideNav-item" href="#url">
+    Text only
+  </a>
+  <a class="SideNav-item" href="#url">
+    <img class="avatar avatar-small mr-2" src="https://avatars.githubusercontent.com/hubot?s=40" alt="hubot" height="20" width="20">
+    With an avatar
+  </a>
+  <a class="SideNav-item" href="#url">
+    <svg class="octicon octicon-octoface mr-2" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
+    With an icon
+  </a>
+  <a class="SideNav-item d-flex flex-items-center flex-justify-between" href="#url">
+    With a status icon <svg class="octicon octicon-primitive-dot color-green-5 ml-2 float-right" viewBox="0 0 8 16" version="1.1" width="8" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 8c0-2.2 1.8-4 4-4s4 1.8 4 4-1.8 4-4 4-4-1.8-4-4z"></path></svg>
+  </a>
+  <a class="SideNav-item d-flex flex-items-center flex-justify-between" href="#url">
+    With a label <span class="Label bg-blue" title="Label: label">label</span>
+  </a>
+  <a class="SideNav-item d-flex flex-items-center flex-justify-between" href="#url">
+    With a counter <span class="Counter bg-gray-2 ml-1">16</span>
+  </a>
+  <a class="SideNav-item" href="#url">
+    <h5>With a heading</h5>
+    <span>and some longer description</span>
+  </a>
+</nav>
+```
+
+The `.SideNav-subItem` is an alternative, more lightweight version without borders and more condensed. It can be used stand-alone.
+
+```html
+<aside class="bg-gray-light border p-3" style="max-width: 360px">
+  <h5 class="text-gray mb-2 pb-1 border-bottom">Menu</h5>
+  <nav class="SideNav">
+    <a class="SideNav-subItem" href="#url">Account</a>
+    <a class="SideNav-subItem" href="#url" aria-current="page">Profile</a>
+    <a class="SideNav-subItem" href="#url">Emails</a>
+    <a class="SideNav-subItem" href="#url">Notifications</a>
+  </nav>
+<aside>
+```
+
+Or also appear nested, as a sub navigation. Use margin/padding utility classes to add indentation.
+
+```html
+<nav class="SideNav bg-gray-light border" style="max-width: 360px">
+  <a class="SideNav-item" href="#url">
+    <svg class="SideNav-icon octicon octicon-person mr-2" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 14.002a.998.998 0 0 1-.998.998H1.001A1 1 0 0 1 0 13.999V13c0-2.633 4-4 4-4s.229-.409 0-1c-.841-.62-.944-1.59-1-4 .173-2.413 1.867-3 3-3s2.827.586 3 3c-.056 2.41-.159 3.38-1 4-.229.59 0 1 0 1s4 1.367 4 4v1.002z"></path></svg>
+    <span>Account</span>
+  </a>
+  <a class="SideNav-item" href="#url" aria-current="page">
+    <svg class="SideNav-icon octicon octicon-octoface mr-2" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
+    <span>Profile</span>
+  </a>
+  <nav class="SideNav bg-white border-top py-3 pl-6">
+    <a class="SideNav-subItem" href="#url" aria-current="page">Sub item 1</a>
+    <a class="SideNav-subItem" href="#url">Sub item 2</a>
+    <a class="SideNav-subItem" href="#url">Sub item 3</a>
+  </nav>
+  <a class="SideNav-item" href="#url">
+    <svg class="SideNav-icon octicon octicon-mail mr-2" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 4v8c0 .55.45 1 1 1h12c.55 0 1-.45 1-1V4c0-.55-.45-1-1-1H1c-.55 0-1 .45-1 1zm13 0L7 9 1 4h12zM1 5.5l4 3-4 3v-6zM2 12l3.5-3L7 10.5 8.5 9l3.5 3H2zm11-.5l-4-3 4-3v6z"></path></svg>
+    <span>Emails</span>
+  </a>
+</nav>
+```
+
+
+
 ## Tabnav
 
 When you need to toggle between different views, consider using a tabnav. It'll give you a left-aligned horizontal row of... tabs!

--- a/pages/css/components/select-menu-deprecated.md
+++ b/pages/css/components/select-menu-deprecated.md
@@ -1,0 +1,878 @@
+---
+title: Select menu (deprecated)
+path: components/select-menu
+status: Deprecated
+source: 'https://github.com/github/github/blob/master/app/assets/stylesheets/components/select-menu.scss'
+symbols: [active, close-button, css-truncate-target, description, description-inline, description-warning, disabled, filterable-empty, has-error, hidden-select-button-text, icon-only, indeterminate, is-loading, is-showing-new-item-form, label-select-menu, last-visible, menu-active, modal-backdrop, navigation-focus, octicon, octicon-check, octicon-dash, octicon-octoface, octicon-x, opaque, primary, select-menu, select-menu-action, select-menu-blankslate, select-menu-button, select-menu-button-gravatar, select-menu-button-large, select-menu-clear-item, select-menu-divider, select-menu-error, select-menu-filters, select-menu-header, select-menu-item, select-menu-item-gravatar, select-menu-item-heading, select-menu-item-icon, select-menu-item-parent, select-menu-item-template, select-menu-item-text, select-menu-list, select-menu-loading-overlay, select-menu-modal, select-menu-modal-holder, select-menu-modal-narrow, select-menu-modal-right, select-menu-new-item-form, select-menu-no-results, select-menu-tab, select-menu-tab-bucket, select-menu-tab-nav, select-menu-tabs, select-menu-text-filter, select-menu-title, selected, spinner]
+---
+
+> Note: The `.select-menu` component is **deprecated**. Use the [`.SelectMenu`](select-menu) instead.
+
+## Migration guide
+
+Here a few tips how to migrate an existing `.select-menu` to `.SelectMenu`.
+
+1. Use a `<details>` element to toggle the Select Menu.
+2. Use a [`<details-menu>`](https://github.com/github/details-menu-element) element to add JS behaviour. The older `.js-select-menu` is not compatible.
+3. In case custom styling is needed, use [utility classes](https://primer.style/css/utilities) if possible.
+
+Below a comparison between class names:
+
+`.select-menu` | `.SelectMenu`
+--- | ---
+`select-menu` | -
+`select-menu-button` | -
+`select-menu-modal-holder` | -
+`select-menu-modal` | `SelectMenu`
+`select-menu-modal-right` | `SelectMenu right-0`
+- | `SelectMenu-modal`
+`select-menu-loading-overlay` | `SelectMenu-loading`
+`select-menu-item-icon` | `SelectMenu-icon`
+`select-menu-header` | `SelectMenu-header`
+`select-menu-title` | `SelectMenu-title`
+`close-button` | `SelectMenu-closeButton`
+`select-menu-filters` | -
+`select-menu-text-filter` | `SelectMenu-filter`
+- | `SelectMenu-input`
+`select-menu-tabs` | `SelectMenu-tabs`
+`select-menu-tab` | `SelectMenu-tab`
+`select-menu-tab-nav` | -
+`select-menu-list` | `SelectMenu-list`
+`select-menu-item` | `SelectMenu-item`
+`select-menu-item-text` | -
+`select-menu-no-results` | `SelectMenu-message`
+`select-menu-blankslate` | `SelectMenu-blankslate`
+`selected` | `aria-checked="true"`
+
+
+---
+
+The select menu provides advanced support for navigation, filtering, and more. Any popover within a select menu can make use of JavaScript-enabled live filtering, selected states, tabbed lists, and keyboard navigation with a bit of markup.
+
+{:toc}
+
+## Basic example
+
+Select menus should be trigged by a `<button>`. In the markup below, all classes prefixed with `select-menu` and `.js-` are required.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    Choose an item
+  </button>
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-list js-navigation-container">
+        <a href="#url" class="select-menu-item selected js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 1</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 2</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 3</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+## Menu contents
+
+The contents of a select menu are easily customized with support for headers, footers, tabbed lists, and live filtering.
+
+### Headers
+
+Add a header to any select menu's popover to house a clear title and a dismiss button.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    Choose an item
+  </button>
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-header js-navigation-enable" tabindex="-1">
+        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
+        <span class="select-menu-title">Options</span>
+      </div>
+      <div class="select-menu-list js-navigation-container">
+        <a href="#url" class="select-menu-item selected js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 1</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 2</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 3</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### List items
+
+The list of items is arguably the most important subcomponent within the menu. Build them out of anchors, buttons, or just about any [interactive content](http://w3c.github.io/html/dom.html#interactive-content). [List items are also customizable](#menu-list-items) with options for avatars, additional icons, and multiple lines of text.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    Choose an item
+  </button>
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-list js-navigation-container">
+        <button type="button" class="select-menu-item selected js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 1</span>
+        </button>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 2</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item" href="#url">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 3</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Filter
+
+Enable live filtering of list items within a `.select-menu-list` with a search input. Only a handful of changes to your menu's markup are required:
+
+- Add the text input, housed in `.select-menu-filters`, before the `.select-menu-list`.
+- Add two attritubes, `data-filterable-for` and `data-filterable-type`, to the `.select-menu-list` to scope the filter to the list.
+
+There are no required changes for the `.select-menu-item`s.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    <i>Label:</i>
+    <span class="js-select-button">Choose an item</span>
+  </button>
+  <div class="select-menu-modal-holder js-menu-content js-navigation-container">
+    <div class="select-menu-modal">
+      <div class="select-menu-header" tabindex="-1">
+        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
+        <span class="select-menu-title">Options</span>
+      </div>
+      <div class="js-select-menu-deferred-content">
+        <div class="select-menu-filters">
+          <div class="select-menu-text-filter">
+            <input type="text" id="example-filter-field" class="form-control js-filterable-field js-navigation-enable" placeholder="Filter this list" aria-label="Type to filter" autocomplete="off">
+          </div>
+        </div>
+        <div class="select-menu-list" data-filterable-for="example-filter-field" data-filterable-type="substring">
+          <input hidden="checkbox" name="example" value="">
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Test element
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Filter to this
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              More content
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Something else
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              One more thing
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Tabs
+
+Sometimes you need two or more lists of items in your select menu, e.g. branches and tags. Select menu lists can be tabbed with the addition of the tab toggles at the top of the menu and a few changes to the `.select-menu-list`.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    <i>Label:</i>
+    <span class="js-select-button">Choose an item</span>
+  </button>
+  <div class="select-menu-modal-holder js-menu-content js-navigation-container">
+    <div class="select-menu-modal">
+      <div class="select-menu-header" tabindex="-1">
+        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
+        <span class="select-menu-title">Options</span>
+      </div>
+      <div class="js-select-menu-deferred-content">
+        <div class="select-menu-filters">
+          <div class="select-menu-tabs">
+            <ul>
+              <li class="select-menu-tab">
+                <a href="#url" data-tab-filter="branches" data-filter-placeholder="Filter for " class="js-select-menu-tab" aria-current="false">Branches</a>
+              </li>
+              <li class="select-menu-tab">
+                <a href="#url" data-tab-filter="tags" data-filter-placeholder="Find a tag…" class="js-select-menu-tab selected" aria-current="true">Tags</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div class="select-menu-list select-menu-tab-bucket js-select-menu-tab-bucket selected" data-filterable-for="example-filter-field" data-filterable-type="substring" data-tab-filter="branches" role="menu">
+          <input hidden="checkbox" name="example" value="">
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Branch 1
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Branch 2
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Branch 3
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Branch 4
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Branch 5
+            </div>
+          </a>
+        </div>
+        <div class="select-menu-list select-menu-tab-bucket js-select-menu-tab-bucket" data-filterable-for="example-filter-field" data-filterable-type="substring" data-tab-filter="tags" role="menu">
+          <input hidden="checkbox" name="example" value="">
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Tag 1
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Tag 2
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Tag 3
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Tag 4
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Tag 5
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Filter and tabs
+
+Show a filter and tabs in a single select menu.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    <i>Label:</i>
+    <span class="js-select-button">Choose an item</span>
+  </button>
+  <div class="select-menu-modal-holder js-menu-content js-navigation-container">
+    <div class="select-menu-modal">
+      <div class="select-menu-header" tabindex="-1">
+        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
+        <span class="select-menu-title">Options</span>
+      </div>
+      <div class="js-select-menu-deferred-content">
+        <div class="select-menu-filters">
+          <div class="select-menu-text-filter">
+            <input type="text" id="example-filter-field-2" class="form-control js-filterable-field js-navigation-enable" placeholder="Filter labels" aria-label="Type or choose a label" autocomplete="off">
+          </div>
+          <div class="select-menu-tabs">
+            <ul>
+              <li class="select-menu-tab">
+                <a href="#url" data-tab-filter="branches" data-filter-placeholder="Filter for " class="js-select-menu-tab" aria-current="false">Branches</a>
+              </li>
+              <li class="select-menu-tab">
+                <a href="#url" data-tab-filter="tags" data-filter-placeholder="Find a tag…" class="js-select-menu-tab selected" aria-current="true">Tags</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div class="select-menu-list select-menu-tab-bucket js-select-menu-tab-bucket selected" data-filterable-for="example-filter-field" data-filterable-type="substring" data-tab-filter="branches" role="menu">
+          <input hidden="checkbox" name="example" value="">
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Branch 1
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Branch 2
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Branch 3
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Branch 4
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Branch 5
+            </div>
+          </a>
+        </div>
+        <div class="select-menu-list select-menu-tab-bucket js-select-menu-tab-bucket" data-filterable-for="example-filter-field" data-filterable-type="substring" data-tab-filter="tags" role="menu">
+          <input hidden="checkbox" name="example" value="">
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Tag 1
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Tag 2
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Tag 3
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Tag 4
+            </div>
+          </a>
+          <a href="#url" class="select-menu-item js-navigation-item">
+            <%= octicon("check", :class => "select-menu-item-icon") %>
+            <div class="select-menu-item-text js-select-button-text">
+              Tag 5
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Blankslate
+
+Sometimes a select menu needs to communicate a "blank slate" where there's no content in the menu's list. Usually these include a clear call to action to add said content to the list. Swap out the contents of a `.select-menu-list` with the `.select-menu-blankslate` and customize it's contents as needed.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    Choose an item
+  </button>
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-header js-navigation-enable" tabindex="-1">
+        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
+        <span class="select-menu-title">Options</span>
+      </div>
+      <div class="select-menu-list js-navigation-container">
+        <div class="select-menu-blankslate">
+          <%= octicon("check", :height => 32) %>
+          <h3>Select menu blankslate</h3>
+          <p>Some text here to describe why you're seeing a blankslate and how to go about fixing that up.</p>
+          <button type="button" class="btn btn-sm btn-primary mt-3 mb-3">Deal with it</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+## Menu list items
+
+Select menu list items have a few options available to them for more complex information patterns.
+
+### Multi-line text
+
+Sometimes the contents of your select menu list require a heading and a description instead of just a string. Select menus come with some default styles for such situations with the addition of a few classes and wrapping `<span>`s.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    <i>Multi line:</i>
+    <span class="js-select-button">Choose an item</span>
+  </button>
+
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal subscription-menu-modal js-menu-content" aria-hidden="false">
+      <div class="select-menu-header js-navigation-enable" tabindex="-1">
+        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
+        <span class="select-menu-title">Notifications</span>
+      </div>
+      <div class="select-menu-list js-navigation-container js-active-navigation-container" role="menu">
+        <a href="#url" class="select-menu-item js-navigation-item selected" role="menuitem">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <div class="select-menu-item-text">
+            <span class="select-menu-item-heading">Not watching</span>
+            <span class="description">Be notified when participating or @mentioned.</span>
+            <span class="js-select-button-text hidden-select-button-text">
+              Watch
+            </span>
+          </div>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item" role="menuitem">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <div class="select-menu-item-text">
+            <span class="select-menu-item-heading">Watching</span>
+            <span class="description">Be notified of all conversations.</span>
+            <span class="js-select-button-text hidden-select-button-text">
+              Stop watching
+            </span>
+          </div>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item" role="menuitem">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <div class="select-menu-item-text">
+            <span class="select-menu-item-heading">Ignoring</span>
+            <span class="description">Never be notified.</span>
+            <span class="js-select-button-text hidden-select-button-text">
+              Stop ignoring
+            </span>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### With avatars
+
+Add avatars to a select menu to help indicate when a menu list item represents a user.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    Choose an item
+  </button>
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-header js-navigation-enable" tabindex="-1">
+        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
+        <span class="select-menu-title">Options</span>
+      </div>
+      <div class="select-menu-list js-navigation-container">
+        <a href="#url" class="select-menu-item selected js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-gravatar">
+            <%= avatar_for(current_user, 20, :alt => "") %>
+          </span>
+          <span class="select-menu-item-text js-select-button-text">
+            probot
+          </span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-gravatar">
+            <%= avatar_for(current_user, 20, :alt => "") %>
+          </span>
+          <span class="select-menu-item-text js-select-button-text">
+            probot
+          </span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-gravatar">
+            <%= avatar_for(current_user, 20, :alt => "") %>
+          </span>
+          <span class="select-menu-item-text js-select-button-text">
+            probot
+          </span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### With dismiss icon
+
+Indicate how to toggle the selected state on a select menu list item with the addition of a dismiss icon.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    Choose an item
+  </button>
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-header js-navigation-enable" tabindex="-1">
+        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
+        <span class="select-menu-title">Options</span>
+      </div>
+      <div class="select-menu-list js-navigation-container">
+        <button type="button" class="select-menu-item selected js-navigation-item width-full">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">
+            <%= octicon("x", :"aria-label" => "Click to remove") %>
+            Item 1
+          </span>
+        </button>
+        <button type="button" class="select-menu-item js-navigation-item width-full">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">
+            <%= octicon("x", :"aria-label" => "Click to remove") %>
+            Item 2
+          </span>
+        </button>
+        <button type="button" class="select-menu-item js-navigation-item width-full">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">
+            <%= octicon("x", :"aria-label" => "Click to remove") %>
+            Item 3
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+## Menu alignment
+
+By default select menus are automatically aligned to the top left corner of an element, but you can also customize that with a few utilities or custom display.
+
+### Right aligned menus
+
+When select menus are right aligned, you can also right-align the select menu's popover with `.select-menu-modal-right`.
+
+```erb
+<div class="select-menu float-right select-menu-modal-right js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    Choose an item
+  </button>
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-header js-navigation-enable" tabindex="-1">
+        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
+        <span class="select-menu-title">Options</span>
+      </div>
+      <div class="select-menu-list js-navigation-container">
+        <a href="#url" class="select-menu-item selected js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 1</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 2</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 3</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+## Button options
+
+Customize the select menu's trigger button by changing the button modifier class, enabling stateful text, and more.
+
+### Style options
+
+Since select menus are powered by JavaScript behaviors, the specific display of your select menu button is up to you and your use case.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    Default button
+  </button>
+
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-list js-navigation-container">
+        <a href="#url" class="select-menu-item selected js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 1</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 2</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 3</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn btn-primary select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    Primary button
+  </button>
+
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-list js-navigation-container">
+        <a href="#url" class="select-menu-item selected js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 1</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 2</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 3</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn btn-outline select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    Outline button
+  </button>
+
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-list js-navigation-container">
+        <a href="#url" class="select-menu-item selected js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 1</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 2</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 3</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn-link select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    Link button
+  </button>
+
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-list js-navigation-container">
+        <a href="#url" class="select-menu-item selected js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 1</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 2</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">Item 3</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Stateful text
+
+Select menu buttons have the option of showing the current selection in the button itself. Wrap the string you intend to update with a `.js-select-button` and the select menu JavaScript will automatically update the contents of that element with the selected item's text.
+
+Open the select menu below and click different options to see it in action.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    <span class="js-select-button">master</span>
+  </button>
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-header js-navigation-enable" tabindex="-1">
+        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
+        <span class="select-menu-title">Options</span>
+      </div>
+      <div class="select-menu-list js-navigation-container">
+        <a href="#url" class="select-menu-item selected js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">master</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">feature-branch</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">refactor-component-name</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Emphasized text
+
+Sometimes you want to spice up your select menu with an emphasized label for the type of content within the menu. For example, you show `Branch:` in front of the current branch on our repository Code page. Within the button, wrap your string in an `<i>` element and you're good to go.
+
+As shown below, emphasized text works great with the stateful text functionality mentioned above.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    <i>Branch:</i>
+    <span class="js-select-button">master</span>
+  </button>
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-header js-navigation-enable" tabindex="-1">
+        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
+        <span class="select-menu-title">Options</span>
+      </div>
+      <div class="select-menu-list js-navigation-container">
+        <a href="#url" class="select-menu-item selected js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">master</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">feature-branch</span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-text js-select-button-text">refactor-component-name</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Button avatars
+
+Add an avatar to the button, like we do in our context switcher on the logged in dashboard.
+
+```erb
+<div class="select-menu js-menu-container js-select-menu">
+  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+    <div class="select-menu-button-gravatar js-select-button-gravatar">
+      <%= avatar_for(current_user, 20, :"aria-label" => "") %>
+    </div>
+    <span class="js-select-button css-truncate css-truncate-target">probot</span>
+  </button>
+  <div class="select-menu-modal-holder">
+    <div class="select-menu-modal js-menu-content">
+      <div class="select-menu-header js-navigation-enable" tabindex="-1">
+        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
+        <span class="select-menu-title">Options</span>
+      </div>
+      <div class="select-menu-list js-navigation-container">
+        <a href="#url" class="select-menu-item selected js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-gravatar">
+            <%= avatar_for(current_user, 20, :"aria-label" => "") %>
+          </span>
+          <span class="select-menu-item-text js-select-button-text">
+            probot
+          </span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-gravatar">
+            <%= avatar_for(current_user, 20, :"aria-label" => "") %>
+          </span>
+          <span class="select-menu-item-text js-select-button-text">
+            probot
+          </span>
+        </a>
+        <a href="#url" class="select-menu-item js-navigation-item">
+          <%= octicon("check", :class => "select-menu-item-icon") %>
+          <span class="select-menu-item-gravatar">
+            <%= avatar_for(current_user, 20, :"aria-label" => "") %>
+          </span>
+          <span class="select-menu-item-text js-select-button-text">
+            probot
+          </span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```

--- a/pages/css/components/select-menu.md
+++ b/pages/css/components/select-menu.md
@@ -1,837 +1,420 @@
 ---
-title: Select menu
-path: components/select-menu
-status: Stable
-source: 'https://github.com/github/github/blob/master/docs/styleguide/css/styles/product/components/select-menu.md'
-symbols: [active, close-button, css-truncate-target, description, description-inline, description-warning, disabled, filterable-empty, has-error, hidden-select-button-text, icon-only, indeterminate, is-loading, is-showing-new-item-form, label-select-menu, last-visible, menu-active, modal-backdrop, navigation-focus, octicon, octicon-check, octicon-dash, octicon-octoface, octicon-x, opaque, primary, select-menu, select-menu-action, select-menu-blankslate, select-menu-button, select-menu-button-gravatar, select-menu-button-large, select-menu-clear-item, select-menu-divider, select-menu-error, select-menu-filters, select-menu-header, select-menu-item, select-menu-item-gravatar, select-menu-item-heading, select-menu-item-icon, select-menu-item-parent, select-menu-item-template, select-menu-item-text, select-menu-list, select-menu-loading-overlay, select-menu-modal, select-menu-modal-holder, select-menu-modal-narrow, select-menu-modal-right, select-menu-new-item-form, select-menu-no-results, select-menu-tab, select-menu-tab-bucket, select-menu-tab-nav, select-menu-tabs, select-menu-text-filter, select-menu-title, selected, spinner]
+title: Select Menu
+status: New Release
+source: 'https://github.com/primer/css/tree/master/src/select-menu'
+bundle: select-menu
 ---
 
-The select menu provides advanced support for navigation, filtering, and more. Any popover within a select menu can make use of JavaScript-enabled live filtering, selected states, tabbed lists, and keyboard navigation with a bit of markup.
+The `SelectMenu` component provides advanced support for navigation, filtering, and more. Any menu can make use of JavaScript-enabled live filtering, selected states, tabbed lists, and keyboard navigation with a bit of markup.
 
 ## Table of Contents
 
 ## Basic example
 
-Select menus should be trigged by a `<button>`. In the markup below, all classes prefixed with `select-menu` and `.js-` are required.
+Use a `<details>` element to toggle the Select Menu. The `<summary>` element can be styled in many ways. In the example below it's a `.btn`.
 
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+```html
+<details class="details-reset details-overlay" open>
+  <summary class="btn" type="button" aria-haspopup="true" aria-expanded="true">
     Choose an item
-  </button>
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-list js-navigation-container">
-        <a href="#url" class="select-menu-item selected js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 1</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 2</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 3</span>
-        </a>
-      </div>
+  </summary>
+  <div class="SelectMenu">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <h3 class="SelectMenu-title">Title</h3>
+        <button class="SelectMenu-closeButton" type="button"><svg class="octicon octicon-x" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
+      </header>
+      <menu class="SelectMenu-list">
+        <button class="SelectMenu-item" role="menuitem">Item 1</button>
+        <button class="SelectMenu-item" role="menuitem">Item 2</button>
+        <button class="SelectMenu-item" role="menuitem">Item 3</button>
+      </menu>
     </div>
   </div>
-</div>
+</details>
+
+<div class="d-sm-none"         style="height: 600px"> <!-- min height for < sm --> </div>
+<div class="d-none d-sm-block" style="height: 180px"> <!-- min height for > sm --> </div>
 ```
 
-## Menu contents
+Add a `.SelectMenu-header` to house a clear title and a close button. Note that the close button is only shown on narrow screens (mobile).
 
-The contents of a select menu are easily customized with support for headers, footers, tabbed lists, and live filtering.
+## Right aligned
 
-### Headers
+In case the Select Menu should be aligned to the right, use `SelectMenu right-0`.
 
-Add a header to any select menu's popover to house a clear title and a dismiss button.
+```html
+<div class="d-flex flex-justify-end">
 
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    Choose an item
-  </button>
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-header js-navigation-enable" tabindex="-1">
-        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
-        <span class="select-menu-title">Options</span>
-      </div>
-      <div class="select-menu-list js-navigation-container">
-        <a href="#url" class="select-menu-item selected js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 1</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 2</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 3</span>
-        </a>
+  <details class="details-reset details-overlay" open>
+    <summary class="btn" type="button" aria-haspopup="true" aria-expanded="true">
+      Choose an item
+    </summary>
+    <div class="SelectMenu right-0">
+      <div class="SelectMenu-modal">
+        <header class="SelectMenu-header">
+          <h3 class="SelectMenu-title">Title</h3>
+          <button class="SelectMenu-closeButton" type="button"><svg class="octicon octicon-x" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
+        </header>
+        <menu class="SelectMenu-list">
+          <button class="SelectMenu-item" role="menuitem">Item 1</button>
+          <button class="SelectMenu-item" role="menuitem">Item 2</button>
+          <button class="SelectMenu-item" role="menuitem">Item 3</button>
+        </menu>
       </div>
     </div>
-  </div>
+  </details>
+
 </div>
+
+<div class="d-sm-none"         style="height: 600px"> <!-- min height for < sm --> </div>
+<div class="d-none d-sm-block" style="height: 180px"> <!-- min height for > sm --> </div>
 ```
 
-### List items
+## Selected state
 
-The list of items is arguably the most important subcomponent within the menu. Build them out of anchors, buttons, or just about any [interactive content](http://w3c.github.io/html/dom.html#interactive-content). [List items are also customizable](#menu-list-items) with options for avatars, additional icons, and multiple lines of text.
+Add a `.SelectMenu-icon .octicon-check` icon and it will show up when `aria-checked="true"` is set.
 
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+```html
+<details class="details-reset details-overlay" open>
+  <summary class="btn" type="button" aria-haspopup="true" aria-expanded="true">
     Choose an item
-  </button>
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-list js-navigation-container">
-        <button type="button" class="select-menu-item selected js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 1</span>
+  </summary>
+  <div class="SelectMenu">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <h3 class="SelectMenu-title">Title</h3>
+        <button class="SelectMenu-closeButton" type="button"><svg class="octicon octicon-x" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
+      </header>
+      <menu class="SelectMenu-list">
+        <button class="SelectMenu-item" role="menuitemcheckbox" aria-checked="true">
+          <svg class="SelectMenu-icon octicon octicon-check" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
+          Selected state
         </button>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 2</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item" href="#url">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 3</span>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-```
-
-### Filter
-
-Enable live filtering of list items within a `.select-menu-list` with a search input. Only a handful of changes to your menu's markup are required:
-
-- Add the text input, housed in `.select-menu-filters`, before the `.select-menu-list`.
-- Add two attritubes, `data-filterable-for` and `data-filterable-type`, to the `.select-menu-list` to scope the filter to the list.
-
-There are no required changes for the `.select-menu-item`s.
-
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    <i>Label:</i>
-    <span class="js-select-button">Choose an item</span>
-  </button>
-  <div class="select-menu-modal-holder js-menu-content js-navigation-container">
-    <div class="select-menu-modal">
-      <div class="select-menu-header" tabindex="-1">
-        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
-        <span class="select-menu-title">Options</span>
-      </div>
-      <div class="js-select-menu-deferred-content">
-        <div class="select-menu-filters">
-          <div class="select-menu-text-filter">
-            <input type="text" id="example-filter-field" class="form-control js-filterable-field js-navigation-enable" placeholder="Filter this list" aria-label="Type to filter" autocomplete="off">
-          </div>
-        </div>
-        <div class="select-menu-list" data-filterable-for="example-filter-field" data-filterable-type="substring">
-          <input hidden="checkbox" name="example" value="">
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Test element
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Filter to this
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              More content
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Something else
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              One more thing
-            </div>
-          </a>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-```
-
-### Tabs
-
-Sometimes you need two or more lists of items in your select menu, e.g. branches and tags. Select menu lists can be tabbed with the addition of the tab toggles at the top of the menu and a few changes to the `.select-menu-list`.
-
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    <i>Label:</i>
-    <span class="js-select-button">Choose an item</span>
-  </button>
-  <div class="select-menu-modal-holder js-menu-content js-navigation-container">
-    <div class="select-menu-modal">
-      <div class="select-menu-header" tabindex="-1">
-        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
-        <span class="select-menu-title">Options</span>
-      </div>
-      <div class="js-select-menu-deferred-content">
-        <div class="select-menu-filters">
-          <div class="select-menu-tabs">
-            <ul>
-              <li class="select-menu-tab">
-                <a href="#url" data-tab-filter="branches" data-filter-placeholder="Filter for " class="js-select-menu-tab" aria-current="false">Branches</a>
-              </li>
-              <li class="select-menu-tab">
-                <a href="#url" data-tab-filter="tags" data-filter-placeholder="Find a tag…" class="js-select-menu-tab selected" aria-current="true">Tags</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <div class="select-menu-list select-menu-tab-bucket js-select-menu-tab-bucket selected" data-filterable-for="example-filter-field" data-filterable-type="substring" data-tab-filter="branches" role="menu">
-          <input hidden="checkbox" name="example" value="">
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Branch 1
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Branch 2
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Branch 3
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Branch 4
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Branch 5
-            </div>
-          </a>
-        </div>
-        <div class="select-menu-list select-menu-tab-bucket js-select-menu-tab-bucket" data-filterable-for="example-filter-field" data-filterable-type="substring" data-tab-filter="tags" role="menu">
-          <input hidden="checkbox" name="example" value="">
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Tag 1
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Tag 2
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Tag 3
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Tag 4
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Tag 5
-            </div>
-          </a>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-```
-
-### Filter and tabs
-
-Show a filter and tabs in a single select menu.
-
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    <i>Label:</i>
-    <span class="js-select-button">Choose an item</span>
-  </button>
-  <div class="select-menu-modal-holder js-menu-content js-navigation-container">
-    <div class="select-menu-modal">
-      <div class="select-menu-header" tabindex="-1">
-        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
-        <span class="select-menu-title">Options</span>
-      </div>
-      <div class="js-select-menu-deferred-content">
-        <div class="select-menu-filters">
-          <div class="select-menu-text-filter">
-            <input type="text" id="example-filter-field-2" class="form-control js-filterable-field js-navigation-enable" placeholder="Filter labels" aria-label="Type or choose a label" autocomplete="off">
-          </div>
-          <div class="select-menu-tabs">
-            <ul>
-              <li class="select-menu-tab">
-                <a href="#url" data-tab-filter="branches" data-filter-placeholder="Filter for " class="js-select-menu-tab" aria-current="false">Branches</a>
-              </li>
-              <li class="select-menu-tab">
-                <a href="#url" data-tab-filter="tags" data-filter-placeholder="Find a tag…" class="js-select-menu-tab selected" aria-current="true">Tags</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <div class="select-menu-list select-menu-tab-bucket js-select-menu-tab-bucket selected" data-filterable-for="example-filter-field" data-filterable-type="substring" data-tab-filter="branches" role="menu">
-          <input hidden="checkbox" name="example" value="">
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Branch 1
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Branch 2
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Branch 3
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Branch 4
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Branch 5
-            </div>
-          </a>
-        </div>
-        <div class="select-menu-list select-menu-tab-bucket js-select-menu-tab-bucket" data-filterable-for="example-filter-field" data-filterable-type="substring" data-tab-filter="tags" role="menu">
-          <input hidden="checkbox" name="example" value="">
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Tag 1
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Tag 2
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Tag 3
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Tag 4
-            </div>
-          </a>
-          <a href="#url" class="select-menu-item js-navigation-item">
-            <%= octicon("check", :class => "select-menu-item-icon") %>
-            <div class="select-menu-item-text js-select-button-text">
-              Tag 5
-            </div>
-          </a>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-```
-
-### Blankslate
-
-Sometimes a select menu needs to communicate a "blank slate" where there's no content in the menu's list. Usually these include a clear call to action to add said content to the list. Swap out the contents of a `.select-menu-list` with the `.select-menu-blankslate` and customize it's contents as needed.
-
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    Choose an item
-  </button>
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-header js-navigation-enable" tabindex="-1">
-        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
-        <span class="select-menu-title">Options</span>
-      </div>
-      <div class="select-menu-list js-navigation-container">
-        <div class="select-menu-blankslate">
-          <%= octicon("check", :height => 32) %>
-          <h3>Select menu blankslate</h3>
-          <p>Some text here to describe why you're seeing a blankslate and how to go about fixing that up.</p>
-          <button type="button" class="btn btn-sm btn-primary mt-3 mb-3">Deal with it</button>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-```
-
-## Menu list items
-
-Select menu list items have a few options available to them for more complex information patterns.
-
-### Multi-line text
-
-Sometimes the contents of your select menu list require a heading and a description instead of just a string. Select menus come with some default styles for such situations with the addition of a few classes and wrapping `<span>`s.
-
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    <i>Multi line:</i>
-    <span class="js-select-button">Choose an item</span>
-  </button>
-
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal subscription-menu-modal js-menu-content" aria-hidden="false">
-      <div class="select-menu-header js-navigation-enable" tabindex="-1">
-        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
-        <span class="select-menu-title">Notifications</span>
-      </div>
-      <div class="select-menu-list js-navigation-container js-active-navigation-container" role="menu">
-        <a href="#url" class="select-menu-item js-navigation-item selected" role="menuitem">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <div class="select-menu-item-text">
-            <span class="select-menu-item-heading">Not watching</span>
-            <span class="description">Be notified when participating or @mentioned.</span>
-            <span class="js-select-button-text hidden-select-button-text">
-              Watch
-            </span>
-          </div>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item" role="menuitem">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <div class="select-menu-item-text">
-            <span class="select-menu-item-heading">Watching</span>
-            <span class="description">Be notified of all conversations.</span>
-            <span class="js-select-button-text hidden-select-button-text">
-              Stop watching
-            </span>
-          </div>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item" role="menuitem">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <div class="select-menu-item-text">
-            <span class="select-menu-item-heading">Ignoring</span>
-            <span class="description">Never be notified.</span>
-            <span class="js-select-button-text hidden-select-button-text">
-              Stop ignoring
-            </span>
-          </div>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-```
-
-### With avatars
-
-Add avatars to a select menu to help indicate when a menu list item represents a user.
-
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    Choose an item
-  </button>
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-header js-navigation-enable" tabindex="-1">
-        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
-        <span class="select-menu-title">Options</span>
-      </div>
-      <div class="select-menu-list js-navigation-container">
-        <a href="#url" class="select-menu-item selected js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-gravatar">
-            <%= avatar_for(current_user, 20, :alt => "") %>
-          </span>
-          <span class="select-menu-item-text js-select-button-text">
-            probot
-          </span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-gravatar">
-            <%= avatar_for(current_user, 20, :alt => "") %>
-          </span>
-          <span class="select-menu-item-text js-select-button-text">
-            probot
-          </span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-gravatar">
-            <%= avatar_for(current_user, 20, :alt => "") %>
-          </span>
-          <span class="select-menu-item-text js-select-button-text">
-            probot
-          </span>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-```
-
-### With dismiss icon
-
-Indicate how to toggle the selected state on a select menu list item with the addition of a dismiss icon.
-
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    Choose an item
-  </button>
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-header js-navigation-enable" tabindex="-1">
-        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
-        <span class="select-menu-title">Options</span>
-      </div>
-      <div class="select-menu-list js-navigation-container">
-        <button type="button" class="select-menu-item selected js-navigation-item width-full">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">
-            <%= octicon("x", :"aria-label" => "Click to remove") %>
-            Item 1
-          </span>
+        <button class="SelectMenu-item" role="menuitemcheckbox">
+          <svg class="SelectMenu-icon octicon octicon-check" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
+          Default state
         </button>
-        <button type="button" class="select-menu-item js-navigation-item width-full">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">
-            <%= octicon("x", :"aria-label" => "Click to remove") %>
-            Item 2
-          </span>
+        <button class="SelectMenu-item" role="menuitemcheckbox" aria-checked="true">
+          <svg class="SelectMenu-icon octicon octicon-check" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
+          Selected state
         </button>
-        <button type="button" class="select-menu-item js-navigation-item width-full">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">
-            <%= octicon("x", :"aria-label" => "Click to remove") %>
-            Item 3
-          </span>
-        </button>
-      </div>
+        <button class="SelectMenu-item" role="menuitemcheckbox">Default state</button>
+        <button class="SelectMenu-item" role="menuitemcheckbox">Default state</button>
+      </menu>
     </div>
   </div>
-</div>
+</details>
+
+<div class="d-sm-none"         style="height: 600px"> <!-- min height for < sm --> </div>
+<div class="d-none d-sm-block" style="height: 250px"> <!-- min height for > sm --> </div>
 ```
 
-## Menu alignment
+## List items
 
-By default select menus are automatically aligned to the top left corner of an element, but you can also customize that with a few utilities or custom display.
+The list of items is arguably the most important subcomponent within the menu. Build them out of anchors, buttons, or just about any [interactive content](http://w3c.github.io/html/dom.html#interactive-content). List items are also customizable with options for avatars, additional icons, and multiple lines of text. Use utility classes like `mr-2`, `d-flex` or `float-right` in case more custom styling is needed.
 
-### Right aligned menus
-
-When select menus are right aligned, you can also right-align the select menu's popover with `.select-menu-modal-right`.
-
-```erb
-<div class="select-menu float-right select-menu-modal-right js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+```html
+<details class="details-reset details-overlay" open>
+  <summary class="btn" type="button" aria-haspopup="true" aria-expanded="true">
     Choose an item
-  </button>
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-header js-navigation-enable" tabindex="-1">
-        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
-        <span class="select-menu-title">Options</span>
-      </div>
-      <div class="select-menu-list js-navigation-container">
-        <a href="#url" class="select-menu-item selected js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 1</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 2</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 3</span>
-        </a>
-      </div>
+  </summary>
+  <div class="SelectMenu">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <h3 class="SelectMenu-title">Title</h3>
+        <button class="SelectMenu-closeButton" type="button"><svg class="octicon octicon-x" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
+      </header>
+      <menu class="SelectMenu-list">
+        <button class="SelectMenu-item" role="menuitem">
+          Text only
+        </button>
+        <button class="SelectMenu-item" role="menuitem">
+          <img class="avatar avatar-small mr-2" src="https://avatars.githubusercontent.com/hubot?s=40" alt="hubot" height="20" width="20">
+          With an avatar
+        </button>
+        <button class="SelectMenu-item" role="menuitem">
+          With a status icon <svg class="octicon octicon-primitive-dot color-green-5 ml-2" style="fill:currentColor" viewBox="0 0 8 16" version="1.1" width="8" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 8c0-2.2 1.8-4 4-4s4 1.8 4 4-1.8 4-4 4-4-1.8-4-4z"></path></svg>
+        </button>
+        <button class="SelectMenu-item" role="menuitem">
+          With a <span class="Label bg-blue" title="Label: label">label</span>
+        </button>
+        <button class="SelectMenu-item" role="menuitem">
+          With a counter <span class="Counter bg-gray-2 ml-1">16</span>
+        </button>
+        <button class="SelectMenu-item" role="menuitem">
+          <h5>With a heading</h5>
+          <span>and some longer description</span>
+        </button>
+      </menu>
     </div>
   </div>
-</div>
+</details>
+
+<div class="d-sm-none"         style="height: 600px"> <!-- min height for < sm --> </div>
+<div class="d-none d-sm-block" style="height: 300px"> <!-- min height for > sm --> </div>
 ```
 
-## Button options
+## Divider
 
-Customize the select menu's trigger button by changing the button modifier class, enabling stateful text, and more.
+The Select Menu's list can be divided into multiple parts by adding a `.SelectMenu-divider`.
 
-### Style options
+```html
+<details class="details-reset details-overlay" open>
+  <summary class="btn" type="button" aria-haspopup="true" aria-expanded="true">
+    Choose an item
+  </summary>
+  <div class="SelectMenu">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <h3 class="SelectMenu-title">Title</h3>
+        <button class="SelectMenu-closeButton" type="button"><svg class="octicon octicon-x" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
+      </header>
+      <menu class="SelectMenu-list">
+        <button class="SelectMenu-item" role="menuitem">Item 1</button>
+        <button class="SelectMenu-item" role="menuitem">Item 2</button>
+        <div class="SelectMenu-divider">More options</div>
+        <button class="SelectMenu-item" role="menuitem">Item 3</button>
+        <button class="SelectMenu-item" role="menuitem">Item 4</button>
+        <button class="SelectMenu-item" role="menuitem">Item 5</button>
+      </menu>
+    </div>
+  </div>
+</details>
 
-Since select menus are powered by JavaScript behaviors, the specific display of your select menu button is up to you and your use case.
+<div class="d-sm-none"         style="height: 600px"> <!-- min height for < sm --> </div>
+<div class="d-none d-sm-block" style="height: 260px"> <!-- min height for > sm --> </div>
+```
+
+## Additional filter and footer
+
+If the list is expected to get long, consider adding a `.SelectMenu-filter` input. Be sure to also include the `.SelectMenu--hasFilter` modifier class. On mobile devices it will add a fixed height and anchor the Select Menu to the top of the screen. This makes sure the filter input stays at the same position while typing.
+
+Also consider adding a `.SelectMenu-footer` at the bottom. It can be used for additional information, but can also greatly improve the scrolling performance because the list doesn't need to be repainted due to the rounded corners.
+
+```html
+<details class="details-reset details-overlay" open>
+  <summary class="btn" type="button" aria-haspopup="true" aria-expanded="true">
+    Choose an item
+  </summary>
+  <div class="SelectMenu SelectMenu--hasFilter">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <h3 class="SelectMenu-title">Title</h3>
+        <button class="SelectMenu-closeButton" type="button"><svg class="octicon octicon-x" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
+      </header>
+      <form class="SelectMenu-filter">
+        <input class="SelectMenu-input form-control" type="text" placeholder="Filter" aria-label="Filter">
+      </form>
+      <menu class="SelectMenu-list">
+        <button class="SelectMenu-item" role="menuitem">Item 1</a>
+        <button class="SelectMenu-item" role="menuitem">Item 2</a>
+        <button class="SelectMenu-item" role="menuitem">Item 3</a>
+        <button class="SelectMenu-item" role="menuitem">Item 4</a>
+        <button class="SelectMenu-item" role="menuitem">Item 5</a>
+        <button class="SelectMenu-item" role="menuitem">Item 6</a>
+        <button class="SelectMenu-item" role="menuitem">Item 7</a>
+        <button class="SelectMenu-item" role="menuitem">Item 8</a>
+        <button class="SelectMenu-item" role="menuitem">Item 9</a>
+        <button class="SelectMenu-item" role="menuitem">Item 10</a>
+        <button class="SelectMenu-item" role="menuitem">Item 11</a>
+        <button class="SelectMenu-item" role="menuitem">Item 12</a>
+        <button class="SelectMenu-item" role="menuitem">Item 13</a>
+        <button class="SelectMenu-item" role="menuitem">Item 14</a>
+        <button class="SelectMenu-item" role="menuitem">Item 15</a>
+        <button class="SelectMenu-item" role="menuitem">Item 16</a>
+        <button class="SelectMenu-item" role="menuitem">Item 17</a>
+        <button class="SelectMenu-item" role="menuitem">Item 18</a>
+        <button class="SelectMenu-item" role="menuitem">Item 19</a>
+        <button class="SelectMenu-item" role="menuitem">Item 20</a>
+        <button class="SelectMenu-item" role="menuitem">Item 21</a>
+        <button class="SelectMenu-item" role="menuitem">Item 22</a>
+        <button class="SelectMenu-item" role="menuitem">Item 23</a>
+        <button class="SelectMenu-item" role="menuitem">Item 24</a>
+        <button class="SelectMenu-item" role="menuitem">Item 25</a>
+      </menu>
+      <footer class="SelectMenu-footer">Showing 25 of 25</footer>
+    </div>
+  </div>
+</details>
+
+<div class="d-sm-none"         style="height: 600px"> <!-- min height for < sm --> </div>
+<div class="d-none d-sm-block" style="height: 380px"> <!-- min height for > sm --> </div>
+```
+
+## Tabs
+
+Sometimes you need two or more lists of items in your Select Menu, e.g. branches and tags. Select Menu lists can be tabbed with the addition of `.SelectMenu-tabs` above the menu.
+
+```html
+<details class="details-reset details-overlay" open>
+  <summary class="btn" type="button" aria-haspopup="true" aria-expanded="true">
+    Choose an item
+  </summary>
+  <div class="SelectMenu SelectMenu--hasFilter">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <h3 class="SelectMenu-title">Title</h3>
+        <button class="SelectMenu-closeButton" type="button"><svg class="octicon octicon-x" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
+      </header>
+      <form class="SelectMenu-filter">
+        <input class="SelectMenu-input form-control" type="text" placeholder="Filter" aria-label="Filter">
+      </form>
+      <nav class="SelectMenu-tabs">
+        <button class="SelectMenu-tab" aria-selected="true">Branches</button>
+        <button class="SelectMenu-tab">Tags</button>
+      </nav>
+      <menu class="SelectMenu-list">
+        <button class="SelectMenu-item" role="menuitem">Branch 1</button>
+        <button class="SelectMenu-item" role="menuitem">Branch 2</button>
+        <button class="SelectMenu-item" role="menuitem">Branch 3</button>
+        <button class="SelectMenu-item" role="menuitem">Branch 4</button>
+        <button class="SelectMenu-item" role="menuitem">Branch 5</button>
+      </menu>
+      <menu class="SelectMenu-list" hidden>
+        <button class="SelectMenu-item" role="menuitem">Tag 1</button>
+        <button class="SelectMenu-item" role="menuitem">Tag 2</button>
+        <button class="SelectMenu-item" role="menuitem">Tag 3</button>
+      </menu>
+      <footer class="SelectMenu-footer">Showing 5 of 5</footer>
+    </div>
+  </div>
+</details>
+
+<div class="d-sm-none"         style="height: 600px"> <!-- min height for < sm --> </div>
+<div class="d-none d-sm-block" style="height: 380px"> <!-- min height for > sm --> </div>
+```
+
+## Message
+
+A `SelectMenu-message` can be used to show different kind of messages to a user. Use utility classes to further style the message.
+
+```html
+<details class="details-reset details-overlay" open>
+  <summary class="btn" type="button" aria-haspopup="true" aria-expanded="true">
+    Choose an item
+  </summary>
+  <div class="SelectMenu">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <h3 class="SelectMenu-title">Title</h3>
+        <button class="SelectMenu-closeButton" type="button"><svg class="octicon octicon-x" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
+      </header>
+      <menu class="SelectMenu-list">
+        <button class="SelectMenu-item" role="menuitem">Item 1</button>
+        <button class="SelectMenu-item" role="menuitem">Item 2</button>
+        <div class="SelectMenu-message border-bottom border-top bg-red-0 text-red p-2">Message goes here</div>
+        <button class="SelectMenu-item" role="menuitem">Item 3</button>
+      </menu>
+    </div>
+  </div>
+</details>
+
+<div class="d-sm-none"         style="height: 600px"> <!-- min height for < sm --> </div>
+<div class="d-none d-sm-block" style="height: 200px"> <!-- min height for > sm --> </div>
+```
+
+## Loading
+
+When fetching large lists, consider showing a `.SelectMenu-loading` animation.
+
+```html
+<details class="details-reset details-overlay">
+  <summary class="btn" type="button" aria-haspopup="true" aria-expanded="true">
+    Choose an item
+  </summary>
+  <div class="SelectMenu SelectMenu--hasFilter">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <h3 class="SelectMenu-title">Title</h3>
+        <button class="SelectMenu-closeButton" type="button"><svg class="octicon octicon-x" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
+      </header>
+      <form class="SelectMenu-filter">
+        <input class="SelectMenu-input form-control" type="text" placeholder="Filter" aria-label="Filter">
+      </form>
+      <menu class="SelectMenu-list">
+        <div class="SelectMenu-loading">
+          <svg height="32" class="octicon octicon-octoface anim-pulse" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"></path></svg>
+        </div>
+      </menu>
+      <footer class="SelectMenu-footer">Loading...</footer>
+    </div>
+  </div>
+</details>
+
+<div class="d-sm-none"         style="height: 600px"> <!-- min height for < sm --> </div>
+<div class="d-none d-sm-block" style="height: 220px"> <!-- min height for > sm --> </div>
+```
+
+## Blankslate
+
+Sometimes a Select Menu needs to communicate a "blank slate" where there's no content in the menu's list. Usually these include a clear call to action to add said content to the list. Swap out the contents of a `.SelectMenu-list` with a `.SelectMenu-blankslate` and customize its contents as needed.
+
+```html
+<details class="details-reset details-overlay" open>
+  <summary class="btn" type="button" aria-haspopup="true" aria-expanded="true">
+    Choose an item
+  </summary>
+  <div class="SelectMenu">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <h3 class="SelectMenu-title">Title</h3>
+        <button class="SelectMenu-closeButton" type="button"><svg class="octicon octicon-x" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
+      </header>
+      <menu class="SelectMenu-list">
+        <div class="SelectMenu-blankslate">
+          <svg height="32" class="octicon octicon-repo color-gray-3" viewBox="0 0 12 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"></path></svg>
+          <h4 class="my-2">No repositories</h4>
+          <p class="mb-3 text-gray">We didn’t find any matching repositories that you can commit to.</p>
+          <button type="button" class="btn btn-sm btn-primary">Create a repository</button>
+        </div>
+      </menu>
+    </div>
+  </div>
+</details>
+
+<div class="d-sm-none"         style="height: 600px"> <!-- min height for < sm --> </div>
+<div class="d-none d-sm-block" style="height: 260px"> <!-- min height for > sm --> </div>
+```
+
+## github.com usage
+
+When adding the `.SelectMenu` component on github.com, use the [`<details-menu>`](https://github.com/github/details-menu-element) element. It will :tophat: magically make the `.SelectMenu` work. Here a basic example:
 
 ```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    Default button
-  </button>
-
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-list js-navigation-container">
-        <a href="#url" class="select-menu-item selected js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 1</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 2</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 3</span>
-        </a>
-      </div>
+<details class="details-reset details-overlay" id="my-select-menu">
+  <summary class="btn" title="Pick an item">
+    <span>Choose</span>
+    <span class="dropdown-caret"></span>
+  </summary>
+  <details-menu class="SelectMenu" role="menu">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <span class="SelectMenu-title">My Select Menu</span>
+        <button class="SelectMenu-closeButton" type="button" data-toggle-for="my-select-menu">
+          <%= octicon("x", :"aria-label" => "Close menu") %>
+        </button>
+      </header>
     </div>
-  </div>
-</div>
+    <div class="SelectMenu-list">
+      <a class="SelectMenu-item" href="" role="menuitem">Item 1</a>
+      <a class="SelectMenu-item" href="" role="menuitem">Item 2</a>
+      <a class="SelectMenu-item" href="" role="menuitem">Item 3</a>
+    </div>
+  </details-menu>
+</details>
 ```
+
+If loading content should be deferred, use the [`<include-fragment>`](https://github.com/github/details-menu-element) element:
 
 ```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn btn-primary select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    Primary button
-  </button>
-
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-list js-navigation-container">
-        <a href="#url" class="select-menu-item selected js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 1</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 2</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 3</span>
-        </a>
-      </div>
-    </div>
+<details-menu class="SelectMenu" src="/my-menu" preload>
+  <div class="SelectMenu-modal">
+    <include-fragment class="SelectMenu-loading" aria-label="Menu is loading">
+      <%= octicon('octoface', class: "anim-pulse", :height => 32) %>
+    </include-fragment>
   </div>
-</div>
+</details-menu>
 ```
 
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn btn-outline select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    Outline button
-  </button>
-
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-list js-navigation-container">
-        <a href="#url" class="select-menu-item selected js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 1</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 2</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 3</span>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-```
-
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn-link select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    Link button
-  </button>
-
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-list js-navigation-container">
-        <a href="#url" class="select-menu-item selected js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 1</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 2</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">Item 3</span>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-```
-
-### Stateful text
-
-Select menu buttons have the option of showing the current selection in the button itself. Wrap the string you intend to update with a `.js-select-button` and the select menu JavaScript will automatically update the contents of that element with the selected item's text.
-
-Open the select menu below and click different options to see it in action.
-
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    <span class="js-select-button">master</span>
-  </button>
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-header js-navigation-enable" tabindex="-1">
-        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
-        <span class="select-menu-title">Options</span>
-      </div>
-      <div class="select-menu-list js-navigation-container">
-        <a href="#url" class="select-menu-item selected js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">master</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">feature-branch</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">refactor-component-name</span>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-```
-
-### Emphasized text
-
-Sometimes you want to spice up your select menu with an emphasized label for the type of content within the menu. For example, you show `Branch:` in front of the current branch on our repository Code page. Within the button, wrap your string in an `<i>` element and you're good to go.
-
-As shown below, emphasized text works great with the stateful text functionality mentioned above.
-
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    <i>Branch:</i>
-    <span class="js-select-button">master</span>
-  </button>
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-header js-navigation-enable" tabindex="-1">
-        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
-        <span class="select-menu-title">Options</span>
-      </div>
-      <div class="select-menu-list js-navigation-container">
-        <a href="#url" class="select-menu-item selected js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">master</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">feature-branch</span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-text js-select-button-text">refactor-component-name</span>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-```
-
-### Button avatars
-
-Add an avatar to the button, like we do in our context switcher on the logged in dashboard.
-
-```erb
-<div class="select-menu js-menu-container js-select-menu">
-  <button class="btn select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
-    <div class="select-menu-button-gravatar js-select-button-gravatar">
-      <%= avatar_for(current_user, 20, :"aria-label" => "") %>
-    </div>
-    <span class="js-select-button css-truncate css-truncate-target">probot</span>
-  </button>
-  <div class="select-menu-modal-holder">
-    <div class="select-menu-modal js-menu-content">
-      <div class="select-menu-header js-navigation-enable" tabindex="-1">
-        <button class="btn-link close-button js-menu-close" type="button"><%= octicon("x", :"aria-label" => "Close menu") %></button>
-        <span class="select-menu-title">Options</span>
-      </div>
-      <div class="select-menu-list js-navigation-container">
-        <a href="#url" class="select-menu-item selected js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-gravatar">
-            <%= avatar_for(current_user, 20, :"aria-label" => "") %>
-          </span>
-          <span class="select-menu-item-text js-select-button-text">
-            probot
-          </span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-gravatar">
-            <%= avatar_for(current_user, 20, :"aria-label" => "") %>
-          </span>
-          <span class="select-menu-item-text js-select-button-text">
-            probot
-          </span>
-        </a>
-        <a href="#url" class="select-menu-item js-navigation-item">
-          <%= octicon("check", :class => "select-menu-item-icon") %>
-          <span class="select-menu-item-gravatar">
-            <%= avatar_for(current_user, 20, :"aria-label" => "") %>
-          </span>
-          <span class="select-menu-item-text js-select-button-text">
-            probot
-          </span>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-```
+It will add a pulsing :octoface: icon while the content is loading.

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -1,0 +1,156 @@
+---
+title: Toasts
+path: components/toasts
+status: Experimental
+status_issue: 'https://github.com/github/design-systems/issues/101'
+source: ''
+bundle: toasts
+---
+
+Toasts are used to show live, time-sensitive feedback to users.
+
+
+## Default
+
+To create a default toast, use `.Toast`. Always use the `info` icon for default messages.
+
+```html title="Default toast"
+<div class="p-1">
+  <div class="Toast">
+    <span class="Toast-icon">
+      <!-- <%= octicon "info" %> -->
+      <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
+    </span>
+    <span class="Toast-content">Toast message goes here</span>
+  </div>
+</div>
+```
+
+The Toast content is formattable. We recommend keeping your message under 140 characters.
+
+```html title="Toast with long text"
+<div class="p-1">
+  <div class="Toast">
+    <span class="Toast-icon">
+      <!-- <%= octicon "info" %> -->
+      <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
+    </span>
+    <span class="Toast-content">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. <strong>Aenean commodo ligula eget dolor.</strong> Aenean massa. Cum sociis <em>natoque</em> penatibus et ma</span>
+  </div>
+</div>
+```
+
+## Variations
+
+Use the success, warning, and error modifiers to communicate different states.
+
+Always use the `check` octicon for success states.
+
+```html title="Success toast"
+<div class="p-1">
+  <div class="Toast Toast--success">
+    <span class="Toast-icon">
+      <!-- <%= octicon "check" %> -->
+      <svg class="octicon octicon-check" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
+    </span>
+    <span class="Toast-content">Success message goes here.</span>
+  </div>
+</div>
+```
+
+Always use the `alert` octicon for warning states.
+
+```html title="Warning toast"
+<div class="p-1">
+  <div class="Toast Toast--warning">
+    <span class="Toast-icon">
+      <!-- <%= octicon "alert" %> -->
+      <svg class="octicon octicon-alert" style="fill:currentColor" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
+    </span>
+    <span class="Toast-content">Warning message goes here.</span>
+  </div>
+</div>
+```
+
+Always use the `stop` octicon for error states.
+
+```html title="Error toast"
+<div class="p-1">
+  <div class="Toast Toast--error">
+    <span class="Toast-icon">
+      <!-- <%= octicon "stop" %> -->
+      <svg class="octicon octicon-stop" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 1H4L0 5v6l4 4h6l4-4V5l-4-4zm3 9.5L9.5 14h-5L1 10.5v-5L4.5 2h5L13 5.5v5zM6 4h2v5H6V4zm0 6h2v2H6v-2z"></path></svg>
+    </span>
+    <span class="Toast-content">Error message goes here</span>
+  </div>
+</div>
+```
+
+## Toast with dismiss
+
+Use `.Toast-dismissButton` to allow a user to explicitly dismiss a Toast.
+
+```html title="Toast with dismiss"
+<div class="p-1">
+  <div class="Toast">
+    <span class="Toast-icon">
+      <!-- <%= octicon "info" %> -->
+      <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
+    </span>
+    <span class="Toast-content">This toast is dismissable.</span>
+    <button class="Toast-dismissButton">
+      <svg class="octicon octicon-x" style="fill:currentcolor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
+    </button>
+  </div>
+</div>
+```
+
+## Toast with link
+
+Include a link to allow users to take actions within a Toast.
+
+```html title="Toast with link"
+<div class="p-1">
+  <div class="Toast">
+    <span class="Toast-icon">
+      <!-- <%= octicon "info" %> -->
+      <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
+    </span>
+    <span class="Toast-content">Toast message goes here </strong><a href="#">Action.</a></span>
+  </div>
+</div>
+```
+
+## Toast animation
+
+The `Toast--animateIn` and `Toast--animateOut` modifier classes can be used to animate the toast in and out from the bottom.
+
+```html title="Toast animating"
+<div class="p-1">
+  <div class="Toast Toast--animateIn">
+    <span class="Toast-icon">
+      <!-- <%= octicon "info" %> -->
+      <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
+    </span>
+    <span class="Toast-content">Toast message goes here.</span>
+  </div>
+</div>
+```
+
+## Toast position
+
+Use the `position-fixed bottom-0` utility classes on a wrapper element to position Toasts at the **bottom left** of the viewport.
+
+```html title="Toast animating"
+<div class="border bg-gray-light" style="height:150px">
+  <div class="position-fixed bottom-0">
+    <div class="Toast">
+      <span class="Toast-icon">
+        <!-- <%= octicon "info" %> -->
+        <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
+      </span>
+      <span class="Toast-content">Toast message goes here.</span>
+    </div>
+  </div>
+</div>
+```

--- a/pages/css/getting-started/contributing.md
+++ b/pages/css/getting-started/contributing.md
@@ -76,7 +76,7 @@ Let the [design systems team](https://github.com/github/design-systems) know if 
 
 - Documentation for Primer CSS modules should live in the corresponding `.md` file for that module in the `/pages/css` folder. 
 
--There are separate folders in `/pages/css` for component, object, support, and utilities docs, as well as separate folders for more general documentation such as principles and tooling.
+- There are separate folders in `/pages/css` for component, object, support, and utilities docs, as well as separate folders for more general documentation such as principles and tooling.
 
 - Each folder corresponds to a new url such as `primer.style/css/utilities`.
 
@@ -117,8 +117,8 @@ Typically the file will look something like this:
 Which consists of three parts:
 
 1. **YML frontmatter** _(optional)_, similar to jekyll’s frontmatter, this is used to generate the sidebar and title components.
-2. **Docs section** _(required)_, This is the section between the YML and the first `````html`
-3. **The example section** _(optional)_, This section is denoted by ````html` and will render into an example used in the page. This can contain rails helpers also eg. `<%= octicons 'fire' %>`
+2. **Docs section** _(required)_, This is the section between the YML and the first `​```html`
+3. **The example section** _(optional)_, This section is denoted by `​```html` and will render into an example used in the page. This can contain rails helpers also eg. `<%= octicons 'fire' %>`
 
 The options you have for the frontmatter are outlined below:
 
@@ -173,11 +173,11 @@ In pages published on [primer.style/css](https://primer.style/css), a table of c
 
 When using code blocks for demo purposes, you can choose to render each of the blocks differently by specifying the layout in the info string. For example if you want to use `toggle` as the layout for a code block:
 
-```markdown
-  ```html layout=toggle
-  <div class="p-5">Animation</div>
-  ```
+````markdown
+```html layout=toggle
+<div class="p-5">Animation</div>
 ```
+````
 
 #### Versioning
 

--- a/pages/css/index.md
+++ b/pages/css/index.md
@@ -54,12 +54,12 @@ Primer CSS is published to npm as `@primer/css`. Each of Primer CSS's "modules" 
 * **Product** styles (in `product/`) are specific to github.com, and include components such as avatars, labels, markdown styles, popovers, and progress indicators.
 * **Marketing** styles (in `marketing/`) are specific to GitHub marketing efforts, including international and event-focused sites as well as the more design-heavy feature pages on github.com. Marketing styles include new colors and button styles, and extend the core typography and whitespace scales.
 
-<div class="bg-gray py-6">
-  <div class="d-flex flex-wrap flex-md-nowrap px-6 gutter-lg">
-    <div class="col-12 col-md-9 pr-0 pr-lg-2">
-      <h3 class="f3 text-normal m-0">Use Primer CSS in your project</h3>
-      <p class="my-3">Pick and choose what you need. Install the entire Primer CSS bundle or import individual folders.</p>
-      <a href="/css/getting-started" class="btn btn-outline">Installation instructions</a>
+<div className="bg-gray py-6">
+  <div className="d-flex flex-wrap flex-md-nowrap px-6 gutter-lg">
+    <div className="col-12 col-md-9 pr-0 pr-lg-2">
+      <h3 className="f3 text-normal m-0">Use Primer CSS in your project</h3>
+      <p className="my-3">Pick and choose what you need. Install the entire Primer CSS bundle or import individual folders.</p>
+      <a href="/css/getting-started" className="btn btn-outline">Installation instructions</a>
     </div>
   </div>
 </div>

--- a/pages/css/principles/index.md
+++ b/pages/css/principles/index.md
@@ -93,7 +93,7 @@ Example:
 
 ## BEM-style naming and structure
 
-Components and objects should follow the [Block Element Modifier](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/) (BEM) model in terms of structure. We've chosen to use a modified form of BEM syntax using [PascalCase](https://en.wikipedia.org/wiki/PascalCase) for the block name, hyphens and lowercase or elements, and double-hyphens and lowercase for modifiers. When a Block class requires two words use PascalCase, for example `ProgressBar`.
+Components and objects should follow the [Block Element Modifier](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/) (BEM) model in terms of structure. We've chosen to use a modified form of BEM syntax using [Uppercase](https://en.wikipedia.org/wiki/Uppercase) for the block name, hyphens and lowercase or elements, and double-hyphens and lowercase for modifiers. When a Block class requires two words use [PascalCase](https://en.wikipedia.org/wiki/PascalCase), for example `ProgressBar`. When an Element or Modifier class requires two words use [camelCase](https://en.wikipedia.org/wiki/camelCase), for example `[Component]-closeButton` or `[Component]--extraLarge`.
 
 * **Block**: A block includes all of the base styles you want shared across every variation of a component. Minimal thematic styling should be applied to blocks, particularly when variations of a component include visual variations. Apply additional styles with modifers rather than overriding base styles.
 * **Element**: An element is part of a component. Elements should work together with other elements and can have modifiers. Element styles should not override block styles - this often results in applying more styles directly to elements rather than having styles flow down from the parent level.
@@ -107,11 +107,12 @@ Components and objects should follow the [Block Element Modifier](http://csswiza
 .Box-header {...}
 .Box-body {...}
 .Box-footer {...}
+.Box-closeButton {...}
 
 // modifiers
 .Box--blue {...}
-.Box--red {...}
-.Box-header--large {...}
+.Box--large {...}
+.Box--extraLarge {...}
 ```
 
 ## Property order

--- a/pages/css/support/color-system.md
+++ b/pages/css/support/color-system.md
@@ -42,7 +42,7 @@ import {PaletteTable, PaletteCell, overlayColor} from '../../../docs/color-syste
         <StyledOcticon icon={LinkIcon} color="inherit !important" height={20} />
       </Flex>
       <PaletteTable
-        columns={['variable', 'value' /*, 'className' */]}
+        columns={['variable', 'value']}
         values={[{variable: name, value, slug: name}].concat(values)}
         hasHeader={false}
         cellPadding="8px 16px" />

--- a/pages/css/support/color-system.md
+++ b/pages/css/support/color-system.md
@@ -1,24 +1,55 @@
 ---
 title: Color system
-path: support/color-system
 description: 'Sass variables, mixins, and functions for use in our components.'
-source: 'https://github.com/primer/primer/blob/master/modules/primer-support/lib/variables/color-system.scss'
-symbols: [gray, grey, blue, green, purple, yellow, orange, red, black, white]
 status: Stable
 status_issue: 'https://github.com/github/design-systems/issues/301'
-package:
-  name: primer-support
 ---
 
-import {BorderBox, Box, Flex, Heading, Text} from '@primer/components'
-import {ColorPalette, ColorVariables} from '../../../docs/color-system'
+import colors from 'primer-colors'
+import {Box, Flex, Heading, Link, StyledOcticon} from '@primer/components'
+import {Link as LinkIcon} from '@githubprimer/octicons-react'
+import {palettes, variables} from '../../../docs/color-variables'
+import {PaletteTable, PaletteCell, overlayColor} from '../../../docs/color-system'
 
-## Table of Contents
+
+# Table of contents
+
 
 ## Color palette
 
-<ColorPalette />
+<Flex flexWrap="wrap" mr={-2}>
+  {palettes.concat(
+    {title: 'Black', name: 'black', value: colors.gray[9]},
+    {title: 'White', name: 'white', value: colors.white, props: {className: 'border'}}
+  ).map(({name, title, value, props = {}}) => (
+    <Flex.Item as={Link} href={`#${name}`} color={overlayColor(value)} flex="1 1 auto" bg={value} p={3} mr={2} mb={2} fontWeight="bold" key={name} {...props}>
+      {title}
+    </Flex.Item>
+  ))}
+</Flex>
 
 ## Color variables
 
-<ColorVariables />
+<Flex flexWrap="wrap" mr={[0, 0, -4]}>{
+  palettes.map(({name, title, value, values}) => (
+    <Box id={name} width={[1, 1, 1/2]} pr={[0, 0, 4]} mb={4}>
+      <Flex as={Link} href={`#${name}`} bg={value} color={overlayColor(value)} px={3} pt={4} style={{borderBottom: `1px solid ${overlayColor(value)}`}} alignItems="center">
+        <Flex.Item color="inherit !important" flex="1 1 auto">
+          <Heading as="div" fontSize={4} pb={1}>
+            {title}
+          </Heading>
+        </Flex.Item>
+        <StyledOcticon icon={LinkIcon} color="inherit !important" height={20} />
+      </Flex>
+      <PaletteTable
+        columns={['variable', 'value' /*, 'className' */]}
+        values={[{variable: name, value, slug: name}].concat(values)}
+        hasHeader={false}
+        cellPadding="8px 16px" />
+    </Box>
+  ))
+}</Flex>
+
+## Color utilities
+
+There are [utility classes](/css/utilities/colors) for every color in our system except fades.

--- a/pages/css/utilities/borders.md
+++ b/pages/css/utilities/borders.md
@@ -231,4 +231,4 @@ You can adjust border widths on all sides or each side individually with respons
     'variable',
     'value'
   ]}
-  borderSpacing="0 4px" />
+  style={{borderSpacing: '0 4px'}} />

--- a/pages/css/utilities/borders.md
+++ b/pages/css/utilities/borders.md
@@ -7,6 +7,11 @@ source: 'https://github.com/primer/css/tree/master/src/utilities/borders.scss'
 bundle: utilities
 ---
 
+import {MarkdownHeading} from '@primer/blueprints'
+import {palettes, borders} from '../../../docs/color-variables'
+import {PaletteTable, PaletteCell, PaletteValue} from '../../../docs/color-system'
+
+
 Utilities for borders, border radius, and box shadows.
 
 ## Table of Contents
@@ -216,3 +221,14 @@ You can adjust border widths on all sides or each side individually with respons
   <span class="d-none d-lg-inline">.border-md-top-0 </span>
 </div>
 ```
+
+## Border color utilities
+<PaletteTable
+  values={borders}
+  prefix="bg"
+  columns={[
+    {title: 'Class', Cell: PaletteCell.Border, Value: props => `.${props.aliases.border}`},
+    'variable',
+    'value'
+  ]}
+  borderSpacing="0 4px" />

--- a/pages/css/utilities/colors.md
+++ b/pages/css/utilities/colors.md
@@ -1,151 +1,49 @@
 ---
 title: Colors
-path: utilities/colors
 description: 'Immutable, atomic CSS classes to rapidly build product'
 status: Stable
-package:
-  name: primer-utilities
-source: 'https://github.com/primer/primer/tree/master/modules/primer-utilities/lib/colors.scss'
 status_issue: 'https://github.com/github/design-systems/issues/97'
 ---
 
-import colors from 'primer-colors'
-import {Box} from '@primer/components'
-const Swatch = props => <Box mt={2} height={60} {...props} />
+import {Box, BorderBox} from '@primer/components'
+import {MarkdownHeading as Heading} from '@primer/blueprints'
+import {palettes, allColors} from '../../../docs/color-variables'
+import {PaletteTable, PaletteTableFragment, PaletteHeading, PaletteCell, PaletteValue} from '../../../docs/color-system'
+const textColumns = [
+  {title: 'Alias', Cell: props => <PaletteCell.Alias {...props} style={{borderBottom: `1px solid ${props.value} !important`}} />},
+  {title: 'Class', Cell: props => <PaletteCell.Text {...props} style={{borderBottom: props.aliases.text ? `1px solid ${props.value} !important` : null}} />, Value: PaletteValue.PrefixedClass},
+  'variable',
+  {title: 'Value', Cell: PaletteCell.Background,  Value: PaletteValue.Value},
+]
 
 Use color utilities to apply color to the background of elements, text, and borders.
 
-* [Background colors](#background-colors)
-* [Text colors](#text-colors)
-* [Link colors](#link-colors)
-* [Border colors](#border-colors)
+# Table of contents
+
 
 ## Background colors
 
 Background colors are most commonly used for filling large blocks of content or areas with a color. When selecting a background color, make sure the foreground color contrast passes a minimum WCAG accessibility rating of [level AA](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html). Meeting these standards ensures that content is accessible by everyone, regardless of disability or user device. You can [check your color combination with this demo site](http://jxnblk.com/colorable/demos/text/). For more information, read our [accessibility standards](../principles/accessibility).
 
-### Gray
+### Background utilities
 
-<div class="container-lg clearfix mb-4">
-  <div class="col-3 float-left pr-4">
-    <div class="h4">.bg-gray</div>
-    <code>{colors.gray[1]}, $bg-gray</code>
-    <Swatch className="bg-gray" />
-  </div>
-  <div class="col-9 float-left">
-    <div class="container-lg clearfix">
-      <div class="col-6 float-left">
-        <div class="h4">.bg-gray-dark</div>
-        <code>{colors.gray[9]}, $bg-gray-dark</code>
-        <Swatch className="bg-gray-dark border-right-0" />
-      </div>
-      <div class="col-6 float-left">
-        <div class="h4">.bg-gray-light</div>
-        <code>{colors.gray[0]}, $bg-gray-light</code>
-        <Swatch className="bg-gray-light" />
-      </div>
-    </div>
-  </div>
-</div>
-
-### Blue
-
-<div class="container-lg clearfix mb-4">
-  <div class="col-3 float-left pr-4">
-    <div class="h4">.bg-blue</div>
-    <code>{colors.blue[5]}, $bg-blue</code>
-    <Swatch className="bg-blue" />
-  </div>
-  <div class="col-9 float-left">
-    <div class="container-lg clearfix">
-      <div class="h4">.bg-blue-light</div>
-      <code>{colors.blue[0]}, $bg-blue-light</code>
-      <Swatch className="bg-blue-light" />
-    </div>
-  </div>
-</div>
-
-### Yellow
-
-<div class="container-lg clearfix mb-4">
-  <div class="col-3 float-left pr-4">
-    <div class="h4">.bg-yellow</div>
-    <code>{colors.yellow[5]}, $bg-yellow</code>
-    <Swatch className="bg-yellow" />
-  </div>
-  <div class="col-9 float-left">
-    <div class="container-lg clearfix">
-      <div class="col-6 float-left">
-        <div class="h4">.bg-yellow-dark</div>
-        <code>{colors.yellow[7]}, $bg-yellow-dark</code>
-        <Swatch className="bg-yellow-dark border-right-0" />
-      </div>
-      <div class="col-6 float-left">
-        <div class="h4">.bg-yellow-light</div>
-        <code>{colors.yellow[2]}, $bg-yellow-light</code>
-        <Swatch className="bg-yellow-light" />
-      </div>
-    </div>
-  </div>
-</div>
-
-### Red
-
-<div class="container-lg clearfix mb-4">
-  <div class="col-3 float-left pr-4">
-    <div class="h4">.bg-red</div>
-    <code>{colors.red[5]}, $bg-red</code>
-    <Swatch className="bg-red" />
-  </div>
-  <div class="col-9 float-left">
-    <div class="container-lg clearfix">
-      <div class="h4">.bg-red-light</div>
-      <code>{colors.red[1]}, $bg-red-light</code>
-      <Swatch className="bg-red-light" />
-    </div>
-  </div>
-</div>
-
-### Green
-
-<div class="container-lg clearfix mb-4">
-  <div class="col-3 float-left pr-4">
-    <div class="h4">.bg-green</div>
-    <code>{colors.green[5]}, $bg-green</code>
-    <Swatch className="bg-green" />
-  </div>
-  <div class="col-9 float-left">
-    <div class="container-lg clearfix">
-      <div class="h4">.bg-green-light</div>
-      <code>{colors.green[1]}, $bg-green-light</code>
-      <Swatch className="bg-green-light" />
-    </div>
-  </div>
-</div>
-
-
-### Purple
-
-<div class="container-lg clearfix mb-4">
-  <div class="col-3 float-left pr-4">
-    <div class="h4">.bg-purple</div>
-    <code>{colors.purple[5]}, $bg-purple</code>
-    <Swatch className="bg-purple" />
-  </div>
-  <div class="col-9 float-left">
-    <div class="container-lg clearfix">
-      <div class="h4">.bg-purple-light</div>
-      <code>{colors.purple[0]}, $bg-purple-light</code>
-      <Swatch className="bg-purple-light" />
-    </div>
-  </div>
-</div>
+<PaletteTable>
+  {palettes.map(({name, title, value}) => (
+    <PaletteTableFragment name={name} type="bg" key={name}>
+      <tr>
+        <PaletteHeading indicatorColor={value} colSpan="4">
+          {title}
+        </PaletteHeading>
+      </tr>
+    </PaletteTableFragment>
+  ))}
+</PaletteTable>
 
 ## Text colors
 
 Use text color utilities to set text or [Octicons](https://octicons.github.com) to a specific color. Color contrast must pass a minimum WCAG accessibility rating of [level AA](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html). This ensures that viewers who cannot see the full color spectrum are able to read the text. To customize outside of the suggested combinations below, we recommend using this [color contrast testing tool](http://jxnblk.com/colorable/demos/text/). For more information, read our [accessibility standards](../principles/accessibility).
 
-These are our most common text with background color combinations. They don't all pass accessibility standards currently, but will be updated in the future. **Any of the combinations with a warning icon must be used with caution**.
+These are our most common text with background color combinations. They don't all pass accessibility standards currently, but will be updated in the future. **⚠️ Any of the combinations with a warning icon must be used with caution**.
 
 ### Text color inheritance
 
@@ -175,22 +73,23 @@ You can set the color inheritance on an element by using the `text-inherit` clas
 <div class="text-orange mb-2">
   .text-orange on white
 </div>
-<span class="float-left text-red tooltipped tooltipped-n" aria-label="Does not meet accessibility standards"><%= octicon("alert") %></span>
 <div class="text-orange-light mb-2">
-  .text-orange-light on white
+   .text-orange-light on white
+  <span class="tooltipped tooltipped-n" aria-label="Does not meet accessibility standards">⚠️</span>
 </div>
-<span class="float-left text-red tooltipped tooltipped-n" aria-label="Does not meet accessibility standards"><%= octicon("alert") %></span>
 <div class="text-yellow mb-2">
   .text-yellow on white
+  <span class="tooltipped tooltipped-n" aria-label="Does not meet accessibility standards">⚠️</span>
 </div>
-<span class="float-left text-red tooltipped tooltipped-n" aria-label="Does not meet accessibility standards"><%= octicon("alert") %></span>
-<div class="text-green mb-2 ml-4">
+<div class="text-green mb-2">
   .text-green on white
+  <span class="tooltipped tooltipped-n" aria-label="Does not meet accessibility standards">⚠️</span>
 </div>
 <div class="text-purple mb-2">
   .text-purple on white
 </div>
 ```
+
 
 ### Text on colored backgrounds
 
@@ -227,6 +126,30 @@ You can set the color inheritance on an element by using the `text-inherit` clas
 </div>
 <div class="bg-gray">
   .text-gray-dark on .bg-gray
+</div>
+```
+
+### Text color utilities
+
+<PaletteTable columns={textColumns}>
+  {palettes.map(({name, title, value}) => (
+    <PaletteTableFragment name={name} type="text" prefix="color" columns={textColumns}>
+      <tr>
+        <PaletteHeading indicatorColor={value} colSpan="4">
+          {title}
+        </PaletteHeading>
+      </tr>
+    </PaletteTableFragment>
+  ))}
+</PaletteTable>
+
+## White background
+
+You can make a background explicitly white (`#fff`) with the `bg-white` utility:
+
+```html
+<div class="bg-gray-dark p-2">
+  <span class="bg-white">.bg-white over .bg-gray-dark</span>
 </div>
 ```
 

--- a/pages/css/utilities/colors.md
+++ b/pages/css/utilities/colors.md
@@ -11,14 +11,14 @@ import {palettes, allColors} from '../../../docs/color-variables'
 import {PaletteTable, PaletteTableFragment, PaletteHeading, PaletteCell, PaletteValue} from '../../../docs/color-system'
 const textColumns = [
   {title: 'Alias', Cell: props => <PaletteCell.Alias {...props} style={{borderBottom: `1px solid ${props.value} !important`}} />},
-  {title: 'Class', Cell: props => <PaletteCell.Text {...props} style={{borderBottom: props.aliases.text ? `1px solid ${props.value} !important` : null}} />, Value: PaletteValue.PrefixedClass},
+  // {title: 'Class', Cell: props => <PaletteCell.Text {...props} style={{borderBottom: props.aliases.text ? `1px solid ${props.value} !important` : null}} />, Value: PaletteValue.PrefixedClass},
   'variable',
   {title: 'Value', Cell: PaletteCell.Background,  Value: PaletteValue.Value},
 ]
 
 Use color utilities to apply color to the background of elements, text, and borders.
 
-# Table of contents
+## Table of Contents
 
 
 ## Background colors
@@ -29,7 +29,7 @@ Background colors are most commonly used for filling large blocks of content or 
 
 <PaletteTable>
   {palettes.map(({name, title, value}) => (
-    <PaletteTableFragment name={name} type="bg" key={name}>
+    <PaletteTableFragment name={name} type="bg" sparse key={name}>
       <tr>
         <PaletteHeading indicatorColor={value} colSpan="4">
           {title}
@@ -133,7 +133,7 @@ You can set the color inheritance on an element by using the `text-inherit` clas
 
 <PaletteTable columns={textColumns}>
   {palettes.map(({name, title, value}) => (
-    <PaletteTableFragment name={name} type="text" prefix="color" columns={textColumns}>
+    <PaletteTableFragment name={name} type="text" sparse prefix="color" columns={textColumns}>
       <tr>
         <PaletteHeading indicatorColor={value} colSpan="4">
           {title}

--- a/pages/css/utilities/flexbox.md
+++ b/pages/css/utilities/flexbox.md
@@ -472,13 +472,17 @@ When the main axis wraps, this creates multiple main axis lines and adds extra s
 
 Use this class to specify the ability of a flex item to alter its dimensions to fill available space.
 
-```CSS
-.flex-auto    { flex: 1 1 auto; }
+```css
+.flex-auto       { flex: 1 1 auto; }
+.flex-grow-0     { flex-grow: 0; }
+.flex-shrink-0   { flex-shrink: 0; }
 ```
 
 | Class | Description |
 | --- | --- |
 | `.flex-auto` | Sets default values for  `flex-grow` (1), `flex-shrink` (1) and `flex-basis` (auto)  |
+| `.flex-grow-0` | Prevents growing of a flex item  |
+| `.flex-shrink-0` | Prevents shrinking of a flex item  |
 
 #### flex-auto
 
@@ -486,6 +490,26 @@ Use this class to specify the ability of a flex item to alter its dimensions to 
 <div class="border d-flex">
   <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
   <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
+  <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
+</div>
+```
+
+#### flex-grow-0
+
+```html
+<div class="border d-flex">
+  <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
+  <div class="p-5 border bg-gray-light flex-auto flex-grow-0">.flex-auto .flex-grow-0</div>
+  <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
+</div>
+```
+
+#### flex-shrink-0
+
+```html
+<div class="border d-flex" style="width: 450px">
+  <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
+  <div class="p-5 border bg-gray-light flex-auto flex-shrink-0">.flex-auto .flex-shrink-0</div>
   <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
 </div>
 ```
@@ -573,6 +597,49 @@ Use these classes to adjust the alignment of an individual flex item on the cros
   <div class="p-5 border bg-gray-light flex-self-stretch">.flex-self-stretch</div>
   <div class="p-5 border bg-gray-light">&nbsp;</div>
   <div class="p-5 border bg-gray-light">&nbsp;</div>
+</div>
+```
+
+## Order
+
+Use these classes to change the order of flex items. Keep in mind that it won't affect screen readers or navigating with the keyboard and it's advised to keep the markup in a logical source order.
+
+#### CSS
+
+```css
+.flex-order-1    { order: 1; }
+.flex-order-2    { order: 2; }
+.flex-order-none { order: inherit; }
+
+```
+
+#### Classes
+
+| Class | Description |
+| --- | --- |
+| `.flex-order-1` | Set order to be 1 |
+| `.flex-order-2` | Set order to be 2  |
+| `.flex-order-none` | Remove order (typically used with responsive variants) |
+
+#### flex-order (1+2)
+
+```html
+<div class="border d-flex">
+  <div class="p-5 border bg-gray-light flex-order-2">1. .flex-order-2</div>
+  <div class="p-5 border bg-gray-light">2.</div>
+  <div class="p-5 border bg-gray-light flex-order-1">3. .flex-order-1</div>
+</div>
+```
+
+#### flex-order-none
+
+Resize window to see the effect.
+
+```html
+<div class="border d-flex">
+  <div class="p-5 border bg-gray-light flex-order-1 flex-md-order-none">1. .flex-order-1 .flex-md-order-none</div>
+  <div class="p-5 border bg-gray-light">2.</div>
+  <div class="p-5 border bg-gray-light">3.</div>
 </div>
 ```
 

--- a/pages/css/utilities/layout.md
+++ b/pages/css/utilities/layout.md
@@ -190,6 +190,16 @@ Use `.width-full` to set width to 100%.
 </div>
 ```
 
+Use `.width-auto` to reset width to `auto` (initial value). Typically used with **responsive variants**. Resize the window to see the effect in the example below.
+
+```html
+<div class="d-table width-full width-md-auto">
+  <div class="d-table-cell">
+    <input class="form-control width-full" type="text" value="Responsive width form field" aria-label="Sample full responsive width form field">
+  </div>
+</div>
+```
+
 Use `.height-fit` to set max-height 100%.
 
 ```html

--- a/src/marketing/support/variables.scss
+++ b/src/marketing/support/variables.scss
@@ -6,6 +6,7 @@ $marketing-font-path: "/fonts/" !default;
   font-style: normal;
   font-weight: $font-weight-normal;
   src: local("Inter"), local("Inter-Regular"), url("#{$marketing-font-path}Inter-Regular.woff") format("woff");
+  font-display: swap;
 }
 
 @font-face {
@@ -13,6 +14,7 @@ $marketing-font-path: "/fonts/" !default;
   font-style: normal;
   font-weight: $font-weight-semibold;
   src: local("Inter Medium"), local("Inter-Medium"), url("#{$marketing-font-path}Inter-Medium.woff") format("woff");
+  font-display: swap;
 }
 
 $font-mktg: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;

--- a/src/marketing/support/variables.scss
+++ b/src/marketing/support/variables.scss
@@ -1,4 +1,4 @@
-$marketing-font-path: "/primer-marketing-support/fonts/" !default;
+$marketing-font-path: "/fonts/" !default;
 
 // Type
 @font-face {

--- a/src/navigation/index.scss
+++ b/src/navigation/index.scss
@@ -3,5 +3,6 @@
 @import "./menu.scss";
 @import "./tabnav.scss";
 @import "./filter-list.scss";
+@import "./sidenav.scss";
 @import "./subnav.scss";
 @import "./underline-nav.scss";

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -1,0 +1,110 @@
+// Side Nav
+//
+// A vertical list of navigational links, typically used on the left side of a page.
+
+.SideNav-item {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: $spacer-3;
+  color: $text-gray;
+  text-align: left;
+  background-color: transparent;
+  border: 0;
+  border-top: $border;
+
+  &:first-child {
+    border-top: 0;
+  }
+
+  &:last-child {
+    // makes sure there is a "bottom border" in case the list is not long enough
+    box-shadow: 0 $border-width 0 $border-color;
+  }
+
+  // Bar on the left
+  &::before {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    width: 3px;
+    pointer-events: none;
+    content: "";
+    background-color: $gray-300;
+    transition: transform 0.24s ease-in;
+    transform: scaleX(0);
+    transform-origin: center left;
+  }
+}
+
+// States
+
+.SideNav-item:hover,
+.SideNav-item:focus {
+  color: $text-gray-dark;
+  text-decoration: none;
+  background-color: $gray-100;
+  outline: none;
+
+  // Bar on the left
+  &::before {
+    transition: transform 0.12s ease-out;
+    transform: scaleX(1);
+  }
+}
+
+.SideNav-item:active {
+  background-color: $bg-white;
+}
+
+.SideNav-item[aria-current="page"],
+.SideNav-item[aria-selected="true"] {
+  font-weight: $font-weight-semibold;
+  color: $text-gray-dark;
+  background-color: $bg-white;
+
+  // Bar on the left
+  &::before {
+    background-color: $orange-600;
+    transform: scaleX(1);
+  }
+}
+
+// Icon
+//
+// Makes sure multiple icons are vertically aligned
+
+.SideNav-icon {
+  width: 16px;
+  color: $text-gray-light;
+}
+
+// Sub Nav
+//
+// A more lightweight version, suited as a sub nav
+
+.SideNav-subItem {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: $spacer-1 0;
+  color: $blue-500;
+  text-align: left;
+  background-color: transparent;
+  border: 0;
+}
+
+.SideNav-subItem:hover,
+.SideNav-subItem:focus {
+  color: $text-gray-dark;
+  text-decoration: none;
+  outline: none;
+}
+
+.SideNav-subItem[aria-current="page"],
+.SideNav-subItem[aria-selected="true"] {
+  font-weight: $font-weight-semibold;
+  color: $text-gray-dark;
+}

--- a/src/product/index.scss
+++ b/src/product/index.scss
@@ -23,3 +23,4 @@
 @import "../popover/index.scss";
 @import "../progress/index.scss";
 @import "../subhead/index.scss";
+@import "../toasts/index.scss"

--- a/src/product/index.scss
+++ b/src/product/index.scss
@@ -22,5 +22,6 @@
 @import "../markdown/index.scss";
 @import "../popover/index.scss";
 @import "../progress/index.scss";
+@import "../select-menu/index.scss";
 @import "../subhead/index.scss";
 @import "../toasts/index.scss"

--- a/src/select-menu/README.md
+++ b/src/select-menu/README.md
@@ -1,0 +1,4 @@
+# Select Menu
+- [Live documentation](https://primer.style/css/components/select-menu)
+- [Documentation source](../../pages/css/components/select-menu.md)
+- [Style source](./select-menu.scss)

--- a/src/select-menu/index.scss
+++ b/src/select-menu/index.scss
@@ -1,0 +1,3 @@
+// support files
+@import "../support/index.scss";
+@import "./select-menu.scss";

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -1,0 +1,422 @@
+// stylelint-disable selector-max-type
+
+// selector-max-type is needed for body:not(.intent-mouse) to target keyboard only styles.
+// TODO: Introduce an additional .intent-keyboard class
+
+// Select Menu
+//
+// A more advanced menu with support for navigation, filtering, and more.
+
+.SelectMenu {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 99;
+  display: flex;
+  padding: $spacer-3;
+  pointer-events: none;
+  flex-direction: column;
+
+  @include breakpoint(sm) {
+    position: absolute;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    padding: 0;
+  }
+}
+
+// Backdrop
+//
+// Adds a dark, semi transparent "cover" underneat the modal. Only visible for xs.
+
+.SelectMenu::before {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  content: "";
+  background-color: $black-fade-50;
+
+  @include breakpoint(sm) {
+    display: none;
+  }
+}
+
+// Modal
+//
+// The main "box" that contains the content
+
+.SelectMenu-modal {
+  position: relative;
+  z-index: 99; // Needs to be higher than .details-overlay's z-index: 80.
+  display: flex;
+  max-height: 66%;
+  margin: auto 0;
+  overflow: hidden; // Enables border radius on scrollable child elements
+  pointer-events: auto;
+  flex-direction: column;
+  background-color: $gray-100;
+  border-radius: $border-radius * 2;
+  box-shadow: 0 0 18px rgba(0, 0, 0, 0.4);
+  animation: SelectMenu-modal-animation 0.12s cubic-bezier(0, 0.1, 0.1, 1) backwards;
+
+  @keyframes SelectMenu-modal-animation {
+    0% {
+      opacity: 0;
+      transform: scale(0.9);
+    }
+  }
+
+  @keyframes SelectMenu-modal-animation--sm {
+    0% {
+      opacity: 0;
+      transform: translateY(-$spacer-3);
+    }
+  }
+
+  @include breakpoint(sm) {
+    width: 300px;
+    height: auto;
+    max-height: 350px;
+    margin: $spacer-1 0 $spacer-3 0;
+    font-size: $font-size-small;
+    border: $border-width $border-style $border-gray-dark;
+    border-radius: $border-radius;
+    box-shadow: $box-shadow-medium;
+    animation-name: SelectMenu-modal-animation--sm;
+  }
+}
+
+// Header
+//
+// Used for showing a title and the close button. Close button is only visible for xs.
+
+.SelectMenu-header {
+  display: flex;
+  flex: none; // fixes header from getting squeezed in Safari iOS
+  padding: $spacer-3;
+
+  @include breakpoint(sm) {
+    padding: $spacer-2;
+  }
+}
+
+.SelectMenu-title {
+  flex: auto;
+  font-size: $body-font-size;
+  font-weight: $font-weight-bold;
+
+  @include breakpoint(sm) {
+    font-size: inherit;
+  }
+}
+
+.SelectMenu-closeButton {
+  padding: $spacer-3;
+  margin: -$spacer-3;
+  color: $text-gray-light;
+  background-color: transparent;
+  border: 0;
+
+  @include breakpoint(sm) {
+    display: none;
+  }
+}
+
+// Filter
+//
+// An input to filter a large list
+
+.SelectMenu-filter {
+  padding: $spacer-3;
+  margin: 0;
+  border-top: $border;
+
+  @include breakpoint(sm) {
+    padding: $spacer-2;
+  }
+}
+
+.SelectMenu-input {
+  display: block;
+  width: 100%;
+
+  @include breakpoint(sm) {
+    font-size: $h5-size;
+  }
+}
+
+// List
+//
+// The container that holds all the list items. Starts scrolling when the list gets too long.
+
+.SelectMenu-list {
+  position: relative;
+  padding: 0;
+  margin: 0;
+  flex: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
+  background-color: $bg-white;
+  border-top: $border;
+  -webkit-overflow-scrolling: touch; // Adds momentum + bouncy scrolling
+}
+
+// List Item
+//
+// The interactive element used to make a selection
+
+.SelectMenu-item {
+  display: block;
+  width: 100%;
+  padding: $spacer-3 $spacer-5;
+  overflow: hidden;
+  color: $text-gray;
+  text-align: left;
+  cursor: pointer;
+  background-color: $bg-white;
+  border: 0;
+
+  & + & {
+    // Add a top border only if the above element also is a list item
+    border-top: $border-width $border-style lighten($gray-200, 3%);
+  }
+
+  @include breakpoint(sm) {
+    padding-top: $spacer-2;
+    padding-bottom: $spacer-2;
+  }
+}
+
+// Icon
+//
+// The icon shown on the left of a list item. Typically a check icon.
+
+.SelectMenu-icon {
+  position: absolute;
+  height: 1.5em; // Mimics line-height to vertically center the icon
+  margin-left: -20px;
+  visibility: hidden;
+  transition: transform 0.12s cubic-bezier(0.5, 0.1, 1, 0.5), visibility 0s 0.12s linear;
+  transform: scale(0);
+}
+
+// Tabs
+//
+// Allows switching between multiple lists
+
+.SelectMenu-tabs {
+  display: flex;
+  flex-shrink: 0;
+  margin-bottom: -$border-width; // hide border of element below
+  overflow-x: auto;
+  overflow-y: hidden;
+  border-top: $border;
+  -webkit-overflow-scrolling: touch;
+
+  // Hide scrollbar so it doesn't cover the text
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  @include breakpoint(sm) {
+    padding: 0 $spacer-2;
+    border-top: 0;
+  }
+}
+
+.SelectMenu-tab {
+  flex: 1;
+  padding: $spacer-2 $spacer-3;
+  font-size: $font-size-small;
+  font-weight: $font-weight-semibold;
+  color: $text-gray-light;
+  text-align: center;
+  background-color: transparent;
+  border: 0;
+  box-shadow: inset 0 -1px 0 $border-color;
+
+  @include breakpoint(sm) {
+    flex: none;
+    padding: $spacer-1 $spacer-3;
+    border-top-left-radius: $border-radius;
+    border-top-right-radius: $border-radius;
+  }
+
+  &[aria-selected="true"] {
+    z-index: 1; // Keeps box-shadow visible when hovering
+    color: $text-gray-dark;
+    background-color: $bg-white;
+    box-shadow: 0 0 0 1px $border-color;
+
+    @include breakpoint(sm) {
+      border: $border;
+      border-bottom-width: 0;
+      box-shadow: none;
+    }
+  }
+}
+
+// Message, Blankslate and Loading
+//
+// A container used to show different kinds of content. Like a message, a blankslate or the loading animation.
+
+.SelectMenu-message,
+.SelectMenu-blankslate,
+.SelectMenu-loading {
+  padding: $spacer-4 $spacer-3;
+  text-align: center;
+  background-color: $bg-white;
+}
+
+// Divider
+//
+// Can be used to divide the list into multiple groups
+
+.SelectMenu-divider {
+  padding: $spacer-1 $spacer-3;
+  margin: 0;
+  font-size: $font-size-small;
+  font-weight: $font-weight-bold;
+  color: $text-gray-light;
+  background-color: $gray-100;
+  border-top: $border;
+  border-bottom: $border;
+
+  &:first-child {
+    border-top: 0;
+  }
+
+  &:last-child {
+    border-bottom: 0;
+  }
+
+  @include breakpoint(sm) {
+    padding: $spacer-1 $spacer-2;
+  }
+}
+
+// Footer
+//
+// A container at the bottom.
+
+.SelectMenu-footer {
+  padding: $spacer-2 $spacer-3;
+  font-size: $font-size-small;
+  color: $text-gray-light;
+  text-align: center;
+  border-top: $border;
+
+  @include breakpoint(sm) {
+    padding: $spacer-1 $spacer-2;
+  }
+}
+
+// Has Filter (modifier)
+//
+// Makes sure that the filter input keeps a fixed position at the top while typing. Only visible for xs.
+
+.SelectMenu--hasFilter {
+  .SelectMenu-modal {
+    height: 80%;
+    max-height: none;
+    margin-top: 0;
+
+    @include breakpoint(sm) {
+      height: auto;
+      max-height: 350px;
+      margin-top: $spacer-1;
+    }
+  }
+
+  // Show bottom "border" for the last item when the list doesn't take up the whole height
+  .SelectMenu-item:last-child {
+    box-shadow: 0 $border-width 0 lighten($gray-200, 3%);
+  }
+}
+
+// States
+//
+// Different states
+
+// Reset outlines
+.SelectMenu-tab:focus,
+.SelectMenu-item:focus {
+  outline: none;
+}
+
+// Reset <a> elements
+.SelectMenu-item:hover {
+  text-decoration: none;
+}
+
+// Selected
+//
+// Visible when a used clicks/taps on a list item
+
+.SelectMenu-item[aria-checked="true"] {
+  font-weight: $font-weight-semibold;
+  color: $text-gray-dark;
+
+  .SelectMenu-icon {
+    visibility: visible;
+    transition: transform 0.12s cubic-bezier(0, 0, 0.2, 1), visibility 0s linear;
+    transform: scale(1);
+  }
+}
+
+// Can hover states
+//
+// For mouse/keyboard input
+
+@media (hover: hover) {
+  body:not(.intent-mouse) .SelectMenu-item:focus,
+  .SelectMenu-item:hover {
+    color: $text-white;
+    background-color: $blue-500;
+  }
+
+  .SelectMenu-item:active {
+    color: $text-white;
+    background-color: $blue-400;
+  }
+
+  body:not(.intent-mouse) .SelectMenu-tab:focus {
+    background-color: $blue-100;
+  }
+
+  .SelectMenu-tab:not([aria-checked="true"]):hover {
+    color: $text-gray-dark;
+    background-color: $gray-200;
+  }
+
+  .SelectMenu-tab:not([aria-checked="true"]):active {
+    color: $text-gray-dark;
+    background-color: $gray-100;
+  }
+}
+
+// Can not hover states
+//
+// For touch input
+
+@media (hover: none) {
+  // Android
+  .SelectMenu-item:focus,
+  .SelectMenu-item:active {
+    background-color: $gray-000;
+  }
+
+  // iOS Safari
+  // :active would work if ontouchstart is added to the button
+  // Instead this tweaks the "native" highlight color
+  .SelectMenu-item {
+    -webkit-tap-highlight-color: rgba($gray-300, 0.5);
+  }
+}

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -36,7 +36,7 @@ $lh-default: 1.5 !default;
 $body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
 
 // Monospace font stack
-$mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace !default;
+$mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace !default;
 
 // The base body size
 $body-font-size: 14px !default;

--- a/src/toasts/README.md
+++ b/src/toasts/README.md
@@ -1,0 +1,1 @@
+# Primer Toasts

--- a/src/toasts/index.scss
+++ b/src/toasts/index.scss
@@ -1,0 +1,2 @@
+@import "../support/index.scss";
+@import "./toasts.scss";

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -1,0 +1,89 @@
+// Toast
+
+.Toast {
+  display: flex;
+  margin: $spacer-2;
+  color: $black;
+  background-color: $bg-white;
+  border-radius: $border-radius;
+  box-shadow: inset 0 0 0 1px $border-gray-dark, $box-shadow-medium;
+
+  @include breakpoint(sm) {
+    width: max-content;
+    max-width: 450px;
+    margin: $spacer-3;
+  }
+}
+
+.Toast-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: $spacer-3 * 3;
+  flex-shrink: 0;
+  color: $text-white;
+  background-color: $blue-500;
+  border-top-left-radius: inherit;
+  border-bottom-left-radius: inherit;
+}
+
+.Toast-content {
+  padding: $spacer-3;
+}
+
+.Toast-dismissButton {
+  max-height: 54px; // keeps button aligned to the top
+  padding: $spacer-3;
+  background-color: transparent;
+  border: 0;
+
+  &:focus,
+  &:hover {
+    color: $text-gray;
+    outline: none;
+  }
+
+  &:active {
+    color: $gray-400;
+  }
+}
+
+// Modifier
+
+.Toast--error .Toast-icon {
+  background-color: $red-500;
+}
+
+.Toast--warning .Toast-icon {
+  color: $gray-900;
+  background-color: $yellow-600;
+}
+
+.Toast--success .Toast-icon {
+  background-color: $green-500;
+}
+
+// Animations
+
+.Toast--animateIn {
+  animation: Toast--animateIn 0.18s cubic-bezier(0.22, 0.61, 0.36, 1) backwards;
+}
+
+@keyframes Toast--animateIn {
+  0% {
+    opacity: 0;
+    transform: translateY(100%);
+  }
+}
+
+.Toast--animateOut {
+  animation: Toast--animateOut 0.18s cubic-bezier(0.55, 0.06, 0.68, 0.19) forwards;
+}
+
+@keyframes Toast--animateOut {
+  100% {
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(100%);
+  }
+}

--- a/src/utilities/flexbox.scss
+++ b/src/utilities/flexbox.scss
@@ -34,6 +34,7 @@
 
     // Item
     .flex#{$variant}-auto { flex: 1 1 auto !important; }
+    .flex#{$variant}-grow-0 { flex-grow: 0 !important; }
     .flex#{$variant}-shrink-0 { flex-shrink: 0 !important; }
 
     .flex#{$variant}-self-auto        { align-self: auto !important; }
@@ -48,5 +49,9 @@
       flex-grow: 1;
       flex-basis: 0;
     }
+
+    .flex#{$variant}-order-1 { order: 1 !important; }
+    .flex#{$variant}-order-2 { order: 2 !important; }
+    .flex#{$variant}-order-none { order: inherit !important; }
   }
 }

--- a/src/utilities/layout.scss
+++ b/src/utilities/layout.scss
@@ -76,6 +76,10 @@
 
 @each $breakpoint, $variant in $responsive-variants {
   @include breakpoint($breakpoint) {
+
+    // Auto varients
+    .width#{$variant}-auto { width: auto !important; }
+
     /* Set the direction to rtl */
     .direction#{$variant}-rtl { direction: rtl !important; }
     /* Set the direction to ltr */


### PR DESCRIPTION
# Primer CSS Minor Release

Version: 📦 **12.5.0**
Approximate release date: 📆 TBD (sometime after 2019-07-15)

### :rocket: Enhancement
- [x] Add `.Toast` component https://github.com/primer/css/pull/831
- [x] Add `.SideNav` component https://github.com/primer/css/pull/827
- [x] Add `.SelectMenu` component https://github.com/primer/css/pull/808
- [x] Add `font-display: swap` to `@font-face` declarations #780
- [x] Add `flex-grow-0`, `flex-order-[1,2,none]` and `width-auto` utilities https://github.com/primer/css/pull/763
- [x] Change default for `$marketing-font-path` to `/fonts/` #837 


### :bug: Bug Fix
- [x] Improve monospaced font on Chrome Android https://github.com/primer/css/pull/812

### :memo: Documentation
- [x] Add multi-word naming conventions to BEM docs #836
- [x] Color system docs updates https://github.com/primer/css/pull/811
- [x] Color utility table tweaks https://github.com/primer/css/pull/842
- [x] Fix markdown typos in Contributing docs page https://github.com/primer/css/pull/846

----

### Ship checklist

- [x] Update the `version` field in `package.json`
- [x] Update `CHANGELOG.md`
- [ ] Test the release candidate version with `github/github` https://github.com/github/github/pull/119544
- [ ] Merge this PR and [create a new release](https://github.com/primer/css/releases/new)
- [ ] Update `github/github`

For more details, see [RELEASING.md](https://github.com/primer/css/blob/master/RELEASING.md).

/cc @primer/ds-core