### PR TITLE
add all the .btn-purple selectors to deprecations.js

### DIFF
--- a/deprecations.js
+++ b/deprecations.js
@@ -6,7 +6,19 @@
 const versionDeprecations = {
   '13.0.0': [
     {
-      selectors: ['.btn-purple'],
+      selectors: [
+        '.btn-purple',
+        '.btn-purple:focus',
+        '.btn-purple.focus',
+        '.btn-purple:hover',
+        '.btn-purple.hover',
+        '.btn-purple:active',
+        '.btn-purple.selected',
+        '[open]>.btn-purple',
+        '.btn-purple:disabled',
+        '.btn-purple.disabled',
+        '.btn-purple .Counter'
+      ],
       message: `Please don't make purple buttons.`
     },
     {


### PR DESCRIPTION
Deleting `.btn-purple` in #736 actually removes a bunch of other, more specific CSS selectors from the stats. In order to appease the deprecations test script introduced in #889, we need to add all of these to the selector deprecations list for `13.0.0`. Running `script/test-deprecations.js` on this branch yields:

```
i 28 selectors removed locally (compared with latest)
i 28 selectors deprecated in v13.0.0
✓ ".btn-purple" is officially deprecated
✓ ".btn-purple:focus" is officially deprecated
✓ ".btn-purple.focus" is officially deprecated
✓ ".btn-purple:hover" is officially deprecated
✓ ".btn-purple.hover" is officially deprecated
✓ ".btn-purple:active" is officially deprecated
✓ ".btn-purple.selected" is officially deprecated
✓ "[open]>.btn-purple" is officially deprecated
✓ ".btn-purple:disabled" is officially deprecated
✓ ".btn-purple.disabled" is officially deprecated
✓ ".btn-purple .Counter" is officially deprecated
✓ ".text-pending" is officially deprecated
✓ ".bg-pending" is officially deprecated
✓ ".container" is officially deprecated
✓ ".container::before" is officially deprecated
✓ ".container::after" is officially deprecated
✓ ".columns" is officially deprecated
✓ ".columns::before" is officially deprecated
✓ ".columns::after" is officially deprecated
✓ ".column" is officially deprecated
✓ ".one-third" is officially deprecated
✓ ".two-thirds" is officially deprecated
✓ ".one-fourth" is officially deprecated
✓ ".one-half" is officially deprecated
✓ ".three-fourths" is officially deprecated
✓ ".one-fifth" is officially deprecated
✓ ".four-fifths" is officially deprecated
✓ ".centered" is officially deprecated
```