### PR TITLE
Loading toast spinner

### DIFF
--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -136,79 +136,16 @@ The `Toast--animateIn` and `Toast--animateOut` modifier classes can be used to a
   </div>
 </div>
 ```
+
 ## Toast with loading animation
-Use the `Toast--spinner` modifier class on the Toast icon to communicate a loading state.
+Add the `Toast--spinner` modifier class on the `Toast-icon` `svg` to communicate a loading state.
 
 ```html title="Toast loading"
 <div class="p-1">
   <div class="Toast Toast--warning">
     <span class="Toast-icon">
       <!-- <%= octicon "info" %> -->
-      <svg class="octicon Toast--spinner" width="16" height="16" viewBox="0 0 16 16" fill="#24292E">
-          <rect width="1.5" height="4" rx="0.5" transform="matrix(-1 0 0 1 8.84561 0)" />
-          <rect width="1.5" height="4" rx="0.5" transform="matrix(-1 0 0 1 8.84561 11.9966)"  />
-          <rect width="1.5" height="4" rx="0.5" transform="matrix(4.37126e-08 -1 -1 -4.37102e-08 16.0722 8.83279)"  />
-          <rect width="1.5" height="4" rx="0.5" transform="matrix(4.37126e-08 -1 -1 -4.37102e-08 4.07523 8.83279)"  />
-          <rect width="1.5" height="4" rx="0.5" transform="matrix(-0.707116 0.707097 0.707116 0.707097 2.93183 1.78406)"  />
-          <rect width="1.5" height="4" rx="0.5" transform="matrix(-0.707116 0.707097 0.707116 0.707097 11.4147 10.2667)"  />
-          <rect width="1.5" height="4" rx="0.5" transform="matrix(-0.707116 -0.707097 -0.707116 0.707097 14.2881 2.91956)"  />
-          <rect width="1.5" height="4" rx="0.5" transform="matrix(-0.707116 -0.707097 -0.707116 0.707097 5.80521 11.4026)"  />
-      </svg>
-    </span>
-    <span class="Toast-content">Toast message goes here.</span>
-  </div>
-</div>
-```
-
-## Toast with loading animation V2
-Use the `Toast--spinner` modifier class on the Toast icon to communicate a loading state.
-
-```html title="Toast loading"
-<div class="p-1">
-  <div class="Toast Toast--warning">
-    <span class="Toast-icon">
-      <!-- <%= octicon "info" %> -->
-      <svg style="transform: scale(.5);" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
-  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(0 16 16)">
-    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0"/>
-  </path>
-  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(45 16 16)">
-    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.125s"/>
-  </path>
-  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(90 16 16)">
-    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.25s"/>
-  </path>
-  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(135 16 16)">
-    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.375s"/>
-  </path>
-  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(180 16 16)">
-    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.5s"/>
-  </path>
-  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(225 16 16)">
-    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.625s"/>
-  </path>
-  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(270 16 16)">
-    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.75s"/>
-  </path>
-  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(315 16 16)">
-    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.875s"/>
-  </path>
-</svg>
-    </span>
-    <span class="Toast-content">Toast message goes here.</span>
-  </div>
-</div>
-```
-
-## Toast with loading animation V3
-Use the `Toast--spinner` modifier class on the Toast icon to communicate a loading state.
-
-```html title="Toast loading"
-<div class="p-1">
-  <div class="Toast Toast--warning">
-    <span class="Toast-icon">
-      <!-- <%= octicon "info" %> -->
-      <svg class="Toast--spinner3" viewBox="0 0 32 32" width="18" height="18" fill="#24292E">
+      <svg class="Toast--spinner" viewBox="0 0 32 32" width="18" height="18" fill="#24292E">
         <path opacity=".2" d="M16 0 A16 16 0 0 0 16 32 A16 16 0 0 0 16 0 M16 4 A12 12 0 0 1 16 28 A12 12 0 0 1 16 4"/>
         <path d="M16 0 A16 16 0 0 1 32 16 L28 16 A12 12 0 0 0 16 4z"></path>
       </svg>
@@ -217,7 +154,6 @@ Use the `Toast--spinner` modifier class on the Toast icon to communicate a loadi
   </div>
 </div>
 ```
-
 
 ## Toast position
 

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -145,7 +145,7 @@ Add the `Toast--spinner` modifier class on the `Toast-icon` `svg` to communicate
   <div class="Toast Toast--loading">
     <span class="Toast-icon">
       <svg class="Toast--spinner" viewBox="0 0 32 32" width="18" height="18">
-        <path fill="#6a737d" d="M16 0 A16 16 0 0 0 16 32 A16 16 0 0 0 16 0 M16 4 A12 12 0 0 1 16 28 A12 12 0 0 1 16 4"/>
+        <path fill="#959da5" d="M16 0 A16 16 0 0 0 16 32 A16 16 0 0 0 16 0 M16 4 A12 12 0 0 1 16 28 A12 12 0 0 1 16 4"/>
         <path fill="#ffffff" d="M16 0 A16 16 0 0 1 32 16 L28 16 A12 12 0 0 0 16 4z"></path>
       </svg>
     </span>

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -144,9 +144,9 @@ Add the `Toast--spinner` modifier class on the `Toast-icon` `svg` to communicate
 <div class="p-1">
   <div class="Toast Toast--loading">
     <span class="Toast-icon">
-      <svg class="Toast--spinner" viewBox="0 0 32 32" width="18" height="18" fill="#24292E">
-        <path opacity=".2" d="M16 0 A16 16 0 0 0 16 32 A16 16 0 0 0 16 0 M16 4 A12 12 0 0 1 16 28 A12 12 0 0 1 16 4"/>
-        <path d="M16 0 A16 16 0 0 1 32 16 L28 16 A12 12 0 0 0 16 4z"></path>
+      <svg class="Toast--spinner" viewBox="0 0 32 32" width="18" height="18">
+        <path fill="#6a737d" d="M16 0 A16 16 0 0 0 16 32 A16 16 0 0 0 16 0 M16 4 A12 12 0 0 1 16 28 A12 12 0 0 1 16 4"/>
+        <path fill="#ffffff" d="M16 0 A16 16 0 0 1 32 16 L28 16 A12 12 0 0 0 16 4z"></path>
       </svg>
     </span>
     <span class="Toast-content">Toast message goes here.</span>

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -137,7 +137,7 @@ The `Toast--animateIn` and `Toast--animateOut` modifier classes can be used to a
 </div>
 ```
 ## Toast with loading animation
-The `Toast--spinner` modifier class on the Toast icon can be used to display a loading state
+Use the `Toast--spinner` modifier class on the Toast icon to communicate a loading state.
 
 ```html title="Toast loading"
 <div class="p-1">
@@ -153,6 +153,64 @@ The `Toast--spinner` modifier class on the Toast icon can be used to display a l
           <rect width="1.5" height="4" rx="0.5" transform="matrix(-0.707116 0.707097 0.707116 0.707097 11.4147 10.2667)"  />
           <rect width="1.5" height="4" rx="0.5" transform="matrix(-0.707116 -0.707097 -0.707116 0.707097 14.2881 2.91956)"  />
           <rect width="1.5" height="4" rx="0.5" transform="matrix(-0.707116 -0.707097 -0.707116 0.707097 5.80521 11.4026)"  />
+      </svg>
+    </span>
+    <span class="Toast-content">Toast message goes here.</span>
+  </div>
+</div>
+```
+
+## Toast with loading animation V2
+Use the `Toast--spinner` modifier class on the Toast icon to communicate a loading state.
+
+```html title="Toast loading"
+<div class="p-1">
+  <div class="Toast Toast--warning">
+    <span class="Toast-icon">
+      <!-- <%= octicon "info" %> -->
+      <svg style="transform: scale(.5);" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(0 16 16)">
+    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0"/>
+  </path>
+  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(45 16 16)">
+    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.125s"/>
+  </path>
+  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(90 16 16)">
+    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.25s"/>
+  </path>
+  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(135 16 16)">
+    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.375s"/>
+  </path>
+  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(180 16 16)">
+    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.5s"/>
+  </path>
+  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(225 16 16)">
+    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.625s"/>
+  </path>
+  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(270 16 16)">
+    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.75s"/>
+  </path>
+  <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(315 16 16)">
+    <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0.875s"/>
+  </path>
+</svg>
+    </span>
+    <span class="Toast-content">Toast message goes here.</span>
+  </div>
+</div>
+```
+
+## Toast with loading animation V3
+Use the `Toast--spinner` modifier class on the Toast icon to communicate a loading state.
+
+```html title="Toast loading"
+<div class="p-1">
+  <div class="Toast Toast--warning">
+    <span class="Toast-icon">
+      <!-- <%= octicon "info" %> -->
+      <svg class="Toast--spinner3" viewBox="0 0 32 32" width="18" height="18" fill="#24292E">
+        <path opacity=".2" d="M16 0 A16 16 0 0 0 16 32 A16 16 0 0 0 16 0 M16 4 A12 12 0 0 1 16 28 A12 12 0 0 1 16 4"/>
+        <path d="M16 0 A16 16 0 0 1 32 16 L28 16 A12 12 0 0 0 16 4z"></path>
       </svg>
     </span>
     <span class="Toast-content">Toast message goes here.</span>

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -142,9 +142,8 @@ Add the `Toast--spinner` modifier class on the `Toast-icon` `svg` to communicate
 
 ```html title="Toast loading"
 <div class="p-1">
-  <div class="Toast Toast--warning">
+  <div class="Toast Toast--loading">
     <span class="Toast-icon">
-      <!-- <%= octicon "info" %> -->
       <svg class="Toast--spinner" viewBox="0 0 32 32" width="18" height="18" fill="#24292E">
         <path opacity=".2" d="M16 0 A16 16 0 0 0 16 32 A16 16 0 0 0 16 0 M16 4 A12 12 0 0 1 16 28 A12 12 0 0 1 16 4"/>
         <path d="M16 0 A16 16 0 0 1 32 16 L28 16 A12 12 0 0 0 16 4z"></path>

--- a/pages/css/components/toasts.md
+++ b/pages/css/components/toasts.md
@@ -121,7 +121,7 @@ Include a link to allow users to take actions within a Toast.
 </div>
 ```
 
-## Toast animation
+## Toast animation in
 
 The `Toast--animateIn` and `Toast--animateOut` modifier classes can be used to animate the toast in and out from the bottom.
 
@@ -136,6 +136,30 @@ The `Toast--animateIn` and `Toast--animateOut` modifier classes can be used to a
   </div>
 </div>
 ```
+## Toast with loading animation
+The `Toast--spinner` modifier class on the Toast icon can be used to display a loading state
+
+```html title="Toast loading"
+<div class="p-1">
+  <div class="Toast Toast--warning">
+    <span class="Toast-icon">
+      <!-- <%= octicon "info" %> -->
+      <svg class="octicon Toast--spinner" width="16" height="16" viewBox="0 0 16 16" fill="#24292E">
+          <rect width="1.5" height="4" rx="0.5" transform="matrix(-1 0 0 1 8.84561 0)" />
+          <rect width="1.5" height="4" rx="0.5" transform="matrix(-1 0 0 1 8.84561 11.9966)"  />
+          <rect width="1.5" height="4" rx="0.5" transform="matrix(4.37126e-08 -1 -1 -4.37102e-08 16.0722 8.83279)"  />
+          <rect width="1.5" height="4" rx="0.5" transform="matrix(4.37126e-08 -1 -1 -4.37102e-08 4.07523 8.83279)"  />
+          <rect width="1.5" height="4" rx="0.5" transform="matrix(-0.707116 0.707097 0.707116 0.707097 2.93183 1.78406)"  />
+          <rect width="1.5" height="4" rx="0.5" transform="matrix(-0.707116 0.707097 0.707116 0.707097 11.4147 10.2667)"  />
+          <rect width="1.5" height="4" rx="0.5" transform="matrix(-0.707116 -0.707097 -0.707116 0.707097 14.2881 2.91956)"  />
+          <rect width="1.5" height="4" rx="0.5" transform="matrix(-0.707116 -0.707097 -0.707116 0.707097 5.80521 11.4026)"  />
+      </svg>
+    </span>
+    <span class="Toast-content">Toast message goes here.</span>
+  </div>
+</div>
+```
+
 
 ## Toast position
 

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -96,3 +96,13 @@
   from { transform:rotate(0deg); }
   to { transform:rotate(360deg); }
 }
+
+.Toast--spinner3 {
+  animation: Toast--spinner3 1000ms linear infinite; 
+}
+
+@keyframes Toast--spinner3 {
+  from { transform:rotate(0deg); }
+  to { transform:rotate(360deg); }
+}
+

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -54,15 +54,17 @@
   background-color: $red-500;
 }
 
-.Toast--warning, .Toast--loading {
-  .Toast-icon {
+.Toast--warning .Toast-icon {
     color: $gray-900;
     background-color: $yellow-600;
-  }
 }
 
 .Toast--success .Toast-icon {
   background-color: $green-500;
+}
+
+.Toast--loading .Toast-icon {
+  background-color: $gray-700;
 }
 
 // Animations
@@ -98,6 +100,3 @@
   from { transform:rotate(0deg); }
   to { transform:rotate(360deg); }
 }
-
-
-

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -87,3 +87,12 @@
     transform: translateY(100%);
   }
 }
+
+.Toast--spinner {
+  animation: Toast--spinner 3000ms linear infinite;
+}
+
+@keyframes Toast--spinner {
+  from { transform:rotate(0deg); }
+  to { transform:rotate(360deg); }
+}

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -89,7 +89,7 @@
 }
 
 .Toast--spinner {
-  animation: Toast--spinner 3000ms linear infinite;
+  animation: Toast--spinner 1000ms linear infinite; 
 }
 
 @keyframes Toast--spinner {
@@ -97,12 +97,5 @@
   to { transform:rotate(360deg); }
 }
 
-.Toast--spinner3 {
-  animation: Toast--spinner3 1000ms linear infinite; 
-}
 
-@keyframes Toast--spinner3 {
-  from { transform:rotate(0deg); }
-  to { transform:rotate(360deg); }
-}
 

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -55,8 +55,8 @@
 }
 
 .Toast--warning .Toast-icon {
-    color: $gray-900;
-    background-color: $yellow-600;
+  color: $gray-900;
+  background-color: $yellow-600;
 }
 
 .Toast--success .Toast-icon {
@@ -93,7 +93,7 @@
 }
 
 .Toast--spinner {
-  animation: Toast--spinner 1000ms linear infinite; 
+  animation: Toast--spinner 1000ms linear infinite;
 }
 
 @keyframes Toast--spinner {

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -54,9 +54,11 @@
   background-color: $red-500;
 }
 
-.Toast--warning .Toast-icon {
-  color: $gray-900;
-  background-color: $yellow-600;
+.Toast--warning, .Toast--loading {
+  .Toast-icon {
+    color: $gray-900;
+    background-color: $yellow-600;
+  }
 }
 
 .Toast--success .Toast-icon {

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -97,6 +97,6 @@
 }
 
 @keyframes Toast--spinner {
-  from { transform:rotate(0deg); }
-  to { transform:rotate(360deg); }
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -64,7 +64,7 @@
 }
 
 .Toast--loading .Toast-icon {
-  background-color: $gray-700;
+  background-color: $gray-600;
 }
 
 // Animations


### PR DESCRIPTION
#### Earlier options:
![screencast 2019-07-30 16-00-43](https://user-images.githubusercontent.com/586552/62161200-9ba34680-b2e3-11e9-82b0-af6a712ea82e.gif)
![screencast 2019-07-30 16-00-18](https://user-images.githubusercontent.com/586552/62161201-9ba34680-b2e3-11e9-9c27-84987e0a0afa.gif)
![screencast 2019-07-30 16-01-14](https://user-images.githubusercontent.com/586552/62161199-9ba34680-b2e3-11e9-9c4d-f3c34680f1a0.gif)

**Thoughts:**
> Yellow feels like the right color here, but curious if others think it's a bad idea to keep the same style as the warning toast. I can see it working for pending and/or warning states.
- landed on gray here as to not confuse this with a warning!
> Leaning on the third option after chatting with @ashygee but open to discuss!
- decided to stick with the circle style loader

#### Updated iteration:
<img width="293" alt="Screenshot 2019-08-01 13 22 07" src="https://user-images.githubusercontent.com/586552/62313693-5f94f080-b45f-11e9-9c5d-d1d317039f27.png">
