### PR TITLE
Move select menu list into the modal div

### DIFF
--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -556,11 +556,11 @@ When adding the `.SelectMenu` component on github.com, use the [`<details-menu>`
           <%= octicon("x", "aria-label": "Close menu") %>
         </button>
       </header>
-    </div>
-    <div class="SelectMenu-list">
-      <a class="SelectMenu-item" href="" role="menuitem">Item 1</a>
-      <a class="SelectMenu-item" href="" role="menuitem">Item 2</a>
-      <a class="SelectMenu-item" href="" role="menuitem">Item 3</a>
+      <div class="SelectMenu-list">
+        <a class="SelectMenu-item" href="" role="menuitem">Item 1</a>
+        <a class="SelectMenu-item" href="" role="menuitem">Item 2</a>
+        <a class="SelectMenu-item" href="" role="menuitem">Item 3</a>
+      </div>
     </div>
   </details-menu>
 </details>


### PR DESCRIPTION
Otherwise the list won't actually show up.

This should make it consistent with all the other examples where the header and the list are at the same level of nesting.

/cc @primer/ds-core
