### PR TITLE
Fix bundle size report

### DIFF
--- a/script/bundle-size-report
+++ b/script/bundle-size-report
@@ -44,10 +44,15 @@ Promise.all(
     const entry = {
       name: bundle.name,
       path: bundle.css,
-      local: require(`../${bundle.stats}`)
+      local: require(`../${bundle.stats}`),
+      remote: {}
     }
     return fetch(unpkgBaseURL + bundle.stats)
       .then(res => res.json())
+      .catch(error => {
+        console.warn(`Unable to fetch old ${bundle.name} bundle from unpkg; assuming it's new!`)
+        return entry.local
+      })
       .then(stats => (entry.remote = stats))
       .then(() => entry)
   })


### PR DESCRIPTION
I was looking at the bundle size report that #862 was supposed to generate, and it looks like it was failing. This is the fix; assuming it works here, let's merge into that PR and include an item for it in #878. 🤞 