### PR TITLE
Add SelectMenu selectors back

### DIFF
--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -409,3 +409,12 @@ $SelectMenu-max-height: 480px;
     -webkit-tap-highlight-color: rgba($gray-300, 0.5);
   }
 }
+
+// Unused selectors
+//
+// TODO: Depreate in next major release
+
+.SelectMenu-item + .SelectMenu-item { /* Unused */ }
+.SelectMenu-divider:first-child { /* Unused */ }
+.SelectMenu-divider:last-child { /* Unused */ }
+.SelectMenu--hasFilter .SelectMenu-item:last-child { /* Unused */ }


### PR DESCRIPTION
This is a follow-up to #900. It adds the removed selectors back. It's a workaround to pass the "test deprecations" check.

```console
𐄂 ".SelectMenu-item+.SelectMenu-item" has been removed, but was not listed in versionDeprecations['13.0.2']
𐄂 ".SelectMenu-divider:first-child" has been removed, but was not listed in versionDeprecations['13.0.2']
𐄂 ".SelectMenu-divider:last-child" has been removed, but was not listed in versionDeprecations['13.0.2']
𐄂 ".SelectMenu--hasFilter .SelectMenu-item:last-child" has been removed, but was not listed in versionDeprecations['13.0.2']
```

A "CSS comment" is used to pass the "block-no-empty" lint rule.