### PR TITLE
BEM multi-word convention for Element or Modifier classes

### DIFF
--- a/pages/css/principles/index.md
+++ b/pages/css/principles/index.md
@@ -93,7 +93,7 @@ Example:
 
 ## BEM-style naming and structure
 
-Components and objects should follow the [Block Element Modifier](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/) (BEM) model in terms of structure. We've chosen to use a modified form of BEM syntax using [PascalCase](https://en.wikipedia.org/wiki/PascalCase) for the block name, hyphens and lowercase or elements, and double-hyphens and lowercase for modifiers. When a Block class requires two words use PascalCase, for example `ProgressBar`.
+Components and objects should follow the [Block Element Modifier](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/) (BEM) model in terms of structure. We've chosen to use a modified form of BEM syntax using [Uppercase](https://en.wikipedia.org/wiki/Uppercase) for the block name, hyphens and lowercase or elements, and double-hyphens and lowercase for modifiers. When a Block class requires two words use [PascalCase](https://en.wikipedia.org/wiki/PascalCase), for example `ProgressBar`. When an Element or Modifier class requires two words use [camelCase](https://en.wikipedia.org/wiki/camelCase), for example `[Component]-closeButton` or `[Component]--extraLarge`.
 
 * **Block**: A block includes all of the base styles you want shared across every variation of a component. Minimal thematic styling should be applied to blocks, particularly when variations of a component include visual variations. Apply additional styles with modifers rather than overriding base styles.
 * **Element**: An element is part of a component. Elements should work together with other elements and can have modifiers. Element styles should not override block styles - this often results in applying more styles directly to elements rather than having styles flow down from the parent level.
@@ -107,11 +107,12 @@ Components and objects should follow the [Block Element Modifier](http://csswiza
 .Box-header {...}
 .Box-body {...}
 .Box-footer {...}
+.Box-closeButton {...}
 
 // modifiers
 .Box--blue {...}
-.Box--red {...}
-.Box-header--large {...}
+.Box--large {...}
+.Box--extraLarge {...}
 ```
 
 ## Property order


### PR DESCRIPTION
This came up in https://github.com/primer/css/pull/834#discussion_r303647341.

### Current

> When a Block class requires two words use [PascalCase](https://en.wikipedia.org/wiki/PascalCase), for example `ProgressBar`.

But we don't have a convention when Element or Modifier classes require two (or more) words.

### Proposal

> When an Element or Modifier class requires two words use [camelCase](https://en.wikipedia.org/wiki/camelCase), for example `[Component]-closeButton` or `[Component]--extraLarge`.

### Alternatives

An alternative would be to use a `-` dash, like `[Component]-close-button` or `[Component]--extra-large`. But that might look like there are multiple nested elements. Or a modifier that has a unique child element. camelCase makes it more clear that the two words belong together.

/cc @primer/ds-core