### PR TITLE
Color utility table tweaks

### DIFF
--- a/docs/color-system.js
+++ b/docs/color-system.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import chroma from 'chroma-js'
 import styled from 'styled-components'
 import {Box, StyledOcticon, Text} from '@primer/components'
-import {Zap} from '@githubprimer/octicons-react'
 import {colors, getPaletteByName} from './color-variables'
 import Table from './Table'
 
@@ -105,12 +104,12 @@ PaletteCell.propTypes = {
 PaletteCell.Alias = ({aliases, type, ...rest}) =>
   aliases && aliases[type] ? (
     <PaletteCell.Smart type={type} {...rest}>
-      <StyledOcticon icon={Zap} mr={2} />
       <Var>.{aliases[type]}</Var>
     </PaletteCell.Smart>
   ) : (
     <td />
   )
+
 PaletteCell.Alias.propTypes = {
   aliases: PropTypes.object.isRequired,
   type: PropTypes.string.isRequired

--- a/docs/color-system.js
+++ b/docs/color-system.js
@@ -59,7 +59,7 @@ export function PaletteTableFragment(props) {
 }
 
 PaletteTable.defaultProps = {
-  columns: ['alias', 'className', 'variable', 'value'],
+  columns: ['alias', 'variable', 'value'],
   hasHeader: true
 }
 
@@ -127,6 +127,7 @@ PaletteCell.Smart = ({type, ...rest}) => {
       return <PaletteCell.Background {...rest} />
   }
 }
+
 PaletteCell.Smart.propTypes = {
   type: PropTypes.string.isRequired
 }
@@ -153,6 +154,7 @@ PaletteValue.PrefixedClass = ({prefix, slug}) => (
     .{prefix}-{slug}
   </Var>
 )
+
 PaletteValue.PrefixedClass.propTypes = {
   prefix: PropTypes.string.isRequired,
   slug: PropTypes.string.isRequired

--- a/docs/color-system.js
+++ b/docs/color-system.js
@@ -200,7 +200,7 @@ export const Var = styled(Text).attrs({
 `
 
 export const PaletteHeading = ({indicatorColor, children, ...rest}) => (
-  <Text as="th" fontWeight="bold" {...rest} style={{borderBottom: `2px solid ${colors.black} !important`}}>
+  <Text as="th" fontWeight="bold" {...rest}>
     <Box pt={3}>{children}</Box>
   </Text>
 )

--- a/docs/color-system.js
+++ b/docs/color-system.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import chroma from 'chroma-js'
 import styled from 'styled-components'
-import {Box, StyledOcticon, Text} from '@primer/components'
+import {Box, Text} from '@primer/components'
 import {colors, getPaletteByName} from './color-variables'
 import Table from './Table'
 

--- a/pages/css/support/color-system.md
+++ b/pages/css/support/color-system.md
@@ -42,7 +42,7 @@ import {PaletteTable, PaletteCell, overlayColor} from '../../../docs/color-syste
         <StyledOcticon icon={LinkIcon} color="inherit !important" height={20} />
       </Flex>
       <PaletteTable
-        columns={['variable', 'value' /*, 'className' */]}
+        columns={['variable', 'value']}
         values={[{variable: name, value, slug: name}].concat(values)}
         hasHeader={false}
         cellPadding="8px 16px" />

--- a/pages/css/utilities/borders.md
+++ b/pages/css/utilities/borders.md
@@ -231,4 +231,4 @@ You can adjust border widths on all sides or each side individually with respons
     'variable',
     'value'
   ]}
-  borderSpacing="0 4px" />
+  style={{borderSpacing: '0 4px'}} />

--- a/pages/css/utilities/colors.md
+++ b/pages/css/utilities/colors.md
@@ -29,7 +29,7 @@ Background colors are most commonly used for filling large blocks of content or 
 
 <PaletteTable>
   {palettes.map(({name, title, value}) => (
-    <PaletteTableFragment name={name} type="bg" key={name}>
+    <PaletteTableFragment name={name} type="bg" sparse key={name}>
       <tr>
         <PaletteHeading indicatorColor={value} colSpan="4">
           {title}
@@ -133,7 +133,7 @@ You can set the color inheritance on an element by using the `text-inherit` clas
 
 <PaletteTable columns={textColumns}>
   {palettes.map(({name, title, value}) => (
-    <PaletteTableFragment name={name} type="text" prefix="color" columns={textColumns}>
+    <PaletteTableFragment name={name} type="text" sparse prefix="color" columns={textColumns}>
       <tr>
         <PaletteHeading indicatorColor={value} colSpan="4">
           {title}

--- a/pages/css/utilities/colors.md
+++ b/pages/css/utilities/colors.md
@@ -11,7 +11,7 @@ import {palettes, allColors} from '../../../docs/color-variables'
 import {PaletteTable, PaletteTableFragment, PaletteHeading, PaletteCell, PaletteValue} from '../../../docs/color-system'
 const textColumns = [
   {title: 'Alias', Cell: props => <PaletteCell.Alias {...props} style={{borderBottom: `1px solid ${props.value} !important`}} />},
-  {title: 'Class', Cell: props => <PaletteCell.Text {...props} style={{borderBottom: props.aliases.text ? `1px solid ${props.value} !important` : null}} />, Value: PaletteValue.PrefixedClass},
+  // {title: 'Class', Cell: props => <PaletteCell.Text {...props} style={{borderBottom: props.aliases.text ? `1px solid ${props.value} !important` : null}} />, Value: PaletteValue.PrefixedClass},
   'variable',
   {title: 'Value', Cell: PaletteCell.Background,  Value: PaletteValue.Value},
 ]

--- a/pages/css/utilities/colors.md
+++ b/pages/css/utilities/colors.md
@@ -18,7 +18,7 @@ const textColumns = [
 
 Use color utilities to apply color to the background of elements, text, and borders.
 
-# Table of contents
+## Table of Contents
 
 
 ## Background colors


### PR DESCRIPTION
This PR removes the "system" utility columns (`.bg-red-0`, `.color-gray-9`, etc.) from the color utility tables introduced in #811 and hides rows in the background and text utility tables that _don't_ have an alias like `.bg-gray-light` or `.text-green`. /cc @broccolini 