### PR TITLE
Add .break-word, improve word-break docs

### DIFF
--- a/docs/content/utilities/typography.md
+++ b/docs/content/utilities/typography.md
@@ -103,14 +103,18 @@ Change the font weight, styles, and alignment with these utilities.
 ```
 
 ## Word-break
-There are two utilities for setting the CSS [word-break](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break) property:
+There are two utilities for adjusting how lines and words of text break when they exceed the width of their containing element:
 
-1. `wb-break-all` sets `word-break: break-all`, and will force long lines to break (but _not words_).
-2. `wb-break-word` sets `word-break: break-word`, and will force long words to break.
+1. `break-word` sets `word-break: break-word` _and_ `overflow-wrap: break-word`. **This is more reliable way to ensure that content doesn't escape its container than `wb-break-all`.**
+
+2. `wb-break-all` sets `word-break: break-all`, which behaves in a subtly different way to `break-word`, [according to MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#Values):
+
+    > **Note:** In contrast to `word-break: break-word` and `overflow-wrap: break-word` (see [`overflow-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap)), `word-break: break-all` will create a break at the exact place where text would otherwise overflow its container (even if putting an entire word on its own line would negate the need for a break).
+
 
 ```html live
-<p class="wb-break-all p-2 bg-gray col-6">Break long lines with words like supercalifragilisticexpialidocious.</p>
-<p class="wb-break-word p-2 bg-gray col-1">Break long words like supercalifragilisticexpialidocious.</p>
+<p class="break-word p-2 bg-gray col-1">Break long words like supercalifragilisticexpialidocious.</p>
+<p class="wb-break-all p-2 bg-gray col-6">Break long words like supercalifragilisticexpialidocious and .</p>
 ```
 
 

--- a/docs/content/utilities/typography.md
+++ b/docs/content/utilities/typography.md
@@ -93,7 +93,6 @@ Change the font weight, styles, and alignment with these utilities.
 <p class="text-uppercase">Uppercase</p>
 <p class="no-wrap">No wrap</p>
 <p class="ws-normal">Normal whitespace</p>
-<p class="wb-break-all">Line break long lines</p>
 <p class="text-underline">Text underline</p>
 <p class="no-underline">No underline</p>
 <p class="text-emphasized">Emphasized</p>
@@ -102,6 +101,18 @@ Change the font weight, styles, and alignment with these utilities.
 <p class="text-mono">Monospace</p>
 <p class="user-select-none">User Select None</p>
 ```
+
+## Word-break
+There are two utilities for setting the CSS [word-break](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break) property:
+
+1. `wb-break-all` sets `word-break: break-all`, and will force long lines to break (but _not words_).
+2. `wb-break-word` sets `word-break: break-word`, and will force long words to break.
+
+```html live
+<p class="wb-break-all p-2 bg-gray col-6">Break long lines with words like supercalifragilisticexpialidocious.</p>
+<p class="wb-break-word p-2 bg-gray col-1">Break long words like supercalifragilisticexpialidocious.</p>
+```
+
 
 ## Text alignment
 

--- a/docs/content/utilities/typography.md
+++ b/docs/content/utilities/typography.md
@@ -109,8 +109,6 @@ There are two utilities for adjusting how lines and words of text break when the
 
 2. `wb-break-all` sets `word-break: break-all`, which will force a word to break regardless of whether it's shorter than the line length. See [MDN's `word-break` docs](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#Values) for more info.
 
-
-
 ```html live
 <p class="break-word p-2 bg-gray col-3 border-right">.break-word will only break long words that exceed the line length, such as supercalifragilisticexpialidocious. Long words like "exceedingly" will simply break to the next line.</p>
 <p class="wb-break-all p-2 bg-gray col-3 border-right">.wb-break-all will break any word that meets the end its line, and should be used sparingly. As you can see here, it's not particularly nice to read text that breaks in weird places.</p>

--- a/docs/content/utilities/typography.md
+++ b/docs/content/utilities/typography.md
@@ -107,9 +107,8 @@ There are two utilities for adjusting how lines and words of text break when the
 
 1. `break-word` sets `word-break: break-word` and `overflow-wrap: break-word`, which will only break words if they would exceed the line length _after wrapping_.
 
-2. `wb-break-all` sets `word-break: break-all`, will force a word to break regardless of whether it's shorter than the line length, per [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#Values):
+2. `wb-break-all` sets `word-break: break-all`, which will force a word to break regardless of whether it's shorter than the line length. See [MDN's `word-break` docs](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#Values) for more info.
 
-    > **Note:** In contrast to `word-break: break-word` and `overflow-wrap: break-word` (see [`overflow-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap)), `word-break: break-all` will create a break at the exact place where text would otherwise overflow its container (even if putting an entire word on its own line would negate the need for a break).
 
 
 ```html live

--- a/docs/content/utilities/typography.md
+++ b/docs/content/utilities/typography.md
@@ -105,16 +105,16 @@ Change the font weight, styles, and alignment with these utilities.
 ## Word-break
 There are two utilities for adjusting how lines and words of text break when they exceed the width of their containing element:
 
-1. `break-word` sets `word-break: break-word` _and_ `overflow-wrap: break-word`. **This is more reliable way to ensure that content doesn't escape its container than `wb-break-all`.**
+1. `break-word` sets `word-break: break-word` and `overflow-wrap: break-word`, which will only break words if they would exceed the line length _after wrapping_.
 
-2. `wb-break-all` sets `word-break: break-all`, which behaves in a subtly different way to `break-word`, [according to MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#Values):
+2. `wb-break-all` sets `word-break: break-all`, will force a word to break regardless of whether it's shorter than the line length, per [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#Values):
 
     > **Note:** In contrast to `word-break: break-word` and `overflow-wrap: break-word` (see [`overflow-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap)), `word-break: break-all` will create a break at the exact place where text would otherwise overflow its container (even if putting an entire word on its own line would negate the need for a break).
 
 
 ```html live
-<p class="break-word p-2 bg-gray col-1">Break long words like supercalifragilisticexpialidocious.</p>
-<p class="wb-break-all p-2 bg-gray col-6">Break long words like supercalifragilisticexpialidocious and .</p>
+<p class="break-word p-2 bg-gray col-3 border-right">.break-word will only break long words that exceed the line length, such as supercalifragilisticexpialidocious. Long words like "exceedingly" will simply break to the next line.</p>
+<p class="wb-break-all p-2 bg-gray col-3 border-right">.wb-break-all will break any word that meets the end its line, and should be used sparingly. As you can see here, it's not particularly nice to read text that breaks in weird places.</p>
 ```
 
 

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -187,9 +187,9 @@
 
 /* Force long "words" to wrap if they exceed the width of the container */
 .break-word {
+  word-break: break-word !important;
   // this is for backwards compatibility with browsers that don't respect overflow-wrap
   word-wrap: break-word !important;
-  word-break: break-word !important;
   overflow-wrap: break-word !important;
 }
 

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -184,8 +184,11 @@
 .no-wrap { white-space: nowrap !important; }
 /* Normal white space */
 .ws-normal { white-space: normal !important; }
+
 /* Allow long lines with no spaces to line break */
 .wb-break-all { word-break: break-all !important; }
+/* Force long "words" to wrap if they exceed the width of the container */
+.wb-break-word { word-break: break-word !important; }
 
 .text-emphasized {
   font-weight: $font-weight-bold;

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -185,10 +185,25 @@
 /* Normal white space */
 .ws-normal { white-space: normal !important; }
 
-/* Allow long lines with no spaces to line break */
-.wb-break-all { word-break: break-all !important; }
 /* Force long "words" to wrap if they exceed the width of the container */
-.wb-break-word { word-break: break-word !important; }
+.break-word {
+  // this is for backwards compatibility with browsers that don't respect overflow-wrap
+  word-wrap: break-word !important;
+  word-break: break-word !important;
+  overflow-wrap: break-word !important;
+}
+
+/*
+ * Specifically apply word-break: break-all; per MDN:
+ *
+ * > Note: In contrast to `word-break: break-word` and `overflow-wrap: break-word`,
+ * > `word-break: break-all` will create a break at the exact place where text would
+ * > otherwise overflow its container (even if putting an entire word on its own line
+ * > would negate the need for a break).
+ *
+ * see: https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#Values
+ */
+.wb-break-all { word-break: break-all !important; }
 
 .text-emphasized {
   font-weight: $font-weight-bold;


### PR DESCRIPTION
The `break-word` class applies _both_ `word-break: break-word` and `overflow-wrap: break-word`, to account for differences in the interpretation of `word-break` between Chrome and Firefox. See [css-tricks](https://css-tricks.com/almanac/properties/o/overflow-wrap/) for more info:

> After describing examples of how word-break can be used in CJK content, the spec says: "To enable additional break opportunities only in the case of overflow, see overflow-wrap".
> 
> From this, we can surmise that word-break is best used with non-English content that requires specific word-breaking rules, and that might be interspersed with English content, while overflow-wrap should be used to avoid broken layouts due to long strings, regardless of the language used.

My understanding is that Chrome's interpretation is "looser", in the sense that it breaks words regardless of language; while Firefox's interpretation is more strict, essentially requiring `overflow-wrap: break-word` for English text.

- [x] ~Add `.wb-break-word` declaration~
- [x] Add `.break-word` declaration
- [x] Add `overflow-wrap: break-word !important`
- [x] Update the docs