### PR TITLE
Update development docs for new gatsby site

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -36,18 +36,16 @@ The typical Primer workflow looks something like this:
 Run `npm install` to install the npm dependencies.
 
 ## Docs site
-The Primer CSS docs are built with React using [Primer Components](https://primer.style/components) and automatically deployed on every push to this repo with [Now]. You can run the server locally with:
+The Primer CSS docs are built with React using [Doctocat](https://primer.style/doctocat) and automatically deployed on every push to this repo with [Now]. You can run the server locally with:
 
 ```sh
 npm start
 ```
 
-Then visit http://localhost:3000/css to view the site.
+Then visit http://localhost:8000 to view the site.
 
-:rotating_light: **Warning:** Next.js has a [long-running issue](https://github.com/zeit/next.js/issues/1189) with trailing slashes in URLs. Avoid visiting `http://localhost:3000/` if possible, as this may cause your development server to fail in less-than-graceful ways.
-
-### The pages directory
-The [pages directory](./pages/) contains all of the documentation files that map to URLs on the site. Because we host the site at `primer.style/css` (and because of the way that Now's path aliasing feature works), we nest all of our documentation under the [css subdirectory](./pages/css).
+### The docs directory
+The [docs directory](./docs/) contains all of the documentation files in our docs site. Files are nested in the `/content` folder.
 
 
 ### URL tests


### PR DESCRIPTION
I noticed that the docs are out of date now that we've moved to doctocat! I've updated a few things.

@shawnbot I have a few questions!

- Is storybook still the defacto way to work on new components or update an existing component? It seems like it's no longer functioning 😬. The main issue was that the folder we pointed to to grab markdown to turn into stories was incorrect, so I tried changing that, but now I'm getting this error:

```
WARNING in ./docs/content/utilities/index.md 1:2
Module parse failed: Assigning to rvalue (1:2)
You may need an appropriate loader to handle this file type.
> ---
| title: Utilities
| path: utilities/index
```

Not sure if it's the front matter specifically that's causing an issue or if we need to add a loader for `md` in general?



- Is the test-urls script still relevant? If so I think we need to update that as well

I can make issues for these things if so!

/cc @primer/ds-core
