### PR TITLE
Toasts v2.1

### DIFF
--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -14,10 +14,11 @@ Toasts are used to show live, time-sensitive feedback to users.
 
 To create a default toast, use `.Toast`. Always use the `info` icon for default messages.
 
-```erb title="Default toast"
+```html title="Default toast"
   <div class="Toast">
     <span class="Toast-icon">
-      <%= octicon "info" %>
+      <!-- <%= octicon "info" %> -->
+      <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
     </span>
     <span class="Toast-content">Toast message goes here</span>
   </div>
@@ -25,10 +26,11 @@ To create a default toast, use `.Toast`. Always use the `info` icon for default 
 
 The Toast content is formattable. We recommend keeping your message under 140 characters.
 
-```erb title="Toast with long text"
+```html title="Toast with long text"
   <div class="Toast">
     <span class="Toast-icon">
-      <%= octicon "info" %>
+      <!-- <%= octicon "info" %> -->
+      <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
     </span>
     <span class="Toast-content">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. <strong>Aenean commodo ligula eget dolor.</strong> Aenean massa. Cum sociis <em>natoque</em> penatibus et ma</span>
   </div>
@@ -40,10 +42,11 @@ Use the success, warning, and error modifiers to communicate different states.
 
 Always use the `check` octicon for success states.
 
-``` erb title="Success toast"
+```html title="Success toast"
 <div class="Toast Toast--success">
   <span class="Toast-icon">
-    <%= octicon "check" %>
+    <!-- <%= octicon "check" %> -->
+    <svg class="octicon octicon-check" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
   </span>
   <span class="Toast-content">Success message goes here.</span>
 </div>
@@ -51,10 +54,11 @@ Always use the `check` octicon for success states.
 
 Always use the `alert` octicon for warning states.
 
-``` erb title="Warning toast"
+```html title="Warning toast"
 <div class="Toast Toast--warning">
   <span class="Toast-icon">
-    <%= octicon "alert" %>
+    <!-- <%= octicon "alert" %> -->
+    <svg class="octicon octicon-alert" style="fill:currentColor" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
   </span>
   <span class="Toast-content">Warning message goes here.</span>
 </div>
@@ -62,10 +66,11 @@ Always use the `alert` octicon for warning states.
 
 Always use the `stop` octicon for error states.
 
-```erb title="Error toast"
+```html title="Error toast"
 <div class="Toast Toast--error">
   <span class="Toast-icon">
-    <%= octicon "stop" %>
+    <!-- <%= octicon "stop" %> -->
+    <svg class="octicon octicon-stop" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 1H4L0 5v6l4 4h6l4-4V5l-4-4zm3 9.5L9.5 14h-5L1 10.5v-5L4.5 2h5L13 5.5v5zM6 4h2v5H6V4zm0 6h2v2H6v-2z"></path></svg>
   </span>
   <span class="Toast-content">Error message goes here</span>
 </div>
@@ -75,10 +80,11 @@ Always use the `stop` octicon for error states.
 
 Use `.Toast-dismissButton` to allow a user to explicitly dismiss a Toast.
 
-```erb title="Toast with dismiss"
+```html title="Toast with dismiss"
 <div class="Toast">
   <span class="Toast-icon">
-    <%= octicon "info" %>
+    <!-- <%= octicon "info" %> -->
+    <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
   </span>
   <span class="Toast-content">This toast is dismissable.</span>
   <button class="Toast-dismissButton">
@@ -91,11 +97,12 @@ Use `.Toast-dismissButton` to allow a user to explicitly dismiss a Toast.
 
 Include a link to allow users to take actions within a Toast.
 
-```erb title="Toast with link"
+```html title="Toast with link"
 <div class="p-3">
   <div class="Toast">
     <span class="Toast-icon">
-      <%= octicon "info" %>
+      <!-- <%= octicon "info" %> -->
+      <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
     </span>
     <span class="Toast-content">Toast message goes here </strong><a href="#">Action.</a></span>
   </div>
@@ -106,10 +113,11 @@ Include a link to allow users to take actions within a Toast.
 
 The toast will animate in and out from the bottom left of the viewport.
 
-```erb title="Toast animating"
+```html title="Toast animating"
 <div class="Toast Toast--animateIn">
   <span class="Toast-icon">
-    <%= octicon "info" %>
+    <!-- <%= octicon "info" %> -->
+    <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
   </span>
   <span class="Toast-content">Toast message goes here.</span>
 </div>

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -88,7 +88,7 @@ To create a default toast, use `.Toast`
 
 ```html title="Toast animating"
 <div class="p-3">
-  <div class="Toast Toast-animated Toast--error">
+  <div class="Toast Toast--error Toast--animateIn">
     <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -51,7 +51,7 @@ To create a default toast, use `.Toast`
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
     <span class="Toast-content">Submitting issue to <strong>github/github.</strong></span>
-    <a class="Toast-dismiss"><svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></a>
+    <button class="Toast-dismissButton"><svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
   </div>
 </div>
 ```
@@ -79,7 +79,7 @@ To create a default toast, use `.Toast`
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
     <span class="Toast-content">Submitting issue to <strong>github/github. </strong><a href="#">Try again.</a></span>
-    <a class="Toast-dismiss"><svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></a>
+    <button class="Toast-dismissButton"><svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
   </div>
 </div>
 ```
@@ -119,7 +119,7 @@ To create a default toast, use `.Toast`
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
     <span class="Toast-content">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</a></span>
-    <a class="Toast-dismiss"><svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></a>
+    <button class="Toast-dismissButton"><svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
   </div>
 </div>
 ```

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -123,7 +123,7 @@ Include a link to allow users to take actions within a Toast.
 
 ## Toast animation
 
-The toast will animate in and out from the bottom left of the viewport.
+The `Toast--animateIn` and `Toast--animateOut` modifier classes can be used to animate the toast in and out from the bottom.
 
 ```html title="Toast animating"
 <div class="p-1">

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -15,25 +15,25 @@ To create a default toast, use `.Toast`
 
 ```html title="Block style"
 <div class="p-3">
-  <div class="Toast Toast-block-default">
+  <div class="Toast">
     <span class="Toast-icon">
       <svg class="octicon octicon-info" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
     </span>
     <span class="Toast-content">Submitting issue to <strong>github/github</strong></span>
   </div>
-  <div class="Toast Toast-block-warning">
+  <div class="Toast Toast--warning">
     <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
     <span class="Toast-content">Submitting issue to <strong>github/github</strong></span>
   </div>
-  <div class="Toast Toast-block-success">
+  <div class="Toast Toast--success">
     <span class="Toast-icon">
       <svg class="octicon octicon-check" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
     </span>
     <span class="Toast-content">Submitting issue to <strong>github/github</strong></span>
   </div>
-  <div class="Toast Toast-block-error">
+  <div class="Toast Toast--error">
     <span class="Toast-icon">
       <svg class="octicon octicon-stop" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 1H4L0 5v6l4 4h6l4-4V5l-4-4zm3 9.5L9.5 14h-5L1 10.5v-5L4.5 2h5L13 5.5v5zM6 4h2v5H6V4zm0 6h2v2H6v-2z"></path></svg>
     </span>
@@ -46,7 +46,7 @@ To create a default toast, use `.Toast`
 
 ```html title="Toast with dismiss"
 <div class="p-3">
-  <div class="Toast Toast-block-error">
+  <div class="Toast Toast--error">
     <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
@@ -61,7 +61,7 @@ To create a default toast, use `.Toast`
 
 ```html title="Toast with link"
 <div class="p-3">
-  <div class="Toast Toast-block-error">
+  <div class="Toast Toast--error">
     <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
@@ -74,7 +74,7 @@ To create a default toast, use `.Toast`
 
 ```html title="Toast with action and dismiss"
 <div class="p-3">
-  <div class="Toast Toast-block-error">
+  <div class="Toast Toast--error">
     <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
@@ -88,7 +88,7 @@ To create a default toast, use `.Toast`
 
 ```html title="Toast animating"
 <div class="p-3">
-  <div class="Toast Toast-animated Toast-block-error">
+  <div class="Toast Toast-animated Toast--error">
     <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
@@ -101,7 +101,7 @@ To create a default toast, use `.Toast`
 
 ```html title="Toast with long text"
 <div class="p-3">
-  <div class="Toast Toast-block-error">
+  <div class="Toast Toast--error">
     <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
@@ -114,7 +114,7 @@ To create a default toast, use `.Toast`
 
 ```html title="Toast with long text"
 <div class="p-3">
-  <div class="Toast Toast-block-error">
+  <div class="Toast Toast--error">
     <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -15,6 +15,7 @@ Toasts are used to show live, time-sensitive feedback to users.
 To create a default toast, use `.Toast`. Always use the `info` icon for default messages.
 
 ```html title="Default toast"
+<div class="p-1">
   <div class="Toast">
     <span class="Toast-icon">
       <!-- <%= octicon "info" %> -->
@@ -22,11 +23,13 @@ To create a default toast, use `.Toast`. Always use the `info` icon for default 
     </span>
     <span class="Toast-content">Toast message goes here</span>
   </div>
+</div>
 ```
 
 The Toast content is formattable. We recommend keeping your message under 140 characters.
 
 ```html title="Toast with long text"
+<div class="p-1">
   <div class="Toast">
     <span class="Toast-icon">
       <!-- <%= octicon "info" %> -->
@@ -34,6 +37,7 @@ The Toast content is formattable. We recommend keeping your message under 140 ch
     </span>
     <span class="Toast-content">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. <strong>Aenean commodo ligula eget dolor.</strong> Aenean massa. Cum sociis <em>natoque</em> penatibus et ma</span>
   </div>
+</div>
 ```
 
 ## Variations
@@ -43,36 +47,42 @@ Use the success, warning, and error modifiers to communicate different states.
 Always use the `check` octicon for success states.
 
 ```html title="Success toast"
-<div class="Toast Toast--success">
-  <span class="Toast-icon">
-    <!-- <%= octicon "check" %> -->
-    <svg class="octicon octicon-check" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
-  </span>
-  <span class="Toast-content">Success message goes here.</span>
+<div class="p-1">
+  <div class="Toast Toast--success">
+    <span class="Toast-icon">
+      <!-- <%= octicon "check" %> -->
+      <svg class="octicon octicon-check" style="fill:currentColor" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
+    </span>
+    <span class="Toast-content">Success message goes here.</span>
+  </div>
 </div>
 ```
 
 Always use the `alert` octicon for warning states.
 
 ```html title="Warning toast"
-<div class="Toast Toast--warning">
-  <span class="Toast-icon">
-    <!-- <%= octicon "alert" %> -->
-    <svg class="octicon octicon-alert" style="fill:currentColor" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
-  </span>
-  <span class="Toast-content">Warning message goes here.</span>
+<div class="p-1">
+  <div class="Toast Toast--warning">
+    <span class="Toast-icon">
+      <!-- <%= octicon "alert" %> -->
+      <svg class="octicon octicon-alert" style="fill:currentColor" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
+    </span>
+    <span class="Toast-content">Warning message goes here.</span>
+  </div>
 </div>
 ```
 
 Always use the `stop` octicon for error states.
 
 ```html title="Error toast"
-<div class="Toast Toast--error">
-  <span class="Toast-icon">
-    <!-- <%= octicon "stop" %> -->
-    <svg class="octicon octicon-stop" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 1H4L0 5v6l4 4h6l4-4V5l-4-4zm3 9.5L9.5 14h-5L1 10.5v-5L4.5 2h5L13 5.5v5zM6 4h2v5H6V4zm0 6h2v2H6v-2z"></path></svg>
-  </span>
-  <span class="Toast-content">Error message goes here</span>
+<div class="p-1">
+  <div class="Toast Toast--error">
+    <span class="Toast-icon">
+      <!-- <%= octicon "stop" %> -->
+      <svg class="octicon octicon-stop" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 1H4L0 5v6l4 4h6l4-4V5l-4-4zm3 9.5L9.5 14h-5L1 10.5v-5L4.5 2h5L13 5.5v5zM6 4h2v5H6V4zm0 6h2v2H6v-2z"></path></svg>
+    </span>
+    <span class="Toast-content">Error message goes here</span>
+  </div>
 </div>
 ```
 
@@ -81,15 +91,17 @@ Always use the `stop` octicon for error states.
 Use `.Toast-dismissButton` to allow a user to explicitly dismiss a Toast.
 
 ```html title="Toast with dismiss"
-<div class="Toast">
-  <span class="Toast-icon">
-    <!-- <%= octicon "info" %> -->
-    <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
-  </span>
-  <span class="Toast-content">This toast is dismissable.</span>
-  <button class="Toast-dismissButton">
-    <svg class="octicon octicon-x" style="fill:currentcolor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
-  </button>
+<div class="p-1">
+  <div class="Toast">
+    <span class="Toast-icon">
+      <!-- <%= octicon "info" %> -->
+      <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
+    </span>
+    <span class="Toast-content">This toast is dismissable.</span>
+    <button class="Toast-dismissButton">
+      <svg class="octicon octicon-x" style="fill:currentcolor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
+    </button>
+  </div>
 </div>
 ```
 
@@ -98,7 +110,7 @@ Use `.Toast-dismissButton` to allow a user to explicitly dismiss a Toast.
 Include a link to allow users to take actions within a Toast.
 
 ```html title="Toast with link"
-<div class="p-3">
+<div class="p-1">
   <div class="Toast">
     <span class="Toast-icon">
       <!-- <%= octicon "info" %> -->
@@ -114,11 +126,13 @@ Include a link to allow users to take actions within a Toast.
 The toast will animate in and out from the bottom left of the viewport.
 
 ```html title="Toast animating"
-<div class="Toast Toast--animateIn">
-  <span class="Toast-icon">
-    <!-- <%= octicon "info" %> -->
-    <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
-  </span>
-  <span class="Toast-content">Toast message goes here.</span>
+<div class="p-1">
+  <div class="Toast Toast--animateIn">
+    <span class="Toast-icon">
+      <!-- <%= octicon "info" %> -->
+      <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
+    </span>
+    <span class="Toast-content">Toast message goes here.</span>
+  </div>
 </div>
 ```

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -7,119 +7,110 @@ source: ''
 bundle: toasts
 ---
 
-# Toasts
+Toasts are used to show live, time-sensitive feedback to users.
 
-To create a default toast, use `.Toast`
 
-## Default style
+## Default
 
-```html title="Block style"
-<div class="p-3">
+To create a default toast, use `.Toast`. Always use the `info` icon for default messages.
+
+```erb title="Default toast"
   <div class="Toast">
     <span class="Toast-icon">
-      <svg class="octicon octicon-info" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
+      <%= octicon "info" %>
     </span>
-    <span class="Toast-content">Submitting issue to <strong>github/github</strong></span>
+    <span class="Toast-content">Toast message goes here</span>
   </div>
-  <div class="Toast Toast--warning">
+```
+
+The Toast content is formattable. We recommend keeping your message under 140 characters.
+
+```erb title="Toast with long text"
+  <div class="Toast">
     <span class="Toast-icon">
-      <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
+      <%= octicon "info" %>
     </span>
-    <span class="Toast-content">Submitting issue to <strong>github/github</strong></span>
+    <span class="Toast-content">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. <strong>Aenean commodo ligula eget dolor.</strong> Aenean massa. Cum sociis <em>natoque</em> penatibus et ma</span>
   </div>
-  <div class="Toast Toast--success">
-    <span class="Toast-icon">
-      <svg class="octicon octicon-check" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
-    </span>
-    <span class="Toast-content">Submitting issue to <strong>github/github</strong></span>
-  </div>
-  <div class="Toast Toast--error">
-    <span class="Toast-icon">
-      <svg class="octicon octicon-stop" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 1H4L0 5v6l4 4h6l4-4V5l-4-4zm3 9.5L9.5 14h-5L1 10.5v-5L4.5 2h5L13 5.5v5zM6 4h2v5H6V4zm0 6h2v2H6v-2z"></path></svg>
-    </span>
-    <span class="Toast-content">Submitting issue to <strong>github/github</strong></span>
-  </div>
+```
+
+## Variations
+
+Use the success, warning, and error modifiers to communicate different states.
+
+Always use the `check` octicon for success states.
+
+``` erb title="Success toast"
+<div class="Toast Toast--success">
+  <span class="Toast-icon">
+    <%= octicon "check" %>
+  </span>
+  <span class="Toast-content">Success message goes here.</span>
+</div>
+```
+
+Always use the `alert` octicon for warning states.
+
+``` erb title="Warning toast"
+<div class="Toast Toast--warning">
+  <span class="Toast-icon">
+    <%= octicon "alert" %>
+  </span>
+  <span class="Toast-content">Warning message goes here.</span>
+</div>
+```
+
+Always use the `stop` octicon for error states.
+
+```erb title="Error toast"
+<div class="Toast Toast--error">
+  <span class="Toast-icon">
+    <%= octicon "stop" %>
+  </span>
+  <span class="Toast-content">Error message goes here</span>
 </div>
 ```
 
 ## Toast with dismiss
 
-```html title="Toast with dismiss"
-<div class="p-3">
-  <div class="Toast Toast--error">
-    <span class="Toast-icon">
-      <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
-    </span>
-    <span class="Toast-content">Submitting issue to <strong>github/github.</strong></span>
-    <button class="Toast-dismissButton"><svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
-  </div>
+Use `.Toast-dismissButton` to allow a user to explicitly dismiss a Toast.
+
+```erb title="Toast with dismiss"
+<div class="Toast">
+  <span class="Toast-icon">
+    <%= octicon "info" %>
+  </span>
+  <span class="Toast-content">This toast is dismissable.</span>
+  <button class="Toast-dismissButton">
+    <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
+  </button>
 </div>
 ```
-
 
 ## Toast with link
 
-```html title="Toast with link"
+Include a link to allow users to take actions within a Toast.
+
+```erb title="Toast with link"
 <div class="p-3">
-  <div class="Toast Toast--error">
+  <div class="Toast">
     <span class="Toast-icon">
-      <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
+      <%= octicon "info" %>
     </span>
-    <span class="Toast-content">Submitting issue to <strong>github/github. </strong><a href="#">Try again.</a></span>
+    <span class="Toast-content">Toast message goes here </strong><a href="#">Action.</a></span>
   </div>
 </div>
 ```
 
-## Toast with link and dismiss
+## Toast animation
 
-```html title="Toast with action and dismiss"
-<div class="p-3">
-  <div class="Toast Toast--error">
-    <span class="Toast-icon">
-      <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
-    </span>
-    <span class="Toast-content">Submitting issue to <strong>github/github. </strong><a href="#">Try again.</a></span>
-    <button class="Toast-dismissButton"><svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
-  </div>
-</div>
-```
+The toast will animate in and out from the bottom left of the viewport.
 
-## Toast animating
-
-```html title="Toast animating"
-<div class="p-3">
-  <div class="Toast Toast--error Toast--animateIn">
-    <span class="Toast-icon">
-      <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
-    </span>
-    <span class="Toast-content">Submitting issue to <strong>github/github</strong></span>
-  </div>
-</div>
-```
-
-## Toast with long text
-
-```html title="Toast with long text"
-<div class="p-3">
-  <div class="Toast Toast--error">
-    <span class="Toast-icon">
-      <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
-    </span>
-    <span class="Toast-content">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</a></span>
-  </div>
-</div>
-```
-
-## Toast with long text and a dismiss
-
-```html title="Toast with long text"
-<div class="p-3">
-  <div class="Toast Toast--error">
-    <span class="Toast-icon">
-      <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
-    </span>
-    <span class="Toast-content">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</a></span>
-    <button class="Toast-dismissButton"><svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg></button>
-  </div>
+```erb title="Toast animating"
+<div class="Toast Toast--animateIn">
+  <span class="Toast-icon">
+    <%= octicon "info" %>
+  </span>
+  <span class="Toast-content">Toast message goes here.</span>
 </div>
 ```

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -136,3 +136,21 @@ The `Toast--animateIn` and `Toast--animateOut` modifier classes can be used to a
   </div>
 </div>
 ```
+
+## Toast position
+
+Use the `position-fixed bottom-0` utility classes on a wrapper element to position Toasts at the **bottom left** of the viewport.
+
+```html title="Toast animating"
+<div class="border bg-gray-light" style="height:150px">
+  <div class="position-fixed bottom-0">
+    <div class="Toast">
+      <span class="Toast-icon">
+        <!-- <%= octicon "info" %> -->
+        <svg class="octicon octicon-info" style="fill:currentColor" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
+      </span>
+      <span class="Toast-content">Toast message goes here.</span>
+    </div>
+  </div>
+</div>
+```

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -82,7 +82,7 @@ Use `.Toast-dismissButton` to allow a user to explicitly dismiss a Toast.
   </span>
   <span class="Toast-content">This toast is dismissable.</span>
   <button class="Toast-dismissButton">
-    <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
+    <svg class="octicon octicon-x" style="fill:currentcolor" viewBox="0 0 12 16" version="1.1" width="12" height="16" role="img"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
   </button>
 </div>
 ```

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -16,25 +16,25 @@ To create a default toast, use `.Toast`
 ```html title="Block style"
 <div class="p-3">
   <div class="Toast Toast-block-default">
-    <span class="Toast-octicon">
+    <span class="Toast-icon">
       <svg class="octicon octicon-info" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
     </span>
     <span class="Toast-content">Submitting issue to <strong>github/github</strong></span>
   </div>
   <div class="Toast Toast-block-warning">
-    <span class="Toast-octicon">
+    <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
     <span class="Toast-content">Submitting issue to <strong>github/github</strong></span>
   </div>
   <div class="Toast Toast-block-success">
-    <span class="Toast-octicon">
+    <span class="Toast-icon">
       <svg class="octicon octicon-check" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"></path></svg>
     </span>
     <span class="Toast-content">Submitting issue to <strong>github/github</strong></span>
   </div>
   <div class="Toast Toast-block-error">
-    <span class="Toast-octicon">
+    <span class="Toast-icon">
       <svg class="octicon octicon-stop" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 1H4L0 5v6l4 4h6l4-4V5l-4-4zm3 9.5L9.5 14h-5L1 10.5v-5L4.5 2h5L13 5.5v5zM6 4h2v5H6V4zm0 6h2v2H6v-2z"></path></svg>
     </span>
     <span class="Toast-content">Submitting issue to <strong>github/github</strong></span>
@@ -47,7 +47,7 @@ To create a default toast, use `.Toast`
 ```html title="Toast with dismiss"
 <div class="p-3">
   <div class="Toast Toast-block-error">
-    <span class="Toast-octicon">
+    <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
     <span class="Toast-content">Submitting issue to <strong>github/github.</strong></span>
@@ -62,7 +62,7 @@ To create a default toast, use `.Toast`
 ```html title="Toast with link"
 <div class="p-3">
   <div class="Toast Toast-block-error">
-    <span class="Toast-octicon">
+    <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
     <span class="Toast-content">Submitting issue to <strong>github/github. </strong><a href="#">Try again.</a></span>
@@ -75,7 +75,7 @@ To create a default toast, use `.Toast`
 ```html title="Toast with action and dismiss"
 <div class="p-3">
   <div class="Toast Toast-block-error">
-    <span class="Toast-octicon">
+    <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
     <span class="Toast-content">Submitting issue to <strong>github/github. </strong><a href="#">Try again.</a></span>
@@ -89,7 +89,7 @@ To create a default toast, use `.Toast`
 ```html title="Toast animating"
 <div class="p-3">
   <div class="Toast Toast-animated Toast-block-error">
-    <span class="Toast-octicon">
+    <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
     <span class="Toast-content">Submitting issue to <strong>github/github</strong></span>
@@ -102,7 +102,7 @@ To create a default toast, use `.Toast`
 ```html title="Toast with long text"
 <div class="p-3">
   <div class="Toast Toast-block-error">
-    <span class="Toast-octicon">
+    <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
     <span class="Toast-content">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</a></span>
@@ -115,7 +115,7 @@ To create a default toast, use `.Toast`
 ```html title="Toast with long text"
 <div class="p-3">
   <div class="Toast Toast-block-error">
-    <span class="Toast-octicon">
+    <span class="Toast-icon">
       <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"></path></svg>
     </span>
     <span class="Toast-content">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</a></span>

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -38,9 +38,14 @@
   border: 0;
   background-color: transparent;
 
+  &:focus,
   &:hover {
-    cursor: pointer;
     fill: $text-gray;
+    outline: none;
+  }
+
+  &:active {
+    fill: $gray-400;
   }
 }
 

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -1,10 +1,5 @@
 // Toast
 
-// just for the documentation, remove before shipping
-.Toast-wrapper {
-  padding: 30px;
-}
-
 .Toast {
   display: flex;
   background-color: white;

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -24,6 +24,7 @@
   flex-shrink: 0;
   color: white;
   fill: white;
+  background-color: $blue-500;
   border-top-left-radius: inherit;
   border-bottom-left-radius: inherit;
 }
@@ -65,31 +66,17 @@
   100% {bottom:-100px;}
 }
 
-.Toast-block-default {
+// Modifier
 
-  .Toast-icon {
-    background-color: $blue-500;
-  }
+.Toast--error .Toast-icon {
+  background-color: $red-500;
 }
 
-.Toast-block-error {
-
-  .Toast-icon {
-    background-color: $red-500;
-  }
+.Toast--warning .Toast-icon {
+  background-color: $yellow-600;
+  fill: $gray-900;
 }
 
-.Toast-block-warning {
-
-  .Toast-icon {
-    background-color: $yellow-600;
-    fill: $gray-900;
-  }
-}
-
-.Toast-block-success {
-
-  .Toast-icon {
-    background-color: $green-500;
-  }
+.Toast--success .Toast-icon {
+  background-color: $green-500;
 }

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -4,7 +4,6 @@
   display: flex;
   background-color: white;
   color: $black;
-  padding: $spacer-3;
   border-radius: $border-radius;
   box-shadow: inset 0 0 0 1px $border-gray-dark, $box-shadow-medium;
   margin: $spacer-2;
@@ -18,11 +17,30 @@
 }
 
 .Toast-icon {
-  margin-right: $spacer-2;
   display: flex;
   align-items: center;
+  justify-content: center;
+  width: $spacer-3 * 3;
+  flex-shrink: 0;
+  color: white;
+  fill: white;
+  border-top-left-radius: inherit;
+  border-bottom-left-radius: inherit;
 }
 
+.Toast-content {
+  padding: $spacer-3;
+}
+
+.Toast-dismiss {
+  padding: $spacer-3;
+  align-self: center;
+
+  &:hover {
+    cursor: pointer;
+    fill: $text-gray;
+  }
+}
 
 // Temporarily splitting this out
 // to play with static styles.
@@ -43,36 +61,6 @@
   10%  {bottom:0px;}
   90%  {bottom:0px;}
   100% {bottom:-100px;}
-}
-
-.Toast-block-default,
-.Toast-block-error,
-.Toast-block-warning,
-.Toast-block-success {
-  padding: 0;
-
-  .Toast-icon {
-    color: white;
-    padding: $spacer-3;
-    margin-right: 0;
-    fill: white;
-    border-top-left-radius: inherit;
-    border-bottom-left-radius: inherit;
-  }
-
-  .Toast-content {
-    padding: $spacer-3;
-  }
-
-  .Toast-dismiss {
-    padding: $spacer-3;
-    align-self: center;
-
-    &:hover {
-      cursor: pointer;
-      fill: $text-gray;
-    }
-  }
 }
 
 .Toast-block-default {

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -56,7 +56,7 @@
 }
 
 .Toast--warning .Toast-icon {
-  fill: $gray-900;
+  color: $gray-900;
   background-color: $yellow-600;
 }
 

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -32,9 +32,11 @@
   padding: $spacer-3;
 }
 
-.Toast-dismiss {
+.Toast-dismissButton {
   padding: $spacer-3;
-  align-self: center;
+  max-height: 54px; // keeps button aligned to the top
+  border: 0;
+  background-color: transparent;
 
   &:hover {
     cursor: pointer;

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -2,15 +2,15 @@
 
 .Toast {
   display: flex;
-  background-color: white;
+  margin: $spacer-2;
   color: $black;
+  background-color: $bg-white;
   border-radius: $border-radius;
   box-shadow: inset 0 0 0 1px $border-gray-dark, $box-shadow-medium;
-  margin: $spacer-2;
 
   @include breakpoint(sm) {
-    max-width: 450px;
     width: max-content;
+    max-width: 450px;
     margin: $spacer-3;
   }
 }
@@ -21,8 +21,8 @@
   justify-content: center;
   width: $spacer-3 * 3;
   flex-shrink: 0;
-  color: white;
-  fill: white;
+  color: $text-white;
+  fill: $text-white;
   background-color: $blue-500;
   border-top-left-radius: inherit;
   border-bottom-left-radius: inherit;
@@ -33,10 +33,10 @@
 }
 
 .Toast-dismissButton {
-  padding: $spacer-3;
   max-height: 54px; // keeps button aligned to the top
-  border: 0;
+  padding: $spacer-3;
   background-color: transparent;
+  border: 0;
 
   &:focus,
   &:hover {
@@ -56,8 +56,8 @@
 }
 
 .Toast--warning .Toast-icon {
-  background-color: $yellow-600;
   fill: $gray-900;
+  background-color: $yellow-600;
 }
 
 .Toast--success .Toast-icon {
@@ -83,8 +83,8 @@
 
 @keyframes Toast--animateOut {
   100% {
+    pointer-events: none;
     opacity: 0;
     transform: translateY(100%);
-    pointer-events: none;
   }
 }

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -7,7 +7,6 @@
   border-radius: $border-radius;
   box-shadow: inset 0 0 0 1px $border-gray-dark, $box-shadow-medium;
   margin: $spacer-2;
-  transition: 0.2s ease;
 
   @include breakpoint(sm) {
     max-width: 450px;
@@ -45,27 +44,6 @@
   }
 }
 
-// Temporarily splitting this out
-// to play with static styles.
-.Toast-animated {
-  position: fixed;
-  bottom: -100px;
-  left: 0;
-  animation-name: toast;
-  animation-duration: 6s;
-  animation-delay: 1s;
-  animation-iteration-count: 1;
-  animation-timing-function: cubic-bezier(0.645, 0.045, 0.355, 1);
-}
-
-// Pop up animation
-@keyframes toast {
-  0%   {bottom:-100px;}
-  10%  {bottom:0px;}
-  90%  {bottom:0px;}
-  100% {bottom:-100px;}
-}
-
 // Modifier
 
 .Toast--error .Toast-icon {
@@ -79,4 +57,29 @@
 
 .Toast--success .Toast-icon {
   background-color: $green-500;
+}
+
+// Animations
+
+.Toast--animateIn {
+  animation: Toast--animateIn 0.18s cubic-bezier(0.22, 0.61, 0.36, 1) backwards;
+}
+
+@keyframes Toast--animateIn {
+  0% {
+    opacity: 0;
+    transform: translateY(100%);
+  }
+}
+
+.Toast--animateOut {
+  animation: Toast--animateOut 0.18s cubic-bezier(0.55, 0.06, 0.68, 0.19) forwards;
+}
+
+@keyframes Toast--animateOut {
+  100% {
+    opacity: 0;
+    transform: translateY(100%);
+    pointer-events: none;
+  }
 }

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -22,7 +22,6 @@
   width: $spacer-3 * 3;
   flex-shrink: 0;
   color: $text-white;
-  fill: $text-white;
   background-color: $blue-500;
   border-top-left-radius: inherit;
   border-bottom-left-radius: inherit;
@@ -40,12 +39,12 @@
 
   &:focus,
   &:hover {
-    fill: $text-gray;
+    color: $text-gray;
     outline: none;
   }
 
   &:active {
-    fill: $gray-400;
+    color: $gray-400;
   }
 }
 

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -17,7 +17,7 @@
   }
 }
 
-.Toast-octicon {
+.Toast-icon {
   margin-right: $spacer-2;
   display: flex;
   align-items: center;
@@ -51,7 +51,7 @@
 .Toast-block-success {
   padding: 0;
 
-  .Toast-octicon {
+  .Toast-icon {
     color: white;
     padding: $spacer-3;
     margin-right: 0;
@@ -77,21 +77,21 @@
 
 .Toast-block-default {
 
-  .Toast-octicon {
+  .Toast-icon {
     background-color: $blue-500;
   }
 }
 
 .Toast-block-error {
 
-  .Toast-octicon {
+  .Toast-icon {
     background-color: $red-500;
   }
 }
 
 .Toast-block-warning {
 
-  .Toast-octicon {
+  .Toast-icon {
     background-color: $yellow-600;
     fill: $gray-900;
   }
@@ -99,7 +99,7 @@
 
 .Toast-block-success {
 
-  .Toast-octicon {
+  .Toast-icon {
     background-color: $green-500;
   }
 }


### PR DESCRIPTION
This is on top of https://github.com/primer/css/pull/831 and adds a few tweaks. The diff might be hard to follow, it's mostly:

- Renames `Toast-octicon` to `Toast-icon`. Not really necessary, but makes it a bit more generic.
- Uses a `<button>` to dismiss instead of a `<a>`. This will still need some JS to make it work.
- Removes the `Toast-block-default` modifier class so that by default, the icon is blue.
- Removes `block` from the modifier classes. Also uses `--` double dash -> `Toast--error`. I think this is part of our naming convention. Like `UnderlineNav--right`.
- Splits the animation into `Toast--animateIn` and `Toast--animateOut`. So they can be triggered by JS.
