### PR TITLE
Include octicon css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1520,6 +1520,14 @@
         }
       }
     },
+    "@primer/octicons": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-9.1.1.tgz",
+      "integrity": "sha512-7EGM0+Kx39bIgaYr9bTCzFvBCxm+fqh/YJIoSns8zfCwss32ZJ2GDP3024UH709VQtM5cKFU4JcIYPHyGdSfIg==",
+      "requires": {
+        "object-assign": "^4.1.1"
+      }
+    },
     "@reach/router": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.2.1.tgz",
@@ -13921,8 +13929,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -121,5 +121,8 @@
     "unist-util-stringify-position": "^2.0.0",
     "unist-util-visit": "^1.4.0",
     "webpack": "4.20.2"
+  },
+  "dependencies": {
+    "@primer/octicons": "9.1.1"
   }
 }

--- a/src/core/index.scss
+++ b/src/core/index.scss
@@ -5,6 +5,9 @@
  * Released under MIT license. Copyright (c) 2019 GitHub Inc.
  */
 
+// Include .octicon base styles
+@import "@primer/octicons/index.scss";
+
 // Primer master file
 //
 // Imports all Primer files in their intended order for easy mass-inclusion.


### PR DESCRIPTION
As requested by @jonrohan in #845, we want to include the `.octicon` styles in the Primer CSS "core" bundle. I added an explicit import in the docs in #847, so if we merge this and still want to go that route, we can remove that JS `import`.

Update: I'm not sure how this will affect github/github, so I'm going to open a PR with a canary release and make sure things still work if I delete the duplicate `@import` in that repo's stylesheets.