### PR TITLE
Add utility class to truncate beginning of long text

### DIFF
--- a/pages/css/components/truncate.md
+++ b/pages/css/components/truncate.md
@@ -7,10 +7,18 @@ bundle: truncate
 ---
 
 
-`.css-truncate` will shorten text with an ellipsis. The maximum width of the truncated text can be changed by overriding the max-width of `.css-truncate-target`. Unless the full text is so long that it affects performace, always add `title` to the truncated element so the full text can still be seen.
+`.css-truncate` will shorten text with an ellipsis. The maximum width of the truncated text can be changed by overriding the max-width of `.css-truncate-target`. Unless the full text is so long that it affects performance, always add `title` to the truncated element so the full text can still be seen.
 
 ```html title="Truncate"
 <span class="branch-ref css-truncate css-truncate-target" title="really-long-branch-name">
+  really-long-branch-name
+</span>
+```
+
+You can truncate the beginning of the text instead of the end by adding `.truncate-left`.
+
+```html title="Truncate Left"
+<span class="branch-ref css-truncate css-truncate-target truncate-left" title="really-long-branch-name">
   really-long-branch-name
 </span>
 ```

--- a/src/truncate/truncate.scss
+++ b/src/truncate/truncate.scss
@@ -24,4 +24,8 @@
   &.expandable:hover.css-truncate-target {
     max-width: 10000px !important;
   }
+
+  &.truncate-left {
+    direction: rtl;
+  }
 }

--- a/src/truncate/truncate.scss
+++ b/src/truncate/truncate.scss
@@ -25,7 +25,8 @@
     max-width: 10000px !important;
   }
 
-  &.truncate-left {
+  &.truncate-left .css-truncate-target,
+  &.truncate-left.css-truncate-target {
     direction: rtl;
   }
 }


### PR DESCRIPTION
Currently, we have the [`.css-truncate` class](https://primer.style/css/components/truncate), which shortens the end of long text with an ellipsis. Sometimes though, it makes sense to truncate the beginning of long text. For example, in the case of a file path, often the most important part is the file name, so we'd want to truncate the beginning of a long file path to make sure we display the name at the end of the path.

This change adds a `.truncate-left` class that shortens long text with an ellipsis by truncating the beginning of the text instead of the end.

#### Screenshot of `span.css-truncate-target.css-truncate`

![Screen Shot 2019-07-22 at 3 48 37 PM](https://user-images.githubusercontent.com/7942714/61670348-4094a280-ac98-11e9-8d36-e919a0981362.png)

#### Screenshot of `span.css-truncate-target.css-truncate.truncate-left`

![Screen Shot 2019-07-22 at 3 48 42 PM](https://user-images.githubusercontent.com/7942714/61670363-48ecdd80-ac98-11e9-9a39-bfe7afd0efc7.png)

/cc @primer/ds-core
