### PR TITLE
Remove "Segoe UI Symbol" from font stack

### DIFF
--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -33,7 +33,7 @@ $lh-condensed: 1.25 !default;
 $lh-default: 1.5 !default;
 
 // Font stacks
-$body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji" !default;
 
 // Monospace font stack
 $mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace !default;


### PR DESCRIPTION
This removes `Segoe UI Symbol` from the `$body-font` stack.

## Reasoning

See issue https://github.com/github/design-systems/issues/710 and more specifically this comment https://github.com/github/design-systems/issues/710#issuecomment-533818820.

In short `Segoe UI Symbol` is used as a fallback for native emoji support. Removing `Segoe UI Symbol` allows users to have other fonts that use the same "private" unicode characters. For example to display certain chinese symbols.

## Concerns

I think it's only an issue for people still on Windows 7 and only affects non-markdown areas on dotcom.. like the title of an issue.

/cc @muan @primer/ds-core
