### PR TITLE
updated blankslate component

### DIFF
--- a/pages/css/components/blankslate.md
+++ b/pages/css/components/blankslate.md
@@ -18,8 +18,8 @@ Wrap some content in the outer `.blankslate` wrapper to give it the blankslate a
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3">New pull request</button>
-  <p><button class="btn-link">Learn more</button></p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```
 
@@ -50,8 +50,8 @@ Narrows the blankslate container to not occupy the entire available width.
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3">New pull request</button>
-  <p><button class="btn-link">Learn more</button></p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```
 
@@ -64,8 +64,8 @@ Removes the `border-radius` on the top corners.
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3">New pull request</button>
-  <p><button class="btn-link">Learn more</button></p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```
 
@@ -78,8 +78,8 @@ Significantly increases the vertical padding.
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3">New pull request</button>
-  <p><button class="btn-link">Learn more</button></p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```
 
@@ -92,8 +92,8 @@ Increases the size of the text in the blankslate
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3">New pull request</button>
-  <p><button class="btn-link">Learn more</button></p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```
 
@@ -106,8 +106,8 @@ To remove the border, use the [border utliity](/css/utilities/borders) `.border-
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3">New pull request</button>
-  <p><button class="btn-link">Learn more</button></p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```
 
@@ -118,7 +118,7 @@ Due to a design refresh of the blank slate component, we will be deprecating the
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3">New pull request</button>
-  <p><button class="btn-link">Learn more</button></p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```

--- a/pages/css/components/blankslate.md
+++ b/pages/css/components/blankslate.md
@@ -55,20 +55,6 @@ Narrows the blankslate container to not occupy the entire available width.
 </div>
 ```
 
-##### Capped
-
-Removes the `border-radius` on the top corners.
-
-```html
-<div class="blankslate blankslate-capped">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
-  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
-  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
-  <button class="btn btn-primary my-3" type="button">New pull request</button>
-  <p><button class="btn-link" type="button">Learn more</button></p>
-</div>
-```
-
 ##### Spacious
 
 Significantly increases the vertical padding.
@@ -97,28 +83,34 @@ Increases the size of the text in the blankslate
 </div>
 ```
 
-##### No border
+##### Add border
 
-To remove the border, use the [border utliity](/css/utilities/borders) `.border-0`.
+To add a border, wrap the blankstate component with the [Box component](/css/components/box).
 
 ```html
-<div class="blankslate border-0">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
-  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
-  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
-  <button class="btn btn-primary my-3" type="button">New pull request</button>
-  <p><button class="btn-link" type="button">Learn more</button></p>
+<div class="Box">
+  <div class="blankslate">
+    <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
+    <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
+    <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
+    <button class="btn btn-primary my-3" type="button">New pull request</button>
+    <p><button class="btn-link" type="button">Learn more</button></p>
+  </div>
 </div>
 ```
 
-Due to a design refresh of the blank slate component, we will be deprecating the use of `.blankslate-clean-background` which removes the `background-color` and `border`.
+##### Capped
+
+Removes the `border-radius` on the top corners.
 
 ```html
-<div class="blankslate blankslate-clean-background">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
-  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
-  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
-  <button class="btn btn-primary my-3" type="button">New pull request</button>
-  <p><button class="btn-link" type="button">Learn more</button></p>
+<div class="Box rounded-top-0">
+  <div class="blankslate">
+    <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
+    <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
+    <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
+    <button class="btn btn-primary my-3" type="button">New pull request</button>
+    <p><button class="btn-link" type="button">Learn more</button></p>
+  </div>
 </div>
 ```

--- a/pages/css/components/blankslate.md
+++ b/pages/css/components/blankslate.md
@@ -110,3 +110,15 @@ To remove the border, use the [border utliity](/css/utilities/borders) `.border-
   <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```
+
+Due to the update to the component, we will be deprecating the use of `.blankslate-clean-background` which removes the `background-color` and `border`.
+
+```html
+<div class="blankslate blankslate-clean-background">
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
+  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
+</div>
+```

--- a/pages/css/components/blankslate.md
+++ b/pages/css/components/blankslate.md
@@ -15,8 +15,11 @@ Wrap some content in the outer `.blankslate` wrapper to give it the blankslate a
 
 ```html
 <div class="blankslate">
-  <h3>This is a blank slate</h3>
-  <p>Use it to provide information when no dynamic content exists.</p>
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
+  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```
 
@@ -44,8 +47,11 @@ Narrows the blankslate container to not occupy the entire available width.
 
 ```html
 <div class="blankslate blankslate-narrow">
-  <h3>This is a blank slate</h3>
-  <p>Use it to provide information when no dynamic content exists.</p>
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
+  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```
 
@@ -55,8 +61,11 @@ Removes the `border-radius` on the top corners.
 
 ```html
 <div class="blankslate blankslate-capped">
-  <h3>This is a blank slate</h3>
-  <p>Use it to provide information when no dynamic content exists.</p>
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
+  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```
 
@@ -66,8 +75,11 @@ Significantly increases the vertical padding.
 
 ```html
 <div class="blankslate blankslate-spacious">
-  <h3>This is a blank slate</h3>
-  <p>Use it to provide information when no dynamic content exists.</p>
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
+  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```
 
@@ -77,18 +89,24 @@ Increases the size of the text in the blankslate
 
 ```html
 <div class="blankslate blankslate-large">
-  <h3>This is a blank slate</h3>
-  <p>Use it to provide information when no dynamic content exists.</p>
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
+  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```
 
-##### No background
+##### No border
 
-Removes the `background-color` and `border`.
+To remove the border, use the [border utliity](/css/utilities/borders) `.border-0`.
 
 ```html
-<div class="blankslate blankslate-clean-background">
-  <h3>This is a blank slate</h3>
-  <p>Use it to provide information when no dynamic content exists.</p>
+<div class="blankslate border-0">
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
+  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```

--- a/pages/css/components/blankslate.md
+++ b/pages/css/components/blankslate.md
@@ -15,11 +15,11 @@ Wrap some content in the outer `.blankslate` wrapper to give it the blankslate a
 
 ```html
 <div class="blankslate">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3" type="button">New pull request</button>
-  <p><button class="btn-link" type="button">Learn more</button></p>
+  <button class="btn btn-primary my-3">New pull request</button>
+  <p><button class="btn-link">Learn more</button></p>
 </div>
 ```
 
@@ -47,11 +47,11 @@ Narrows the blankslate container to not occupy the entire available width.
 
 ```html
 <div class="blankslate blankslate-narrow">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3" type="button">New pull request</button>
-  <p><button class="btn-link" type="button">Learn more</button></p>
+  <button class="btn btn-primary my-3">New pull request</button>
+  <p><button class="btn-link">Learn more</button></p>
 </div>
 ```
 
@@ -61,11 +61,11 @@ Removes the `border-radius` on the top corners.
 
 ```html
 <div class="blankslate blankslate-capped">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3" type="button">New pull request</button>
-  <p><button class="btn-link" type="button">Learn more</button></p>
+  <button class="btn btn-primary my-3">New pull request</button>
+  <p><button class="btn-link">Learn more</button></p>
 </div>
 ```
 
@@ -75,11 +75,11 @@ Significantly increases the vertical padding.
 
 ```html
 <div class="blankslate blankslate-spacious">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3" type="button">New pull request</button>
-  <p><button class="btn-link" type="button">Learn more</button></p>
+  <button class="btn btn-primary my-3">New pull request</button>
+  <p><button class="btn-link">Learn more</button></p>
 </div>
 ```
 
@@ -89,11 +89,11 @@ Increases the size of the text in the blankslate
 
 ```html
 <div class="blankslate blankslate-large">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3" type="button">New pull request</button>
-  <p><button class="btn-link" type="button">Learn more</button></p>
+  <button class="btn btn-primary my-3">New pull request</button>
+  <p><button class="btn-link">Learn more</button></p>
 </div>
 ```
 
@@ -103,22 +103,22 @@ To remove the border, use the [border utliity](/css/utilities/borders) `.border-
 
 ```html
 <div class="blankslate border-0">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3" type="button">New pull request</button>
-  <p><button class="btn-link" type="button">Learn more</button></p>
+  <button class="btn btn-primary my-3">New pull request</button>
+  <p><button class="btn-link">Learn more</button></p>
 </div>
 ```
 
-Due to the update to the component, we will be deprecating the use of `.blankslate-clean-background` which removes the `background-color` and `border`.
+Due to a design refresh of the blank slate component, we will be deprecating the use of `.blankslate-clean-background` which removes the `background-color` and `border`.
 
 ```html
 <div class="blankslate blankslate-clean-background">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="Pull requests" class="mb-3">
+  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
-  <button class="btn btn-primary my-3" type="button">New pull request</button>
-  <p><button class="btn-link" type="button">Learn more</button></p>
+  <button class="btn btn-primary my-3">New pull request</button>
+  <p><button class="btn-link">Learn more</button></p>
 </div>
 ```

--- a/pages/css/components/blankslate.md
+++ b/pages/css/components/blankslate.md
@@ -17,7 +17,7 @@ Wrap some content in the outer `.blankslate` wrapper to give it the blankslate a
 <div class="blankslate">
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
-  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
   <button class="btn btn-primary my-3" type="button">New pull request</button>
   <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
@@ -49,7 +49,7 @@ Narrows the blankslate container to not occupy the entire available width.
 <div class="blankslate blankslate-narrow">
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
-  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
   <button class="btn btn-primary my-3" type="button">New pull request</button>
   <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
@@ -63,7 +63,7 @@ Removes the `border-radius` on the top corners.
 <div class="blankslate blankslate-capped">
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
-  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
   <button class="btn btn-primary my-3" type="button">New pull request</button>
   <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
@@ -77,7 +77,7 @@ Significantly increases the vertical padding.
 <div class="blankslate blankslate-spacious">
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
-  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
   <button class="btn btn-primary my-3" type="button">New pull request</button>
   <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
@@ -91,7 +91,7 @@ Increases the size of the text in the blankslate
 <div class="blankslate blankslate-large">
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
-  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
   <button class="btn btn-primary my-3" type="button">New pull request</button>
   <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
@@ -105,7 +105,7 @@ To remove the border, use the [border utliity](/css/utilities/borders) `.border-
 <div class="blankslate border-0">
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
-  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
   <button class="btn btn-primary my-3" type="button">New pull request</button>
   <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
@@ -117,7 +117,7 @@ Due to a design refresh of the blank slate component, we will be deprecating the
 <div class="blankslate blankslate-clean-background">
   <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3">
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
-  <p>Pull requests help you discuss potential changes before your changes are merged into the base branch.</p>
+  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
   <button class="btn btn-primary my-3" type="button">New pull request</button>
   <p><button class="btn-link" type="button">Learn more</button></p>
 </div>

--- a/src/blankslate/blankslate.scss
+++ b/src/blankslate/blankslate.scss
@@ -3,10 +3,8 @@
   position: relative;
   padding: $spacer-5;
   text-align: center;
-  background-color: $gray-000;
   border: 1px solid $gray-200;
   border-radius: 3px;
-  box-shadow: inset 0 0 10px rgba($black, 0.05);
 
   code {
     padding: 2px 5px 3px;
@@ -14,6 +12,11 @@
     background: $bg-white;
     border: 1px solid $border-gray-light;
     border-radius: 3px;
+  }
+
+  img {
+    width: 56px;
+    height: 56px;
   }
 }
 
@@ -38,10 +41,17 @@
 }
 
 // was .large-format
+// QUESTION: should we deprecate this?
 .blankslate-large {
+  img {
+    width: 80px;
+    height: 80px;
+  }
+
   h3 {
     margin: $spacer-3 0;
-    font-size: $h3-size;
+    //font-size: $h3-size; // This doesn't actually make the text larger. Should this be $h2-size?
+    font-size: $h2-size;
   }
 
   p {
@@ -50,8 +60,7 @@
 }
 
 // was .clean-background
+// TO DO: deprecate this and use utility instead
 .blankslate-clean-background {
-  background: none;
   border: 0;
-  box-shadow: none;
 }

--- a/src/blankslate/blankslate.scss
+++ b/src/blankslate/blankslate.scss
@@ -3,8 +3,6 @@
   position: relative;
   padding: $spacer-5;
   text-align: center;
-  border: 1px solid $gray-200;
-  border-radius: 3px;
 
   code {
     padding: 2px 5px 3px;


### PR DESCRIPTION
This PR updates the `blankslate` component and addresses #860 :
- updated examples to add pictograms, primary action button, and secondary action link
- removed background and box-shadow inset
- updated no border version to use `border-0` utility

**Related docs PRs:**
[primer/design #55](https://github.com/primer/design/pull/55)
[primer/design #58](https://github.com/primer/design/pull/58)

**Design:**
Original design [issue](https://github.com/github/design-systems/issues/645) covers background and links to figma files.

**Screenshot:**
<img width="944" alt="Screenshot 2019-08-08 15 46 58" src="https://user-images.githubusercontent.com/10384315/62742544-cb450380-b9f3-11e9-9e2f-7a3ede8e9477.png">


/cc @primer/ds-core