### PR TITLE
Remove non-ascii characters from scss files

### DIFF
--- a/src/support/mixins/typography.scss
+++ b/src/support/mixins/typography.scss
@@ -40,7 +40,7 @@
 }
 
 // Responsive heading mixins
-// There are no responsive mixins for h4—h6 because they are small
+// There are no responsive mixins for h4-h6 because they are small
 // and don't need to be smaller on mobile.
 @mixin f1-responsive {
   font-size: $h1-size-mobile;

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -2,7 +2,7 @@
 // stylelint-disable declaration-bang-space-before
 
 // Heading sizes - mobile
-// h4—h6 remain the same size on both mobile & desktop
+// h4-h6 remain the same size on both mobile & desktop
 $h00-size-mobile: 40px !default;
 $h0-size-mobile: 32px !default;
 $h1-size-mobile: 26px !default;


### PR DESCRIPTION
Replace em dashes with hyphens so these files are ascii characters only. These files have been producing an error in my jekyll site way downstream.

    Conversion error: Jekyll::Converters::Scss encountered an error while converting 'assets/css/style.scss':
                      Invalid US-ASCII character "\xE2" on line 5

I traced the issue to the jekyll-primer-theme gem, and [was told there](https://github.com/pages-themes/primer/pull/35) that I should make this fix upstream, here.

This can be fixed by setting `LANG=en_US.UTF-8` in the terminal environment, but removing this unnecessary utf8 will more widely fix the problem.

/cc @primer/ds-core
