### PR TITLE
Fix SideNav "jumping" in Safari

### DIFF
--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -32,10 +32,6 @@
     width: 3px;
     pointer-events: none;
     content: "";
-    background-color: $gray-300;
-    transition: transform 0.24s ease-in;
-    transform: scaleX(0);
-    transform-origin: center left;
   }
 }
 
@@ -50,8 +46,7 @@
 
   // Bar on the left
   &::before {
-    transition: transform 0.12s ease-out;
-    transform: scaleX(1);
+    background-color: $gray-300;
   }
 }
 
@@ -68,7 +63,6 @@
   // Bar on the left
   &::before {
     background-color: $orange-600;
-    transform: scaleX(1);
   }
 }
 


### PR DESCRIPTION
This removes the animation on the "indicator bars".

## Reasoning

It causes the nav items to "jump" when hovering in **Safari**:

![jump](https://user-images.githubusercontent.com/378023/63399466-99786780-c40b-11e9-93c6-a820cb4afff4.gif)

## Alternatives

We could fix the "jumping" by adding `will-change: transform` or similar, but that creates additional GPU layers that might have other side effects depending on the rest of the page. Removing the animation seems safer.

---

Fixes https://github.com/primer/css/issues/864