### PR TITLE
Primer CSS 12.4.1-hotfix.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 12.4.1-hotfix.1
+
+### :bug: Bug Fix
+- Remove "Segoe UI Symbol" from font stack [#906](https://github.com/primer/css/pull/906)
+
+### Committers
+- [@simurai](https://github.com/simurai)
+
 # 12.4.1
 
 ### :bug: Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/css",
-  "version": "12.4.1",
+  "version": "12.4.1-hotfix.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/css",
-  "version": "12.4.1-hotfix.1",
+  "version": "12.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/css",
-  "version": "12.4.1-hotfix.1",
+  "version": "12.4.2",
   "description": "Primer is the CSS framework that powers GitHub's front-end design. primer includes 23 packages that are grouped into 3 core meta-packages for easy install. Each package and meta-package is independently versioned and distributed via npm, so it's easy to include all or part of Primer within your own project.",
   "homepage": "https://primer.style/css",
   "author": "GitHub, Inc.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/css",
-  "version": "12.4.1",
+  "version": "12.4.1-hotfix.1",
   "description": "Primer is the CSS framework that powers GitHub's front-end design. primer includes 23 packages that are grouped into 3 core meta-packages for easy install. Each package and meta-package is independently versioned and distributed via npm, so it's easy to include all or part of Primer within your own project.",
   "homepage": "https://primer.style/css",
   "author": "GitHub, Inc.",

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -33,7 +33,7 @@ $lh-condensed: 1.25 !default;
 $lh-default: 1.5 !default;
 
 // Font stacks
-$body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji" !default;
 
 // Monospace font stack
 $mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace !default;


### PR DESCRIPTION
# Primer CSS Hotfix Release

Version: 📦 **12.4.1-hotfix.1**
Approximate release date: 📆 Sep 24, 2019 (ASAP)

### :bug: Bug Fix
- [x] Remove "Segoe UI Symbol" from font stack #906

----

### Ship checklist

- [x] Update the `version` field in `package.json`
- [x] Update `CHANGELOG.md`
- [ ] Update `github/github` with the release candidate version

⚠️ DO NOT MERGE this PR. ⚠️ It's only used to create a "hotfix" for GitHub Enterprise.

/cc @primer/ds-core