### PR TITLE
Report needless disables in CI, bump stylelint, tidy scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
         with:
           version: 11
       - name: install
-        run: npm --unsafe-perm install
+        run: npm install
       - name: lint
-        run: npm --unsafe-perm run lint
+        run: script/lint-ci
       - name: test
-        run: npm --unsafe-perm test
+        run: npm test
       - name: prepublish
         run: script/prepublish
       - name: test deprecations

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .changelog
 .next/
 .sass-cache
+.stylelintcache
 .storybuild/
 _site
 dist/

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,8 +1,0 @@
-{
-  "extends": [
-    "stylelint-config-primer"
-  ],
-  "rules": {
-    "primer/no-override": false
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4348,13 +4348,12 @@
       }
     },
     "clone-regexp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
-      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
       "dev": true,
       "requires": {
-        "is-regexp": "^1.0.0",
-        "is-supported-regexp-flag": "^1.0.0"
+        "is-regexp": "^2.0.0"
       }
     },
     "co": {
@@ -4439,9 +4438,9 @@
       "dev": true
     },
     "colorette": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.0.7.tgz",
-      "integrity": "sha512-KeK4klsvAgdODAjFPm6QLzvStizJqlxMBtVo4KQMCgk5tt/tf9rAzxmxLHNRynJg3tJjkKGKbHx3j4HLox27Lw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.1.0.tgz",
+      "integrity": "sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg==",
       "dev": true
     },
     "colors": {
@@ -6678,12 +6677,12 @@
       }
     },
     "execall": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
-      "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
       "dev": true,
       "requires": {
-        "clone-regexp": "^1.0.0"
+        "clone-regexp": "^2.1.0"
       }
     },
     "exenv": {
@@ -7145,9 +7144,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
     "flow-bin": {
@@ -8543,9 +8542,9 @@
       }
     },
     "html-tags": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
-      "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+      "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
       "dev": true
     },
     "html-webpack-plugin": {
@@ -8670,6 +8669,12 @@
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
+    "ignore": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+      "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+      "dev": true
+    },
     "immer": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-1.12.1.tgz",
@@ -8703,6 +8708,12 @@
       "requires": {
         "resolve-from": "^3.0.0"
       }
+    },
+    "import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -9162,9 +9173,9 @@
       }
     },
     "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+      "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
       "dev": true
     },
     "is-resolvable": {
@@ -9183,12 +9194,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
-    },
-    "is-supported-regexp-flag": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
-      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
       "dev": true
     },
     "is-symbol": {
@@ -9513,9 +9518,9 @@
       }
     },
     "known-css-properties": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.11.0.tgz",
-      "integrity": "sha512-bEZlJzXo5V/ApNNa5z375mJC6Nrz4vG43UgcSCrg2OHC+yuB6j0iDSrY7RQ/+PRofFB03wNIIt9iXIVLr4wc7w==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.14.0.tgz",
+      "integrity": "sha512-P+0a/gBzLgVlCnK8I7VcD0yuYJscmWn66wH9tlKsQnmVdg689tLEmziwB9PuazZYLkcm07fvWOKCJJqI55sD5Q==",
       "dev": true
     },
     "lazy-cache": {
@@ -9601,9 +9606,9 @@
       }
     },
     "leven": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true
     },
     "levn": {
@@ -9754,12 +9759,12 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "^2.4.2"
       }
     },
     "longest-streak": {
@@ -9888,9 +9893,9 @@
       }
     },
     "mathml-tag-names": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.0.tgz",
-      "integrity": "sha512-3Zs9P/0zzwTob2pdgT0CHZuMbnSUSp8MB1bddfm+HDmnFWHGT4jvEZRf+2RuPoa+cjdn/z25SEt5gFTqdhvJAg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
+      "integrity": "sha512-pWB896KPGSGkp1XtyzRBftpTzwSOL0Gfk0wLvxt4f2mgzjY19o0LxJ3U25vNWTzsh7da+KTbuXQoQ3lOJZ8WHw==",
       "dev": true
     },
     "md5.js": {
@@ -11180,6 +11185,12 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
+      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+      "dev": true
+    },
     "pidtree": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
@@ -11361,12 +11372,12 @@
       }
     },
     "postcss-jsx": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.0.tgz",
-      "integrity": "sha512-/lWOSXSX5jlITCKFkuYU2WLFdrncZmjSVyNpHAunEgirZXLwI8RjU556e3Uz4mv0WVHnJA9d3JWb36lK9Yx99g==",
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.3.tgz",
+      "integrity": "sha512-yV8Ndo6KzU8eho5mCn7LoLUGPkXrRXRjhMpX4AaYJ9wLJPv099xbtpbRQ8FrPnzVxb/cuMebbPR7LweSt+hTfA==",
       "dev": true,
       "requires": {
-        "@babel/core": ">=7.1.0"
+        "@babel/core": ">=7.2.2"
       }
     },
     "postcss-less": {
@@ -11545,6 +11556,17 @@
         "lodash": "^4.17.11",
         "log-symbols": "^2.2.0",
         "postcss": "^7.0.7"
+      },
+      "dependencies": {
+        "log-symbols": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1"
+          }
+        }
       }
     },
     "postcss-resolve-nested-selector": {
@@ -13435,9 +13457,9 @@
       "dev": true
     },
     "slash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
     "slice-ansi": {
@@ -14097,58 +14119,59 @@
       }
     },
     "stylelint": {
-      "version": "9.10.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.10.1.tgz",
-      "integrity": "sha512-9UiHxZhOAHEgeQ7oLGwrwoDR8vclBKlSX7r4fH0iuu0SfPwFaLkb1c7Q2j1cqg9P7IDXeAV2TvQML/fRQzGBBQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-10.1.0.tgz",
+      "integrity": "sha512-OmlUXrgzEMLQYj1JPTpyZPR9G4bl0StidfHnGJEMpdiQ0JyTq0MPg1xkHk1/xVJ2rTPESyJCDWjG8Kbpoo7Kuw==",
       "dev": true,
       "requires": {
-        "autoprefixer": "^9.0.0",
+        "autoprefixer": "^9.5.1",
         "balanced-match": "^1.0.0",
-        "chalk": "^2.4.1",
-        "cosmiconfig": "^5.0.0",
-        "debug": "^4.0.0",
-        "execall": "^1.0.0",
-        "file-entry-cache": "^4.0.0",
-        "get-stdin": "^6.0.0",
+        "chalk": "^2.4.2",
+        "cosmiconfig": "^5.2.0",
+        "debug": "^4.1.1",
+        "execall": "^2.0.0",
+        "file-entry-cache": "^5.0.1",
+        "get-stdin": "^7.0.0",
         "global-modules": "^2.0.0",
-        "globby": "^9.0.0",
+        "globby": "^9.2.0",
         "globjoin": "^0.1.4",
-        "html-tags": "^2.0.0",
-        "ignore": "^5.0.4",
-        "import-lazy": "^3.1.0",
+        "html-tags": "^3.0.0",
+        "ignore": "^5.0.6",
+        "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
-        "known-css-properties": "^0.11.0",
-        "leven": "^2.1.0",
-        "lodash": "^4.17.4",
-        "log-symbols": "^2.0.0",
-        "mathml-tag-names": "^2.0.1",
+        "known-css-properties": "^0.14.0",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.11",
+        "log-symbols": "^3.0.0",
+        "mathml-tag-names": "^2.1.0",
         "meow": "^5.0.0",
-        "micromatch": "^3.1.10",
+        "micromatch": "^4.0.0",
         "normalize-selector": "^0.2.0",
-        "pify": "^4.0.0",
-        "postcss": "^7.0.13",
+        "pify": "^4.0.1",
+        "postcss": "^7.0.14",
         "postcss-html": "^0.36.0",
-        "postcss-jsx": "^0.36.0",
-        "postcss-less": "^3.1.0",
+        "postcss-jsx": "^0.36.1",
+        "postcss-less": "^3.1.4",
         "postcss-markdown": "^0.36.0",
         "postcss-media-query-parser": "^0.2.3",
-        "postcss-reporter": "^6.0.0",
+        "postcss-reporter": "^6.0.1",
         "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-safe-parser": "^4.0.0",
+        "postcss-safe-parser": "^4.0.1",
         "postcss-sass": "^0.3.5",
         "postcss-scss": "^2.0.0",
         "postcss-selector-parser": "^3.1.0",
         "postcss-syntax": "^0.36.2",
-        "postcss-value-parser": "^3.3.0",
-        "resolve-from": "^4.0.0",
+        "postcss-value-parser": "^3.3.1",
+        "resolve-from": "^5.0.0",
         "signal-exit": "^3.0.2",
-        "slash": "^2.0.0",
+        "slash": "^3.0.0",
         "specificity": "^0.4.1",
-        "string-width": "^3.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^5.2.0",
         "style-search": "^0.1.0",
         "sugarss": "^2.0.0",
         "svg-tags": "^1.0.0",
-        "table": "^5.0.0"
+        "table": "^5.2.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -14156,6 +14179,60 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
+        },
+        "autoprefixer": {
+          "version": "9.6.1",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.1.tgz",
+          "integrity": "sha512-aVo5WxR3VyvyJxcJC3h4FKfwCQvQWb1tSI5VHNibddCVWrcD1NvlxEweg3TSgiPztMnWfjpy2FURKA2kvDE+Tw==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^4.6.3",
+            "caniuse-lite": "^1.0.30000980",
+            "chalk": "^2.4.2",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^7.0.17",
+            "postcss-value-parser": "^4.0.0"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.18",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
+              "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
+              }
+            },
+            "postcss-value-parser": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+              "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+              "dev": true
+            }
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "browserslist": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
+          "integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000989",
+            "electron-to-chromium": "^1.3.247",
+            "node-releases": "^1.1.29"
+          }
         },
         "camelcase": {
           "version": "4.1.0",
@@ -14174,6 +14251,12 @@
             "quick-lru": "^1.0.0"
           }
         },
+        "caniuse-lite": {
+          "version": "1.0.30000997",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000997.tgz",
+          "integrity": "sha512-BQLFPIdj2ntgBNWp9Q64LGUIEmvhKkzzHhUHR3CD5A9Lb7ZKF20/+sgadhFap69lk5XmK1fTUleDclaRFvgVUA==",
+          "dev": true
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -14183,13 +14266,34 @@
             "ms": "^2.1.1"
           }
         },
+        "electron-to-chromium": {
+          "version": "1.3.266",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.266.tgz",
+          "integrity": "sha512-UTuTZ4v8T0gLPHI7U75PXLQePWI65MTS3mckRrnLCkNljHvsutbYs+hn2Ua/RFul3Jt/L3Ht2rLP+dU/AlBfrQ==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
         "file-entry-cache": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-4.0.0.tgz",
-          "integrity": "sha512-AVSwsnbV8vH/UVbvgEhf3saVQXORNv0ZzSkvkhQIaia5Tia+JhGTaa/ePUSVoPHQyGayQNmYfkzFi3WZV5zcpA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+          "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
           "dev": true,
           "requires": {
             "flat-cache": "^2.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
           }
         },
         "find-up": {
@@ -14213,9 +14317,9 @@
           }
         },
         "get-stdin": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
           "dev": true
         },
         "globby": {
@@ -14239,25 +14343,25 @@
               "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
               "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
               "dev": true
+            },
+            "slash": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+              "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+              "dev": true
             }
           }
         },
-        "ignore": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.6.tgz",
-          "integrity": "sha512-/+hp3kUf/Csa32ktIaj0OlRqQxrgs30n62M90UBpNd9k+ENEch5S+hmbW3DtcJGz3sYFTh4F3A6fQ0q7KWsp4w==",
-          "dev": true
-        },
-        "import-lazy": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
-          "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
-          "dev": true
-        },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         },
         "load-json-file": {
@@ -14313,11 +14417,30 @@
             "yargs-parser": "^10.0.0"
           }
         },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.32",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.32.tgz",
+          "integrity": "sha512-VhVknkitq8dqtWoluagsGPn3dxTvN9fwgR59fV3D7sLBHe0JfDramsMI8n8mY//ccq/Kkrf8ZRHRpsyVZ3qw1A==",
+          "dev": true,
+          "requires": {
+            "semver": "^5.3.0"
+          }
         },
         "p-limit": {
           "version": "1.3.0",
@@ -14401,21 +14524,16 @@
           }
         },
         "resolve-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
         },
-        "slice-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-          "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "astral-regex": "^1.0.0",
-            "is-fullwidth-code-point": "^2.0.0"
-          }
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         },
         "specificity": {
           "version": "0.4.1",
@@ -14424,14 +14542,14 @@
           "dev": true
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
           }
         },
         "strip-ansi": {
@@ -14455,16 +14573,22 @@
           "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
           "dev": true
         },
-        "table": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
-          "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "ajv": "^6.9.1",
-            "lodash": "^4.17.11",
-            "slice-ansi": "^2.1.0",
-            "string-width": "^3.0.0"
+            "has-flag": "^3.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
           }
         },
         "trim-newlines": {
@@ -14494,9 +14618,9 @@
       }
     },
     "stylelint-config-primer": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-primer/-/stylelint-config-primer-8.0.0.tgz",
-      "integrity": "sha512-PRhlYe/6x1H9Lbfr/j/RFGT3vnUGmpvTATl01TVsy43tEAZVELzQRfSdgg18WuegJo3LSRkgM8rxbz0eX3Ucdw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-primer/-/stylelint-config-primer-8.1.0.tgz",
+      "integrity": "sha512-o15Bzr7FaX2+v+Lrby9s98jFjFYh8njo5rf2r5Z9q8+dSLdBtDrx9jeoQt31zmEgahta85aC6J31O0uKwVylsg==",
       "dev": true,
       "requires": {
         "stylelint-no-unsupported-browser-features": "^1.0.0",
@@ -14547,9 +14671,9 @@
       }
     },
     "stylelint-scss": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.10.1.tgz",
-      "integrity": "sha512-YnzYmcLd5DGGsjfoj44gArjo3TWhMWjS/ytfu+1HKtToZae5ditZOXHBmrgitsHvNk9mzp5WO3/PjA5IO1GpUw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.11.0.tgz",
+      "integrity": "sha512-2rA9hV8+ebvzGyRBQt/KCLDS1o11SEVRzOBlhAbqk4u1PVnWcjUhRhKIGGGWcyM4QE9t+YWivbnq6kjdeHg2Nw==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.15",
@@ -15302,12 +15426,20 @@
       }
     },
     "unist-util-find-all-after": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.2.tgz",
-      "integrity": "sha512-nDl79mKpffXojLpCimVXnxhlH/jjaTnDuScznU9J4jjsaUtBdDbxmlc109XtcqxY4SDO0SwzngsxxW8DIISt1w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.4.tgz",
+      "integrity": "sha512-CaxvMjTd+yF93BKLJvZnEfqdM7fgEACsIpQqz8vIj9CJnUb9VpyymFS3tg6TCtgrF7vfCJBF5jbT2Ox9CBRYRQ==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.0.0"
+        "unist-util-is": "^3.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+          "dev": true
+        }
       }
     },
     "unist-util-find-before": {
@@ -15344,61 +15476,59 @@
       }
     },
     "unist-util-select": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-2.0.0.tgz",
-      "integrity": "sha512-fRQqhrpgRIwdaeeZwbgDO84VyiyQP6cOcbzCao4saXuMuP3fLiWkssEI+o71OC2mASWqa9JEEYiGOV8EqpStPw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-2.0.2.tgz",
+      "integrity": "sha512-Yv5Z5ShMxv7Z9Dw175tKvOiRVXV4FrMHG778DSD9Z0jALgb3wAx9DoeInr3200QlYp71rYUXzzJdCb76xKdrCw==",
       "dev": true,
       "requires": {
         "css-selector-parser": "^1.1.0",
-        "debug": "^3.1.0",
         "not": "^0.1.0",
         "nth-check": "^1.0.1",
-        "unist-util-is": "^2.1.2",
+        "unist-util-is": "^3.0.0",
         "zwitch": "^1.0.3"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+        "unist-util-is": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
           "dev": true
         }
       }
     },
     "unist-util-stringify-position": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.0.tgz",
-      "integrity": "sha512-Uz5negUTrf9zm2ZT2Z9kdOL7Mr7FJLyq3ByqagUi7QZRVK1HnspVazvSqwHt73jj7APHtpuJ4K110Jm8O6/elw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.1.tgz",
+      "integrity": "sha512-Zqlf6+FRI39Bah8Q6ZnNGrEHUhwJOkHde2MHVk96lLyftfJJckaPslKgzhVcviXj8KcE9UJM9F+a4JEiBUTYgA==",
       "dev": true,
       "requires": {
         "@types/unist": "^2.0.2"
       }
     },
     "unist-util-visit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
-      "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
       "dev": true,
       "requires": {
         "unist-util-visit-parents": "^2.0.0"
       }
     },
     "unist-util-visit-parents": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
-      "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.1.2"
+        "unist-util-is": "^3.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+          "dev": true
+        }
       }
     },
     "universalify": {
@@ -16046,9 +16176,9 @@
       }
     },
     "zwitch": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.3.tgz",
-      "integrity": "sha512-aynRpmJDw7JIq6X4NDWJoiK1yVSiG57ArWSg4HLC1SFupX5/bo0Cf4jpX0ifwuzBfxpYBuNSyvMlWNNRuy3cVA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.4.tgz",
+      "integrity": "sha512-YO803/X+13GNaZB7fVopjvHH0uWQKgJkgKnU1YCjxShjKGVuN9PPHHW8g+uFDpkHpSTNi3rCMKMewIcbC1BAYg==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
   "scripts": {
     "fresh": "rm -rf node_modules; npm install",
     "dist": "script/dist.js",
-    "lint": "npm-run-all -s lint-css lint-js",
-    "lint-css": "stylelint --quiet --syntax scss src/**/*.scss",
-    "lint-js": "eslint script docs deprecations.js lib .storybook",
+    "lint": "npm-run-all -s stylelint eslint eslint-docs",
+    "stylelint": "stylelint --quiet src",
+    "eslint": "eslint script deprecations.js lib .storybook",
+    "eslint-docs": "eslint docs/{content,src,*.js}",
     "postpublish": "script/postpublish",
     "prepublishOnly": "script/prepublish",
     "publish-storybook": "script/publish-storybook",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@storybook/react": "5.0.11",
     "autoprefixer": "9.4.7",
     "code-blocks": "^1.1.0",
-    "colorette": "^1.0.7",
+    "colorette": "^1.1.0",
     "css-loader": "1.0.0",
     "cssstats": "3.3.0",
     "details-dialog-element": "^1.4.0",
@@ -70,13 +70,13 @@
     "semver": "5.7.1",
     "style-loader": "^0.18.2",
     "styled-components": "4.1.2",
-    "stylelint": "9.10.1",
-    "stylelint-config-primer": "^8.0.0",
+    "stylelint": "^10.1.0",
+    "stylelint-config-primer": "^8.1.0",
     "table": "5.2.3",
     "typographic-base": "^1.0.4",
     "unified": "^7.1.0",
-    "unist-util-select": "^2.0.0",
-    "unist-util-stringify-position": "^2.0.0",
-    "unist-util-visit": "^1.4.0"
+    "unist-util-select": "^2.0.2",
+    "unist-util-stringify-position": "^2.0.1",
+    "unist-util-visit": "^1.4.1"
   }
 }

--- a/script/lint-ci
+++ b/script/lint-ci
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+npm run stylelint -- --cache
+npx stylelint src --cache --report-needless-disables
+npm run eslint
+npm run eslint-docs

--- a/script/lint-ci
+++ b/script/lint-ci
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-npm run stylelint -- --cache
-npx stylelint src --cache --report-needless-disables
+npm run stylelint
+npm run stylelint -- --report-needless-disables
 npm run eslint
 npm run eslint-docs

--- a/script/remove-needless-disables
+++ b/script/remove-needless-disables
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+const stylelint = require('stylelint')
+const {readFileSync, writeFileSync} = require('fs')
+
+const files = process.argv.slice(2)
+if (files.length === 0) {
+  files.push('src/**/*.scss')
+}
+
+// we use an empty "marker" to delineate removed lines
+const REMOVED = `===REMOVED@${Date.now()}===`
+
+stylelint.lint({files, reportNeedlessDisables: true}).then(({needlessDisables}) => {
+  for (const {source, ranges} of needlessDisables) {
+    const lines = readFileSync(source, 'utf8').split(/\n/)
+    let offset = 0
+    for (const {start, unusedRule} of ranges) {
+      let index = start - 1
+      let line = lines[index]
+      let disable = parseDisableComment(line)
+      if (!disable) {
+        console.warn(`unable to parse disable on line ${start}: ${lines[start - 1]}; trying previous line...`)
+        index--
+        line = lines[index]
+        disable = parseDisableComment(line)
+        if (!disable) {
+          console.warn(`unable to parse disable on line ${index + 1}: ${lines}`)
+          continue
+        }
+      }
+
+      const rules = new Set(disable.rules)
+      rules.delete(unusedRule)
+
+      if (rules.size === 0) {
+        console.log(`- ${line}`)
+        lines[index] = REMOVED
+      } else {
+        const replacement = line.replace(disable.content, `${disable.type} ${Array.from(rules).join(', ')}`)
+        lines[index] = replacement
+        console.log(`- ${line}`)
+        console.log(`+ ${replacement}`)
+      }
+    }
+    const output = lines.filter(line => line !== REMOVED).join('\n')
+    writeFileSync(source, output, 'utf8')
+  }
+})
+
+function parseDisableComment(str) {
+  const match = str.match(/(stylelint-disable((-next)?-line)?)\s+(.+)$/)
+  return match
+    ? {
+        content: match[0],
+        type: match[1],
+        rules: match[4].split(/,\s+/)
+      }
+    : false
+}

--- a/src/labels/labels.scss
+++ b/src/labels/labels.scss
@@ -1,6 +1,4 @@
 // Needs refactoring
-// stylelint-disable selector-no-qualifying-type
-// stylelint-disable selector-max-type
 // Labels
 //
 // Use labels to add keyword tags or phrases to issues and pull requests. These

--- a/src/markdown/images.scss
+++ b/src/markdown/images.scss
@@ -1,5 +1,5 @@
 // Need to target base styles
-// stylelint-disable selector-max-compound-selectors, selector-no-qualifying-type, primer/selector-no-utility
+// stylelint-disable selector-max-compound-selectors, selector-no-qualifying-type
 // stylelint-disable selector-max-type
 .markdown-body {
   // Images & Stuff

--- a/src/marketing/utilities/filters.scss
+++ b/src/marketing/utilities/filters.scss
@@ -1,4 +1,3 @@
 .grayscale {
-  // stylelint-disable-next-line plugin/no-unsupported-browser-features
   filter: grayscale(100%);
 }

--- a/src/marketing/utilities/filters.scss
+++ b/src/marketing/utilities/filters.scss
@@ -1,4 +1,4 @@
-// stylelint-disable no-unsupported-browser-features
 .grayscale {
+  // stylelint-disable-next-line plugin/no-unsupported-browser-features
   filter: grayscale(100%);
 }

--- a/src/marketing/utilities/layout.scss
+++ b/src/marketing/utilities/layout.scss
@@ -1,4 +1,5 @@
 // Layout utilities
+// stylelint-disable block-opening-brace-space-before
 
 // Responsive utilities to position content
 // No utilities for sm and xl breakpoints

--- a/src/marketing/utilities/layout.scss
+++ b/src/marketing/utilities/layout.scss
@@ -1,5 +1,4 @@
 // Layout utilities
-// stylelint-disable block-opening-brace-space-before, primer/selector-no-utility, comment-empty-line-before
 
 // Responsive utilities to position content
 // No utilities for sm and xl breakpoints

--- a/src/marketing/utilities/margin.scss
+++ b/src/marketing/utilities/margin.scss
@@ -1,6 +1,5 @@
 // Margin spacer utilities for marketing
 // Utilities only added for y-direction margin (i.e. top & bottom)
-// stylelint-disable block-opening-brace-space-before, declaration-colon-space-before, primer/selector-no-utility, comment-empty-line-before
 
 @each $breakpoint, $variant in $responsive-variants {
   @include breakpoint($breakpoint) {

--- a/src/marketing/utilities/padding.scss
+++ b/src/marketing/utilities/padding.scss
@@ -1,6 +1,4 @@
 // Padding spacer utilities for marketing
-// stylelint-disable block-opening-brace-space-before, declaration-colon-space-before
-// stylelint-disable comment-empty-line-before
 
 @each $breakpoint, $variant in $responsive-variants {
   @include breakpoint($breakpoint) {

--- a/src/marketing/utilities/padding.scss
+++ b/src/marketing/utilities/padding.scss
@@ -1,22 +1,20 @@
 // Padding spacer utilities for marketing
+// stylelint-disable block-opening-brace-space-before, comment-empty-line-before
 
 @each $breakpoint, $variant in $responsive-variants {
   @include breakpoint($breakpoint) {
     @each $scale, $size in $marketing-spacers {
-
-      /* Set a #{$size} padding for all sides */
-      .p#{$variant}-#{$scale}  { padding: #{$size} !important; }
-
-      /* Set a #{$size} padding to the top */
+      // Set a #{$size} padding for all sides
+      .p#{$variant}-#{$scale}   { padding: #{$size} !important; }
+      // Set a #{$size} padding to the top
       .pt#{$variant}-#{$scale}  { padding-top: #{$size} !important; }
-      /* Set a #{$size} padding to the right */
+      // Set a #{$size} padding to the right
       .pr#{$variant}-#{$scale}  { padding-right: #{$size} !important; }
-      /* Set a #{$size} padding to the bottom */
+      // Set a #{$size} padding to the bottom
       .pb#{$variant}-#{$scale}  { padding-bottom: #{$size} !important; }
-      /* Set a #{$size} padding to the left */
+      // Set a #{$size} padding to the left
       .pl#{$variant}-#{$scale}  { padding-left: #{$size} !important; }
-
-      /* Set a #{$size} padding to the top & bottom */
+      // Set a #{$size} padding to the top & bottom
       .py#{$variant}-#{$scale} {
         padding-top: #{$size} !important;
         padding-bottom: #{$size} !important;

--- a/src/marketing/utilities/padding.scss
+++ b/src/marketing/utilities/padding.scss
@@ -1,5 +1,5 @@
 // Padding spacer utilities for marketing
-// stylelint-disable block-opening-brace-space-before, comment-empty-line-before
+// stylelint-disable block-opening-brace-space-before
 
 @each $breakpoint, $variant in $responsive-variants {
   @include breakpoint($breakpoint) {

--- a/src/support/mixins/buttons.scss
+++ b/src/support/mixins/buttons.scss
@@ -1,5 +1,3 @@
-// stylelint-disable block-closing-brace-newline-after
-
 // Button color generator for primary and themed buttons
 
 // New button hotness

--- a/src/support/mixins/buttons.scss
+++ b/src/support/mixins/buttons.scss
@@ -38,7 +38,8 @@
       box-shadow: none;
     }
 
-  } @else {
+  }
+  @else {
     &:focus,
     &.focus {
       box-shadow: 0 0 0 0.2em rgba($bg, 0.4);

--- a/src/support/variables/colors.scss
+++ b/src/support/variables/colors.scss
@@ -1,6 +1,5 @@
 @import "color-system.scss";
 // Color variables
-// stylelint-disable declaration-bang-space-before
 
 // State indicators.
 $status-pending:    desaturate($yellow-700, 15%) !default;

--- a/src/support/variables/layout.scss
+++ b/src/support/variables/layout.scss
@@ -1,5 +1,4 @@
 // Layout variables
-// stylelint-disable declaration-bang-space-before
 
 // These are our margin and padding utility spacers. The default step size we
 // use is 8px. This gives us a key of:

--- a/src/support/variables/misc.scss
+++ b/src/support/variables/misc.scss
@@ -1,5 +1,4 @@
 // Miscellaneous variables
-// stylelint-disable declaration-bang-space-before
 
 // Border size
 $border-width: 1px !default;

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -1,5 +1,4 @@
 // Typography variables
-// stylelint-disable declaration-bang-space-before
 
 // Heading sizes - mobile
 // h4-h6 remain the same size on both mobile & desktop

--- a/src/utilities/animations.scss
+++ b/src/utilities/animations.scss
@@ -1,5 +1,4 @@
 // This file contains reusable animations for github.
-// stylelint-disable primer/selector-no-utility
 
 /* Fade in an element */
 .anim-fade-in {

--- a/src/utilities/borders.scss
+++ b/src/utilities/borders.scss
@@ -1,5 +1,4 @@
 // Core border utilities
-// stylelint-disable primer/selector-no-utility
 // stylelint-disable block-opening-brace-space-before, comment-empty-line-before
 
 /* Add a gray border to the left and right */

--- a/src/utilities/box-shadow.scss
+++ b/src/utilities/box-shadow.scss
@@ -1,5 +1,4 @@
 // Box shadow utilities
-// stylelint-disable primer/selector-no-utility
 
 // Box shadows
 

--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -1,5 +1,4 @@
 // Color utilities
-// stylelint-disable primer/selector-no-utility
 // stylelint-disable block-opening-brace-space-before, comment-empty-line-before
 
 // background colors

--- a/src/utilities/details.scss
+++ b/src/utilities/details.scss
@@ -1,4 +1,3 @@
-// stylelint-disable primer/selector-no-utility
 // stylelint-disable selector-max-type
 
 .details-overlay[open] > summary::before {

--- a/src/utilities/flexbox.scss
+++ b/src/utilities/flexbox.scss
@@ -1,7 +1,5 @@
 // Flex utility classes
-// stylelint-disable primer/selector-no-utility
-// stylelint-disable block-opening-brace-space-after, block-opening-brace-space-before, comment-empty-line-before
-
+// stylelint-disable block-opening-brace-space-after, block-opening-brace-space-before
 @each $breakpoint, $variant in $responsive-variants {
   @include breakpoint($breakpoint) {
     // Flexbox classes

--- a/src/utilities/layout.scss
+++ b/src/utilities/layout.scss
@@ -1,5 +1,4 @@
 // Layout
-// stylelint-disable primer/selector-no-utility
 // stylelint-disable block-opening-brace-space-after, block-opening-brace-space-before, comment-empty-line-before
 
 // Loop through the breakpoint values

--- a/src/utilities/margin.scss
+++ b/src/utilities/margin.scss
@@ -1,5 +1,4 @@
 // Margin spacer utilities
-// stylelint-disable primer/selector-no-utility
 // stylelint-disable block-opening-brace-space-before, declaration-colon-space-before, comment-empty-line-before
 
 // Loop through the breakpoint values

--- a/src/utilities/padding.scss
+++ b/src/utilities/padding.scss
@@ -1,5 +1,4 @@
 // Padding spacer utilities
-// stylelint-disable primer/selector-no-utility
 // stylelint-disable block-opening-brace-space-before, declaration-colon-space-before, comment-empty-line-before
 
 // Responsive padding spacer utilities

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -1,4 +1,4 @@
-// stylelint-disable block-closing-brace-space-before, selector-list-comma-newline-after, comment-empty-line-before
+// stylelint-disable block-closing-brace-space-before, comment-empty-line-before
 
 // Type scale variables found in ../support/lib/variables.scss
 // $h00-size-mobile: 40px;
@@ -50,7 +50,12 @@
 .h6 { font-size: $h6-size !important; }
 
 // Heading utilities
-.h1, .h2, .h3, .h4, .h5, .h6 { font-weight: $font-weight-bold !important; }
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 { font-weight: $font-weight-bold !important; }
 
 // Type utilities that match type sale
 /* Set the font size to 26px */
@@ -189,6 +194,7 @@
   word-break: break-word !important;
   // this is for backwards compatibility with browsers that don't respect overflow-wrap
   word-wrap: break-word !important;
+  // stylelint-disable-next-line plugin/no-unsupported-browser-features
   overflow-wrap: break-word !important;
 }
 

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -194,7 +194,6 @@
   word-break: break-word !important;
   // this is for backwards compatibility with browsers that don't respect overflow-wrap
   word-wrap: break-word !important;
-  // stylelint-disable-next-line plugin/no-unsupported-browser-features
   overflow-wrap: break-word !important;
 }
 

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -1,4 +1,3 @@
-// stylelint-disable primer/selector-no-utility
 // stylelint-disable block-closing-brace-space-before, selector-list-comma-newline-after, comment-empty-line-before
 
 // Type scale variables found in ../support/lib/variables.scss

--- a/src/utilities/visibility-display.scss
+++ b/src/utilities/visibility-display.scss
@@ -1,7 +1,4 @@
 // Visibility and display utilities
-// stylelint-disable primer/selector-no-utility
-// stylelint-disable block-opening-brace-space-after, block-opening-brace-space-before, comment-empty-line-before
-
 $display-values: (
   block,
   flex,

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['stylelint-config-primer'],
+  syntax: 'scss',
+  rules: {
+    'primer/no-override': false
+  }
+}


### PR DESCRIPTION
This adds a call to `stylelint --report-needless-disables` to our lint test in Actions. I also bumped us to `stylelint@^10.1.0` order to get the better output that @muan added in https://github.com/stylelint/stylelint/pull/4071, and bumped a couple of other dev dependency versions while I was in there.

I've also removed the `--unsafe-perm` flags from calls to `npm` in our Actions workflows, since those were only necessary when we had `pre`- and `post`- scripts. (We seem to have gotten rid of all of those — maybe both after migrating from Next to Gatsby, then to Doctocat?)

### TODO
- [x] get this running and failing CI (see: [this failure](https://github.com/primer/css/runs/236320088#step:6:14))
- [x] fix the needless disables
- [x] get it passing again