### PR TITLE
Include GitHub's stylesheet.css in Storybook head

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,2 +1,3 @@
 <link rel="stylesheet" href="https://unpkg.com/octicons@8.5.0/build/build.css">
+<link rel="stylesheet" href="https://github.com/site/assets/styleguide.css">
 <script src="https://github.com/site/assets/styleguide.js" async></script>


### PR DESCRIPTION
A couple of Primer CSS components need GitHub's stylesheet.css to render correctly (I'm looking at you, dropdown). This adds it to the Storybook config directory along with preexisting stylesheet.js.

This fixes this:
![Screen Shot 2019-07-29 at 13 09 03](https://user-images.githubusercontent.com/293280/62078686-0ed48c00-b202-11e9-8eb7-2107e165f851.png)

So it renders as this:
![Screen Shot 2019-07-29 at 13 08 36](https://user-images.githubusercontent.com/293280/62078669-00867000-b202-11e9-9fad-1d03e6d60280.png)

/cc @primer/ds-core
