### PR TITLE
More SelectMenu improvements

### DIFF
--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -350,7 +350,7 @@ Also consider adding a `.SelectMenu-footer` at the bottom. It can be used for ad
 </details>
 
 <div class="d-sm-none"         style="height: 600px"> <!-- min height for < sm --> </div>
-<div class="d-none d-sm-block" style="height: 380px"> <!-- min height for > sm --> </div>
+<div class="d-none d-sm-block" style="height: 500px"> <!-- min height for > sm --> </div>
 ```
 
 ## Tabs

--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -430,7 +430,7 @@ A `SelectMenu-message` can be used to show different kind of messages to a user.
       <div class="SelectMenu-list">
         <button class="SelectMenu-item" role="menuitem">Item 1</button>
         <button class="SelectMenu-item" role="menuitem">Item 2</button>
-        <div class="SelectMenu-message border-bottom border-top bg-red-0 text-red p-2">Message goes here</div>
+        <div class="SelectMenu-message bg-red-0 text-red p-2">Message goes here</div>
         <button class="SelectMenu-item" role="menuitem">Item 3</button>
       </div>
     </div>

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -3,6 +3,8 @@
 // selector-max-type is needed for body:not(.intent-mouse) to target keyboard only styles.
 // TODO: Introduce an additional .intent-keyboard class
 
+$SelectMenu-border: $border-width $border-style lighten($gray-200, 3%);
+
 // Select Menu
 //
 // A more advanced menu with support for navigation, filtering, and more.
@@ -161,6 +163,7 @@
   position: relative;
   padding: 0;
   margin: 0;
+  margin-bottom: -$border-width; // Hides the last border in the list
   flex: auto;
   overflow-x: hidden;
   overflow-y: auto;
@@ -184,11 +187,7 @@
   cursor: pointer;
   background-color: $bg-white;
   border: 0;
-
-  & + & {
-    // Add a top border only if the above element also is a list item
-    border-top: $border-width $border-style lighten($gray-200, 3%);
-  }
+  border-bottom: $SelectMenu-border;
 
   @include breakpoint(sm) {
     padding-top: $spacer-2;
@@ -269,6 +268,10 @@
 //
 // A container used to show different kinds of content. Like a message, a blankslate or the loading animation.
 
+.SelectMenu-message {
+  border-bottom: $SelectMenu-border;
+}
+
 .SelectMenu-message,
 .SelectMenu-blankslate,
 .SelectMenu-loading {
@@ -288,16 +291,7 @@
   font-weight: $font-weight-bold;
   color: $text-gray-light;
   background-color: $gray-100;
-  border-top: $border;
-  border-bottom: $border;
-
-  &:first-child {
-    border-top: 0;
-  }
-
-  &:last-child {
-    border-bottom: 0;
-  }
+  border-bottom: $SelectMenu-border;
 }
 
 // Footer
@@ -310,6 +304,7 @@
   color: $text-gray-light;
   text-align: center;
   border-top: $border;
+  z-index: 0; // Avoid top border from getting covered by the negative margin of the list
 
   @include breakpoint(sm) {
     padding: $spacer-1 $spacer-2;
@@ -331,11 +326,6 @@
       max-height: 350px;
       margin-top: $spacer-1;
     }
-  }
-
-  // Show bottom "border" for the last item when the list doesn't take up the whole height
-  .SelectMenu-item:last-child {
-    box-shadow: 0 $border-width 0 lighten($gray-200, 3%);
   }
 }
 

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -299,12 +299,12 @@ $SelectMenu-border: $border-width $border-style lighten($gray-200, 3%);
 // A container at the bottom.
 
 .SelectMenu-footer {
+  z-index: 0; // Avoid top border from getting covered by the negative margin of the list
   padding: $spacer-2 $spacer-3;
   font-size: $font-size-small;
   color: $text-gray-light;
   text-align: center;
   border-top: $border;
-  z-index: 0; // Avoid top border from getting covered by the negative margin of the list
 
   @include breakpoint(sm) {
     padding: $spacer-1 $spacer-2;

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -85,7 +85,7 @@ $SelectMenu-border: $border-width $border-style lighten($gray-200, 3%);
   @include breakpoint(sm) {
     width: 300px;
     height: auto;
-    max-height: 350px;
+    max-height: 480px;
     margin: $spacer-1 0 $spacer-3 0;
     font-size: $font-size-small;
     border: $border-width $border-style $border-gray-dark;
@@ -323,7 +323,7 @@ $SelectMenu-border: $border-width $border-style lighten($gray-200, 3%);
 
     @include breakpoint(sm) {
       height: auto;
-      max-height: 350px;
+      max-height: 480px;
       margin-top: $spacer-1;
     }
   }

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -4,6 +4,7 @@
 // TODO: Introduce an additional .intent-keyboard class
 
 $SelectMenu-border: $border-width $border-style lighten($gray-200, 3%);
+$SelectMenu-max-height: 480px;
 
 // Select Menu
 //
@@ -85,7 +86,7 @@ $SelectMenu-border: $border-width $border-style lighten($gray-200, 3%);
   @include breakpoint(sm) {
     width: 300px;
     height: auto;
-    max-height: 480px;
+    max-height: $SelectMenu-max-height;
     margin: $spacer-1 0 $spacer-3 0;
     font-size: $font-size-small;
     border: $border-width $border-style $border-gray-dark;
@@ -323,7 +324,7 @@ $SelectMenu-border: $border-width $border-style lighten($gray-200, 3%);
 
     @include breakpoint(sm) {
       height: auto;
-      max-height: 480px;
+      max-height: $SelectMenu-max-height;
       margin-top: $spacer-1;
     }
   }


### PR DESCRIPTION
While testing the SelectMenu for the "branch picker" [more issues](https://github.com/github/github/pull/116285#issuecomment-531636279) came up:

## When filtering, a top border is visible

When using `fuzzy-list` to filter, the DOM nodes get removed, but for the branch picker `display: none` is used. This has the effect that `:first/:last-child` can't be used anymore.

**Fix**: Use a `bottom-border` and then `margin-bottom: -1px` on the list to hide the "last" border https://github.com/primer/css/commit/fb3a10aa9a3249a5ef7c7b6945cd58bd1a4fd63d

Using `box-shadow` would be an alternative because it gets cut off within `overflow-y: auto;`. But it seems scrolling performance suffers.

Before | After
--- | ---
![Before](https://user-images.githubusercontent.com/378023/64933468-71501d00-d880-11e9-8934-76d9c81aa006.png) | ![After](https://user-images.githubusercontent.com/378023/64933467-70b78680-d880-11e9-8364-12b9ac75da1a.png)

## The branch list is not as tall

**Fix**: Increase `max-height` a bit. https://github.com/primer/css/commit/279c87ebea72cef5fb9395bafb616439c0a35896

Before | After
--- | ---
![Before](https://user-images.githubusercontent.com/378023/64934246-65665a00-d884-11e9-8223-73165ba68bf3.png) | ![After](https://user-images.githubusercontent.com/378023/64934245-64cdc380-d884-11e9-8b20-253d75f4e671.png)
