### PR TITLE
Add dark support for input field and dropdown

### DIFF
--- a/pages/css/components/dropdown.md
+++ b/pages/css/components/dropdown.md
@@ -186,3 +186,29 @@ Align the direction of dropdown menus and their arrows with modifier classes.
   </div>
 </details>
 ```
+
+### Dark
+
+```html
+<div class="bg-gray-dark p-4 mt-n4 ml-n4 mr-n4" style="min-height: 400px;">
+  <details class="dropdown details-reset details-overlay d-inline-block">
+    <summary class="btn" aria-haspopup="true">
+      Dropdown
+      <div class="dropdown-caret"></div>
+    </summary>
+
+    <div class="dropdown-menu dropdown-menu-se dropdown-menu-dark">
+      <div class="dropdown-header">
+        Dropdown header
+      </div>
+      <ul>
+        <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+        <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+        <li class="dropdown-divider" role="separator"></li>
+        <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+        <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      </ul>
+    </div>
+  </details>
+</div>
+```

--- a/pages/css/components/forms.md
+++ b/pages/css/components/forms.md
@@ -114,6 +114,15 @@ Make inputs smaller, larger, or full-width with an additional class.
 </form>
 ```
 
+##### Dark
+
+```html
+<div class="bg-gray-dark p-4 mt-n4 ml-n4 mr-n4">
+  <input class="form-control input-dark" type="text" placeholder="Dark input" aria-label="Dark input">
+  <input class="form-control input-dark input-sm" type="text" placeholder="Dark input small" aria-label="Dark input">
+</div>
+``` 
+
 ##### Hide webkit's contact info autofill icon
 Webkit sometimes gets confused and tries to add an icon/dropdown to autofill contact information on fields that may not be appropriate (such as input for number of users). Use this class to override the display of this icon.
 

--- a/pages/css/components/forms.md
+++ b/pages/css/components/forms.md
@@ -118,7 +118,7 @@ Make inputs smaller, larger, or full-width with an additional class.
 
 ```html
 <div class="bg-gray-dark p-4 mt-n4 ml-n4 mr-n4">
-  <input class="form-control input-dark" type="text" placeholder="Dark input" aria-label="Dark input">
+  <input class="form-control input-dark" type="text" placeholder="Dark input" aria-label="Dark input"> 
   <input class="form-control input-dark input-sm" type="text" placeholder="Dark input small" aria-label="Dark input">
 </div>
 ``` 

--- a/src/core/index.scss
+++ b/src/core/index.scss
@@ -18,6 +18,7 @@
 @import "../box/index.scss";
 @import "../breadcrumb/index.scss";
 @import "../buttons/index.scss";
+@import "../dropdowns/index.scss";
 @import "../table-object/index.scss";
 @import "../forms/index.scss";
 @import "../layout/index.scss";

--- a/src/dropdowns/README.md
+++ b/src/dropdowns/README.md
@@ -1,0 +1,19 @@
+# Primer dropdown
+
+> Dropdowns are lightweight, JavaScript-powered context menus for housing navigation and actions. They're great for instances where you don't need the full power (and code) of the select menu.
+
+This repository is a module of the full [primer][primer] repository.
+
+## Documentation
+
+Find further documentation at [primer.style/css/components/dropdown](https://primer.style/css/components/dropdown).
+
+## License
+
+[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+
+[primer]: https://github.com/primer/css
+[docs]: https://primer.style/css
+[npm]: https://www.npmjs.com/
+[install-npm]: https://docs.npmjs.com/getting-started/installing-node
+[sass]: http://sass-lang.com/

--- a/src/dropdowns/dropdown.scss
+++ b/src/dropdowns/dropdown.scss
@@ -1,3 +1,273 @@
+.dropdown {
+  position: relative;
+
+  &.active {
+    .dropdown-menu-content {
+      display: block;
+      pointer-events: all;
+    }
+  }
+}
+
+.dropdown-caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  vertical-align: middle;
+  content: "";
+  border-style: solid;
+  border-width: $spacer-1 $spacer-1 0;
+  border-right-color: transparent;
+  border-bottom-color: transparent;
+  border-left-color: transparent;
+}
+
+// Requires a positioning class (e.g., `.dropdown-menu-w`) to determine which
+// way the menu should render from the element triggering it.
+.dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 100;
+  width: 160px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  margin-top: 2px;
+  list-style: none;
+  background-color: $bg-white;
+  background-clip: padding-box;
+  border: $border-width $border-style $black-fade-15;
+  border-radius: $spacer-1;
+  box-shadow: 0 3px 12px $black-fade-15;
+
+  &::before,
+  &::after {
+    position: absolute;
+    display: inline-block;
+    content: "";
+  }
+
+  &::before {
+    border: $spacer-2 solid transparent;
+    border-bottom-color: $black-fade-15;
+  }
+
+  &::after {
+    border: 7px solid transparent;
+    border-bottom-color: $white;
+  }
+
+  // stylelint-disable-next-line selector-max-type
+  > ul {
+    list-style: none;
+  }
+}
+
+.dropdown-menu-no-overflow {
+  width: auto;
+
+  .dropdown-item {
+    padding: $spacer-1 $spacer-3;
+    overflow: visible;
+    text-overflow: inherit;
+  }
+}
+
+// Dropdown items (can be links or buttons)
+.dropdown-item {
+  display: block;
+  padding: $spacer-1 10px $spacer-1 $spacer-3;
+  overflow: hidden;
+  color: $text-gray-dark;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &:focus,
+  &:hover,
+  &.zeroclipboard-is-hover {
+    color: $text-white;
+    text-decoration: none;
+    background-color: $bg-blue;
+    outline: none;
+
+    > .octicon {
+      color: inherit;
+      opacity: 1;
+    }
+  }
+
+  &.btn-link {
+    width: 100%;
+    text-align: left;
+  }
+}
+
+.dropdown-signout {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: 0;
+}
+
+.dropdown-divider {
+  display: block;
+  height: 0;
+  margin: $spacer-2 0;
+  border-top: $border;
+}
+
+.dropdown-header {
+  padding: $spacer-1 $spacer-3;
+  font-size: $h6-size;
+  color: $text-gray;
+}
+
+.dropdown-menu-content {
+  display: none;
+
+  // stylelint-disable-next-line primer/no-override
+  &.anim-scale-in {
+    position: relative;
+    z-index: 100;
+    pointer-events: none;
+  }
+}
+
+.dropdown-item[aria-checked="false"] .octicon-check {
+  display: none;
+}
+
+// Directional classes
+//
+// Move the menu and the caret attached to it. Requires at least one of these on
+// the `.dropdown-menu` element.
+
+.dropdown-menu-w {
+  top: 0;
+  right: 100%;
+  left: auto;
+  width: auto;
+  margin-top: 0;
+  margin-right: 10px;
+
+  &::before {
+    top: 10px;
+    right: -$spacer-3;
+    left: auto;
+    border-color: transparent;
+    border-left-color: $black-fade-15;
+  }
+
+  &::after {
+    top: 11px;
+    right: -14px;
+    left: auto;
+    border-color: transparent;
+    border-left-color: $white;
+  }
+}
+
+.dropdown-menu-e {
+  top: 0;
+  left: 100%;
+  width: auto;
+  margin-top: 0;
+  margin-left: 10px;
+
+  &::before {
+    top: 10px;
+    left: -$spacer-3;
+    border-color: transparent;
+    border-right-color: $black-fade-15;
+  }
+
+  &::after {
+    top: 11px;
+    left: -14px;
+    border-color: transparent;
+    border-right-color: $white;
+  }
+}
+
+.dropdown-menu-ne {
+  top: auto;
+  bottom: 100%;
+  left: 0;
+  margin-bottom: 3px;
+
+  &::before,
+  &::after {
+    top: auto;
+    right: auto;
+  }
+
+  &::before {
+    bottom: -$spacer-2;
+    left: 9px;
+    border-top: $spacer-2 solid $black-fade-15;
+    border-right: $spacer-2 solid transparent;
+    border-bottom: 0;
+    border-left: $spacer-2 solid transparent;
+  }
+
+  &::after {
+    bottom: -7px;
+    left: 10px;
+    border-top: 7px solid $white;
+    border-right: 7px solid transparent;
+    border-bottom: 0;
+    border-left: 7px solid transparent;
+  }
+}
+
+.dropdown-menu-s {
+  right: 50%;
+  left: auto;
+  transform: translateX(50%);
+
+  &::before {
+    top: -$spacer-3;
+    right: 50%;
+    transform: translateX(50%);
+  }
+
+  &::after {
+    top: -14px;
+    right: 50%;
+    transform: translateX(50%);
+  }
+}
+
+.dropdown-menu-sw {
+  right: 0;
+  left: auto;
+
+  &::before {
+    top: -$spacer-3;
+    right: 9px;
+    left: auto;
+  }
+
+  &::after {
+    top: -14px;
+    right: 10px;
+    left: auto;
+  }
+}
+
+.dropdown-menu-se {
+  &::before {
+    top: -$spacer-3;
+    left: 9px;
+  }
+
+  &::after {
+    top: -14px;
+    left: 10px;
+  }
+}
+
+// Dark dropdowns
 .dropdown-menu-dark {
   background: $gray-800;
   color: $white;

--- a/src/dropdowns/dropdown.scss
+++ b/src/dropdowns/dropdown.scss
@@ -30,15 +30,15 @@
   left: 0;
   z-index: 100;
   width: 160px;
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding-top: $spacer-1;
+  padding-bottom: $spacer-1;
   margin-top: 2px;
   list-style: none;
   background-color: $bg-white;
   background-clip: padding-box;
   border: $border-width $border-style $black-fade-15;
   border-radius: $spacer-1;
-  box-shadow: 0 3px 12px $black-fade-15;
+  box-shadow: $box-shadow-large;
 
   &::before,
   &::after {
@@ -76,7 +76,7 @@
 // Dropdown items (can be links or buttons)
 .dropdown-item {
   display: block;
-  padding: $spacer-1 10px $spacer-1 $spacer-3;
+  padding: $spacer-1 $spacer-2 $spacer-1 $spacer-3;
   overflow: hidden;
   color: $text-gray-dark;
   text-overflow: ellipsis;
@@ -148,7 +148,7 @@
   left: auto;
   width: auto;
   margin-top: 0;
-  margin-right: 10px;
+  margin-right: $spacer-2;
 
   &::before {
     top: 10px;
@@ -172,10 +172,10 @@
   left: 100%;
   width: auto;
   margin-top: 0;
-  margin-left: 10px;
+  margin-left: $spacer-2;
 
   &::before {
-    top: 10px;
+    top: $spacer-2;
     left: -$spacer-3;
     border-color: transparent;
     border-right-color: $black-fade-15;
@@ -272,7 +272,7 @@
   background: $gray-800;
   color: $white;
   border-color: $gray-700;
-  box-shadow: 0 3px 12px $black-fade-50;
+  box-shadow: $box-shadow-large;
 
   &::before {
     border-bottom-color: $gray-700;

--- a/src/dropdowns/dropdown.scss
+++ b/src/dropdowns/dropdown.scss
@@ -1,0 +1,55 @@
+.dropdown-menu-dark {
+  background: $gray-800;
+  color: $white;
+  border-color: $gray-700;
+  box-shadow: 0 3px 12px $black-fade-50;
+
+  &::before {
+    border-bottom-color: $gray-700;
+  }
+
+  &::after {
+    border-bottom-color: $gray-800;
+  }
+
+  .dropdown-header {
+    color: $gray-300;
+  }
+
+  .dropdown-divider {
+    border-top-color: $border-gray-darker;
+  }
+
+  .dropdown-item {
+    color: inherit;
+  }
+
+  // Directional classes
+
+  &.dropdown-menu-w {
+    &::before {
+      border-color: transparent transparent transparent $gray-700;
+    }
+    &::after {
+      border-color: transparent transparent transparent $gray-800;
+    }
+  }
+
+  &.dropdown-menu-e {
+    &::before {
+      border-color: transparent $gray-700 transparent transparent;
+    }
+    &::after {
+      border-color: transparent $gray-800 transparent transparent;
+    }
+  }
+
+  &.dropdown-menu-ne {
+    &::before {
+      border-color: $gray-700 transparent transparent transparent;
+    }
+    &::after {
+      border-color: $gray-800 transparent transparent transparent;
+    }
+  }
+}

--- a/src/dropdowns/index.scss
+++ b/src/dropdowns/index.scss
@@ -1,0 +1,2 @@
+@import "../support/index.scss";
+@import "./dropdown.scss";

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -51,6 +51,24 @@ label {
   &:focus { background-color: $bg-white; }
 }
 
+// Inputs to be used against dark backgrounds.
+.input-dark {
+  background-color: $white-fade-15;
+  color: $text-white;
+  border-color: transparent;
+
+  &::placeholder {
+    color: inherit;
+    opacity: 0.6; // inceases contrast ratio to 4.52
+  }
+  
+  &.focus,
+  &:focus {
+    border-color: $black-fade-30;
+    box-shadow: 0 0 0 0.2em rgba($blue-300, 0.4);
+  }
+}
+
 // Custom styling for HTML5 validation bubbles (WebKit only)
 ::placeholder {
   color: $text-gray-light;


### PR DESCRIPTION
While this work is not trying to reflect on how dark theme should be supported across all primer components, it adds lightweight support for input fields and dropdowns to behave better in dark areas.

`input-dark` and `dropdown-menu-dark` are two new classes that are added on top of the existing markup to request a dark variation.

<img width="199" alt="Screen Shot 2019-07-30 at 15 06 07" src="https://user-images.githubusercontent.com/293280/62168934-a528b080-b2db-11e9-8859-0315d16d466f.png">

<img width="352" alt="Screen Shot 2019-07-30 at 15 06 35" src="https://user-images.githubusercontent.com/293280/62168939-a78b0a80-b2db-11e9-99c0-fdddb852ea66.png">

In order to create new styles to the dropdown component, I had to move the existing classes from GitHub's `stylesheet.css` into Primer (https://github.com/primer/css/commit/14237e9c05ff49f214d0b6c06283cbadf3b15b7a), since it didn't have any styles inline. To avoid duplicated code, `dropdown.scss` should be removed from GH's stylesheet.

This fixes https://github.com/github/design-systems/issues/669