### PR TITLE
Don't let State labels wrap

### DIFF
--- a/src/labels/states.scss
+++ b/src/labels/states.scss
@@ -15,6 +15,7 @@
   line-height: 20px;
   color: $text-white;
   text-align: center;
+  white-space: nowrap;
   background-color: $gray-500;
   border-radius: 3px;
 }


### PR DESCRIPTION
I was working on the timeline and tested data with a long name, resulting in a `State` label getting squished. I can fix this with a utility but realized that we probably shouldn't ever let the State label wrap. So I'm proposing we add that here.

Here's what it looked like before the change
<img width="295" alt="image" src="https://user-images.githubusercontent.com/54012/62798849-23cbdd80-ba94-11e9-9a87-dbc2a3db204e.png">

And after
<img width="293" alt="image" src="https://user-images.githubusercontent.com/54012/62798864-2deddc00-ba94-11e9-9cba-caa60ea8018f.png">
