### PR TITLE
Switch source order for `styleguide.css`

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
@@ -4,8 +4,8 @@ import primerStyles from '!!raw-loader!postcss-loader!../../../../../src/index.s
 function LivePreviewWrapper({children}) {
   return (
     <>
-      <style>{primerStyles}</style>
       <link rel="stylesheet" href="https://github.com/site/assets/styleguide.css" />
+      <style>{primerStyles}</style>
       <div className="p-3">{children}</div>
     </>
   )


### PR DESCRIPTION
This switches the source order for Primer CSS styles and .com's `styleguide.css`.

## Reasoning

.com's `styleguide.css` currently overrides the Primer CSS styles in our docs. Making it hard to move components from .com to Primer, see https://github.com/primer/css/pull/862#pullrequestreview-277652530. Switching the source order fixes that.

## Concerns

Does this have any other side effects? I guess when trying to move Primer CSS styles to .com? But that should probably happen more rarely? 🤔

Also, it doesn't work when removing certain properties (instead overriding them). Maybe in that case it's better to refactor the whole component and use another name.
