### PR TITLE
Generate bundle READMEs from a template

### DIFF
--- a/script/generate-bundle-readmes
+++ b/script/generate-bundle-readmes
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const {dirname, join} = require('path')
+const globby = require('globby')
+const {exists, readFile, writeFile} = require('fs-extra')
+
+Promise.all([
+  readFile('src/README.template.md', 'utf8'),
+  globby('src/*/index.scss')
+]).then(async ([template, indexes]) => {
+  for (const indexPath of indexes) {
+    const dir = dirname(indexPath)
+    const parts = dir.split('/')
+    const bundle = parts.pop()
+    const readmePath = join(dir, 'README.md')
+    await writeFile(readmePath, getReadmeContents(bundle), 'utf8')
+  }
+
+  function getReadmeContents(bundle) {
+    return template.replace(/{bundle}/g, bundle)
+  }
+})

--- a/src/README.template.md
+++ b/src/README.template.md
@@ -1,0 +1,25 @@
+---
+bundle: "{bundle}"
+generated: true
+---
+
+# Primer CSS: `{bundle}` bundle
+
+## Usage
+
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
+
+```scss
+@import "@primer/css/{bundle}/index.scss";
+```
+
+## Build
+
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/{bundle}.css`.
+
+## License
+
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
+
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/alerts/README.md
+++ b/src/alerts/README.md
@@ -1,36 +1,25 @@
-# Primer Alerts
-> Flash messages, or alerts, inform users of successful or pending actions. Use them sparingly. Don’t show more than one at a time.
+---
+bundle: "alerts"
+generated: true
+---
 
-This repository is a module of the full [Primer CSS][primer] repository.
+# Primer CSS: `alerts` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-alerts/index.scss";
+@import "@primer/css/alerts/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/alerts](https://primer.style/css/components/alerts).
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/alerts.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/avatars/README.md
+++ b/src/avatars/README.md
@@ -1,37 +1,25 @@
-# Primer Avatars
+---
+bundle: "avatars"
+generated: true
+---
 
-> Avatars are images that users can set as their profile picture. On GitHub, they’re always going to be rounded squares. They can be custom photos, uploaded by users, or generated as Identicons as a placeholder.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `avatars` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-avatars/index.scss";
+@import "@primer/css/avatars/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/avatars](https://primer.style/css/components/avatars).
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/avatars.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/base/README.md
+++ b/src/base/README.md
@@ -1,36 +1,25 @@
-# Primer Base
-> GitHub's CSS to reset the browsers default styles. Built on top of normalize.css
+---
+bundle: "base"
+generated: true
+---
 
-This repository is a module of the full [primer][primer] repository. And is built off of [normalize.css](https://github.com/necolas/normalize.css/)
+# Primer CSS: `base` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-base/index.scss";
+@import "@primer/css/base/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-You can read more about base in the [docs][docs].
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/base.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/blankslate/README.md
+++ b/src/blankslate/README.md
@@ -1,37 +1,25 @@
-# Primer Blankslate
+---
+bundle: "blankslate"
+generated: true
+---
 
-> Blankslates are for when there is a lack of content within a page or section. Use them as placeholders to tell users why something isn’t there. Be sure to provide an action to add content as well.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `blankslate` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-blankslate/index.scss";
+@import "@primer/css/blankslate/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/blankslate](https://primer.style/css/components/blankslate).
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/blankslate.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/box/README.md
+++ b/src/box/README.md
@@ -1,37 +1,25 @@
-# Primer box
+---
+bundle: "box"
+generated: true
+---
 
-> Box is a module for creating rounded-corner boxes with a white background and gray borders. Box has optional element styles for headers, lists, and footers.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `box` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-box/index.scss";
+@import "@primer/css/box/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/box](https://primer.style/css/components/box).
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/box.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/branch-name/README.md
+++ b/src/branch-name/README.md
@@ -1,37 +1,25 @@
-# Primer / Branch Name
+---
+bundle: "branch-name"
+generated: true
+---
 
-> A nice, consistent way to display branch names.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `branch-name` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (SCSS) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-branch-name/index.scss";
+@import "@primer/css/branch-name/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **CSS** version of this module, an npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package:
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/branch-name](https://primer.style/css/components/branch-name).
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/branch-name.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/breadcrumb/README.md
+++ b/src/breadcrumb/README.md
@@ -1,21 +1,25 @@
-# Primer Breadcrumb Navigation
+---
+bundle: "breadcrumb"
+generated: true
+---
 
-> Breadcrumb navigation for GitHub's pages with parents / grandparents.
+# Primer CSS: `breadcrumb` bundle
 
-This repository is a module of the full [primer][primer] repository.
+## Usage
 
-## Documentation
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
-Find further documentation at [primer.style/css/components/breadcrumb](https://primer.style/css/components/breadcrumb).
+```scss
+@import "@primer/css/breadcrumb/index.scss";
+```
+
+## Build
+
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/breadcrumb.css`.
 
 ## License
 
-MIT &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[primer-support]: https://github.com/primer/css-support
-[support]: https://github.com/primer/css-support
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/buttons/README.md
+++ b/src/buttons/README.md
@@ -1,37 +1,25 @@
-# Primer Buttons
+---
+bundle: "buttons"
+generated: true
+---
 
-> Buttons are used for actions, like in forms, while textual hyperlinks are used for destinations, or moving from one page to another.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `buttons` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-buttons/index.scss";
+@import "@primer/css/buttons/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/buttons](https://primer.style/css/components/buttons).
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/buttons.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,37 +1,25 @@
-# Primer Core
+---
+bundle: "core"
+generated: true
+---
 
-> Primer core is one of 3 meta-packages that belong to the Primer framework. Primer core contains packages that are shared between GitHub product and marketing websites.
-
-This repository is a compilation of [several CSS packages](https://github.com/primer/css). You can break it down into smaller sections using npm.
+# Primer CSS: `core` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-core/index.scss";
+@import "@primer/css/core/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **CSS** version of this module, an npm script is included that will output a CSS version to `build/build.css` The built CSS file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-You can read more about primer in the [docs][docs].
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/core.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/forms/README.md
+++ b/src/forms/README.md
@@ -1,37 +1,25 @@
-# Primer Forms
+---
+bundle: "forms"
+generated: true
+---
 
-> Style individual form controls and utilize common layouts.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `forms` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-forms/index.scss";
+@import "@primer/css/forms/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/forms](https://primer.style/css/components/forms).
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/forms.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/labels/README.md
+++ b/src/labels/README.md
@@ -1,37 +1,25 @@
-# Primer Labels
+---
+bundle: "labels"
+generated: true
+---
 
-> Labels add metadata or indicate status of items and navigational elements.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `labels` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-labels/index.scss";
+@import "@primer/css/labels/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/labels](https://primer.style/css/components/labels).
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/labels.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/layout/README.md
+++ b/src/layout/README.md
@@ -1,37 +1,25 @@
-# Primer Layout
+---
+bundle: "layout"
+generated: true
+---
 
-> Primer’s layout includes basic page containers and a single-tiered, fraction-based grid system. That sounds more complicated than it really is though—it’s just containers, rows, and columns.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `layout` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-layout/index.scss";
+@import "@primer/css/layout/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/objects/layout](https://primer.style/css/objects/layout).
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/layout.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/markdown/README.md
+++ b/src/markdown/README.md
@@ -1,37 +1,25 @@
-# Primer Markdown
+---
+bundle: "markdown"
+generated: true
+---
 
-> Stylesheets for rendering GitHub Flavored Markdown and syntax highlighted code snippets.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `markdown` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-markdown/index.scss";
+@import "@primer/css/markdown/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/markdown](https://primer.style/css/components/markdown).
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/markdown.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/marketing/README.md
+++ b/src/marketing/README.md
@@ -1,37 +1,25 @@
-# Primer marketing
+---
+bundle: "marketing"
+generated: true
+---
 
-> Primer marketing is one of 3 meta-packages that belong to the Primer framework. Primer marketing contains packages that are used on GitHub marketing websites.
-
-This repository is a compilation of [several CSS packages](https://github.com/primer/css). You can break it down into smaller sections using npm.
+# Primer CSS: `marketing` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-marketing/index.scss";
+@import "@primer/css/marketing/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a CSS version to `build/build.css` The built CSS file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-You can read more about primer in the [docs][docs].
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/marketing.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/navigation/README.md
+++ b/src/navigation/README.md
@@ -1,37 +1,25 @@
-# Primer Navigation
+---
+bundle: "navigation"
+generated: true
+---
 
-> Primer comes with several navigation components. Some were designed with singular purposes, while others were design to be more flexible and appear quite frequently.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `navigation` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-navigation/index.scss";
+@import "@primer/css/navigation/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/navigation](https://primer.style/css/components/navigation).
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/navigation.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/pagination/README.md
+++ b/src/pagination/README.md
@@ -1,27 +1,25 @@
-# Primer Pagination
+---
+bundle: "pagination"
+generated: true
+---
 
-> Pagination component for applying button styles to a connected set of links that go to related pages
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `pagination` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (SCSS) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-pagination/index.scss";
+@import "@primer/css/pagination/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **CSS** version of this module, an npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package:
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/pagination.css`.
 
-```
-$ npm run build
-```
+## License
 
-## Documentation
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-Find further documentation at [primer.style/css/components/pagination](https://primer.style/css/components/pagination).
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/popover/README.md
+++ b/src/popover/README.md
@@ -1,38 +1,25 @@
-# Primer Popover
+---
+bundle: "popover"
+generated: true
+---
 
-> Popover for suggesting, guiding, and bringing attention to specific UI elements on a page.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `popover` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (SCSS) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-popover/index.scss";
+@import "@primer/css/popover/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **CSS** version of this module, an npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package:
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/popover](https://primer.style/css/components/popover).
-
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/popover.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/product/README.md
+++ b/src/product/README.md
@@ -1,37 +1,25 @@
-# Primer product
+---
+bundle: "product"
+generated: true
+---
 
-> Primer product is one of 3 meta-packages that belong to the Primer framework. Primer product contains packages that are used on GitHub product websites.
-
-This repository is a compilation of [several CSS packages](https://github.com/primer/css). You can break it down into smaller sections using npm.
+# Primer CSS: `product` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-product/index.scss";
+@import "@primer/css/product/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **CSS** version of this module, a npm script is included that will output a CSS version to `build/build.css` The built CSS file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-You can read more about primer in the [docs][docs].
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/product.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/progress/README.md
+++ b/src/progress/README.md
@@ -1,37 +1,25 @@
-# Primer / Progress
+---
+bundle: "progress"
+generated: true
+---
 
-> Use Progress components to visualize task completion
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `progress` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (SCSS) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-progress/index.scss";
+@import "@primer/css/progress/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **CSS** version of this module, an npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package:
-
-```
-$ npm run build
-```
-## Documentation
-
-Find further documentation at [primer.style/css/components/progress](https://primer.style/css/components/progress).
-
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/progress.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/select-menu/README.md
+++ b/src/select-menu/README.md
@@ -1,4 +1,25 @@
-# Select Menu
-- [Live documentation](https://primer.style/css/components/select-menu)
-- [Documentation source](../../pages/css/components/select-menu.md)
-- [Style source](./select-menu.scss)
+---
+bundle: "select-menu"
+generated: true
+---
+
+# Primer CSS: `select-menu` bundle
+
+## Usage
+
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
+
+```scss
+@import "@primer/css/select-menu/index.scss";
+```
+
+## Build
+
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/select-menu.css`.
+
+## License
+
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
+
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/subhead/README.md
+++ b/src/subhead/README.md
@@ -1,39 +1,25 @@
-# Primer / Subhead
+---
+bundle: "subhead"
+generated: true
+---
 
-> The Subhead is a simple header with a bottom border. It&#39;s designed to be used on settings and configuration pages.
-
-This repository is a module of the full [primer][primer] repository.
-
+# Primer CSS: `subhead` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (SCSS) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-subhead/index.scss";
+@import "@primer/css/subhead/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **CSS** version of this module, an npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package:
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/subhead](https://primer.style/css/components/subhead).
-
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/subhead.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/support/README.md
+++ b/src/support/README.md
@@ -1,31 +1,25 @@
-# Primer Support
+---
+bundle: "support"
+generated: true
+---
 
-> Support files are Sass variables, mixins, and functions that we import into different bases for use across components, objects, and utilities. Sharing these common properties across GitHub sites helps us to keep our styles more consistent.
->
-> Most of the time to include these you'll only need to add `@import "support/support";` to the top of your bundle. If you want only a specific partial you can import them separately.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `support` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-support/index.scss";
+@import "@primer/css/support/index.scss";
 ```
 
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
+## Build
 
-## Documentation
-
-Find further documentation at [primer.style/css/support](https://primer.style/css/support).
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/support.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css/support
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/table-object/README.md
+++ b/src/table-object/README.md
@@ -1,38 +1,25 @@
-# Primer table object
+---
+bundle: "table-object"
+generated: true
+---
 
-> Table object is a module for creating dynamically resizable elements that always sit on the same horizontal line (e.g., they never break to a new line). Using table styles in our CSS means it’s cross browser friendly back to at least IE9.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `table-object` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-table-object/index.scss";
+@import "@primer/css/table-object/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/objects/table-object](https://primer.style/css/objects/table-object).
-
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/table-object.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/toasts/README.md
+++ b/src/toasts/README.md
@@ -1,1 +1,25 @@
-# Primer Toasts
+---
+bundle: "toasts"
+generated: true
+---
+
+# Primer CSS: `toasts` bundle
+
+## Usage
+
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
+
+```scss
+@import "@primer/css/toasts/index.scss";
+```
+
+## Build
+
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/toasts.css`.
+
+## License
+
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
+
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/tooltips/README.md
+++ b/src/tooltips/README.md
@@ -1,38 +1,25 @@
-# Primer Tooltips
+---
+bundle: "tooltips"
+generated: true
+---
 
-> Add tooltips built entirely in CSS to nearly any element. Just add a few classes and an aria-label attribute.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `tooltips` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-tooltips/index.scss";
+@import "@primer/css/tooltips/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/tooltips](https://primer.style/css/components/tooltips).
-
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/tooltips.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/truncate/README.md
+++ b/src/truncate/README.md
@@ -1,38 +1,25 @@
-# Primer Truncate
+---
+bundle: "truncate"
+generated: true
+---
 
-> .css-truncate will shorten text with an ellipsis. The maximum width of the truncated text can be changed by overriding the max-width of the .css-truncate-target.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `truncate` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-truncate/index.scss";
+@import "@primer/css/truncate/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/components/truncate](https://primer.style/css/components/truncate).
-
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/truncate.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/utilities/README.md
+++ b/src/utilities/README.md
@@ -1,37 +1,25 @@
-# Primer Utilities
+---
+bundle: "utilities"
+generated: true
+---
 
-> There are a handful of utilities in Primer for quick behaviors, floats, colors, alignment, and more.
-
-This repository is a module of the full [primer][primer] repository.
+# Primer CSS: `utilities` bundle
 
 ## Usage
 
-The source files included are written in [Sass][sass] (`scss`) You can simply point your sass `include-path` at your `node_modules` directory and import it like this.
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
 
 ```scss
-@import "primer-utilities/index.scss";
+@import "@primer/css/utilities/index.scss";
 ```
-
-You can also import specific portions of the module by importing those partials from the `/lib/` folder. _Make sure you import any requirements along with the modules._
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
-
-```
-$ npm run build
-```
-
-## Documentation
-
-Find further documentation at [primer.style/css/utilities](https://primer.style/css/utilities).
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/utilities.css`.
 
 ## License
 
-[MIT](./LICENSE) &copy; [GitHub](https://github.com/)
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
 
-[primer]: https://github.com/primer/css
-[docs]: https://primer.style/css
-[npm]: https://www.npmjs.com/
-[install-npm]: https://docs.npmjs.com/getting-started/installing-node
-[sass]: http://sass-lang.com/
+
+[scss]: https://sass-lang.com/documentation/syntax#scss


### PR DESCRIPTION
This is a lazy (yet innovative!) way of keeping the `src/**/README.md` files up to date. I started trying to address the inconsistencies manually in #858, but quickly found that to be a waste of time. Here's the deal:

* [src/README.template.md](https://github.com//primer/css/blob/generate-bundle-readmes/src/README.template.md) is a template for the bundle docs with one or more `{bundle}` placeholders.
* [script/generate-bundle-readmes](https://github.com//primer/css/blob/generate-bundle-readmes/script/generate-bundle-readmes) generates a new `README.md` for each `index.scss` in the `src` directory, and replaces the `{bundle}` placeholder with the directory name. See [src/alerts/README.md](https://github.com//primer/css/blob/generate-bundle-readmes/src/alerts/#readme) as an example of the generated output.

If I'm out of town when y'all get around to reviewing this and the template needs tweaking, please go ahead and [edit it on this branch](https://github.com//primer/css/edit/generate-bundle-readmes/src/README.template.md) and re-run `script/generate-bundle-readmes` locally, then push your changes to `src/**/README.md`.

@colebemis: the README files in our `src` directory are _not_ included on the docs site, so you shouldn't need to worry about this!