### PR TITLE
More SelectMenu improvements

### DIFF
--- a/deprecations.js
+++ b/deprecations.js
@@ -7,6 +7,16 @@ const versionDeprecations = {
   '14.0.0': [
     {
       selectors: [
+        '.SelectMenu-item+.SelectMenu-item',
+        '.SelectMenu-divider:first-child',
+        '.SelectMenu-divider:last-child',
+        '.SelectMenu--hasFilter .SelectMenu-item:last-child',
+        '.SelectMenu-item[aria-checked="true"] .SelectMenu-icon'
+      ],
+      message: `These selectors are deprecated and not used anymore.`
+    },
+    {
+      selectors: [
         '.flex-item-equal',
         '.flex-sm-item-equal',
         '.flex-md-item-equal',

--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -350,7 +350,7 @@ Also consider adding a `.SelectMenu-footer` at the bottom. It can be used for ad
 </details>
 
 <div class="d-sm-none"         style="height: 600px"> <!-- min height for < sm --> </div>
-<div class="d-none d-sm-block" style="height: 380px"> <!-- min height for > sm --> </div>
+<div class="d-none d-sm-block" style="height: 500px"> <!-- min height for > sm --> </div>
 ```
 
 ## Tabs
@@ -430,7 +430,7 @@ A `SelectMenu-message` can be used to show different kind of messages to a user.
       <div class="SelectMenu-list">
         <button class="SelectMenu-item" role="menuitem">Item 1</button>
         <button class="SelectMenu-item" role="menuitem">Item 2</button>
-        <div class="SelectMenu-message border-bottom border-top bg-red-0 text-red p-2">Message goes here</div>
+        <div class="SelectMenu-message bg-red-0 text-red p-2">Message goes here</div>
         <button class="SelectMenu-item" role="menuitem">Item 3</button>
       </div>
     </div>

--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -85,7 +85,7 @@ In case the Select Menu should be aligned to the right, use `SelectMenu right-0`
 
 ## Selected state
 
-Add a `.SelectMenu-icon .octicon-check` icon and it will show up when `aria-checked="true"` is set.
+If the `SelectMenu` should show a check icon for selected items, use the `SelectMenu-icon SelectMenu-icon--check` classes. It will make the check icon show when `aria-checked="true"` is set.
 
 ```html live
 <details class="details-reset details-overlay" open>
@@ -108,68 +108,28 @@ Add a `.SelectMenu-icon .octicon-check` icon and it will show up when `aria-chec
       </header>
       <div class="SelectMenu-list">
         <button class="SelectMenu-item" role="menuitemcheckbox" aria-checked="true">
-          <!-- <%= octicon "check", class: "SelectMenu-icon" %> -->
-          <svg
-            width="12"
-            height="16"
-            viewBox="0 0 12 16"
-            class="octicon octicon-check SelectMenu-icon"
-            aria-hidden="true"
-          >
-            <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" />
-          </svg>
+          <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
           Selected state
         </button>
         <button class="SelectMenu-item" role="menuitemcheckbox">
-          <!-- <%= octicon "check", class: "SelectMenu-icon" %> -->
-          <svg
-            width="12"
-            height="16"
-            viewBox="0 0 12 16"
-            class="octicon octicon-check SelectMenu-icon"
-            aria-hidden="true"
-          >
-            <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" />
-          </svg>
+          <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
           Default state
         </button>
         <button class="SelectMenu-item" role="menuitemcheckbox" aria-checked="true">
-          <!-- <%= octicon "check", class: "SelectMenu-icon" %> -->
-          <svg
-            width="12"
-            height="16"
-            viewBox="0 0 12 16"
-            class="octicon octicon-check SelectMenu-icon"
-            aria-hidden="true"
-          >
-            <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" />
-          </svg>
+          <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
           Selected state
         </button>
         <button class="SelectMenu-item" role="menuitemcheckbox">
-          <!-- <%= octicon "check", class: "SelectMenu-icon" %> -->
-          <svg
-            width="12"
-            height="16"
-            viewBox="0 0 12 16"
-            class="octicon octicon-check SelectMenu-icon"
-            aria-hidden="true"
-          >
-            <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" />
-          </svg>
+          <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
           Default state
         </button>
         <button class="SelectMenu-item" role="menuitemcheckbox">
-          <!-- <%= octicon "check", class: "SelectMenu-icon" %> -->
-          <svg
-            width="12"
-            height="16"
-            viewBox="0 0 12 16"
-            class="octicon octicon-check SelectMenu-icon"
-            aria-hidden="true"
-          >
-            <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" />
-          </svg>
+          <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
           Default state
         </button>
       </div>
@@ -183,7 +143,7 @@ Add a `.SelectMenu-icon .octicon-check` icon and it will show up when `aria-chec
 
 ## List items
 
-The list of items is arguably the most important subcomponent within the menu. Build them out of anchors, buttons, or just about any [interactive content](http://w3c.github.io/html/dom.html#interactive-content). List items are also customizable with options for avatars, additional icons, and multiple lines of text. Use utility classes like `mr-2`, `d-flex` or `float-right` in case more custom styling is needed.
+The list of items is arguably the most important subcomponent within the menu. Build them out of anchors, buttons, or just about any [interactive content](http://w3c.github.io/html/dom.html#interactive-content). List items are also customizable with options for avatars, additional icons, and multiple lines of text. Use utility classes in case more custom styling is needed.
 
 ```html live
 <details class="details-reset details-overlay" open>
@@ -207,6 +167,11 @@ The list of items is arguably the most important subcomponent within the menu. B
       <div class="SelectMenu-list">
         <button class="SelectMenu-item" role="menuitem">
           Text only
+        </button>
+        <button class="SelectMenu-item" role="menuitem">
+          <!-- <%= octicon "pin", class: "SelectMenu-icon" %> -->
+          <svg class="SelectMenu-icon octicon octicon-pin" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 1.2V2l.5 1L6 6H2.2c-.44 0-.67.53-.34.86L5 10l-4 5 5-4 3.14 3.14a.5.5 0 00.86-.34V10l3-4.5 1 .5h.8c.44 0 .67-.53.34-.86L10.86.86a.5.5 0 00-.86.34z"></path></svg>
+          With an icon
         </button>
         <button class="SelectMenu-item" role="menuitem">
           <img
@@ -247,7 +212,7 @@ The list of items is arguably the most important subcomponent within the menu. B
 </details>
 
 <div class="d-sm-none" style="height: 600px"><!-- min height for < sm --></div>
-<div class="d-none d-sm-block" style="height: 300px"><!-- min height for > sm --></div>
+<div class="d-none d-sm-block" style="height: 320px"><!-- min height for > sm --></div>
 ```
 
 ## Divider

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -199,11 +199,15 @@ $SelectMenu-max-height: 480px;
 
 // Icon
 //
-// The icon shown on the left of a list item. Typically a check icon.
+// Icon shown on the left of a list item.
 
 .SelectMenu-icon {
   width: $spacer-3; // fixed width to make sure following content aligns
   margin-right: $spacer-2;
+}
+
+// Check icon
+.SelectMenu-icon--check {
   visibility: hidden;
   transition: transform 0.12s cubic-bezier(0.5, 0.1, 1, 0.5), visibility 0s 0.12s linear;
   transform: scale(0);
@@ -357,7 +361,7 @@ $SelectMenu-max-height: 480px;
   font-weight: $font-weight-semibold;
   color: $text-gray-dark;
 
-  .SelectMenu-icon {
+  .SelectMenu-icon--check {
     visibility: visible;
     transition: transform 0.12s cubic-bezier(0, 0, 0.2, 1), visibility 0s linear;
     transform: scale(1);

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -204,6 +204,7 @@ $SelectMenu-max-height: 480px;
 .SelectMenu-icon {
   width: $spacer-3; // fixed width to make sure following content aligns
   margin-right: $spacer-2;
+  flex-shrink: 0;
 }
 
 // Check icon

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -3,6 +3,8 @@
 // selector-max-type is needed for body:not(.intent-mouse) to target keyboard only styles.
 // TODO: Introduce an additional .intent-keyboard class
 
+$SelectMenu-max-height: 480px;
+
 // Select Menu
 //
 // A more advanced menu with support for navigation, filtering, and more.
@@ -85,7 +87,7 @@
   @include breakpoint(sm) {
     width: 300px;
     height: auto;
-    max-height: 350px;
+    max-height: $SelectMenu-max-height;
     margin: $spacer-1 0 $spacer-3 0;
     font-size: $font-size-small;
     border: $border-width $border-style $border-gray-dark;
@@ -163,6 +165,7 @@
   position: relative;
   padding: 0;
   margin: 0;
+  margin-bottom: -$border-width; // Hides the last border in the list
   flex: auto;
   overflow-x: hidden;
   overflow-y: auto;
@@ -186,11 +189,7 @@
   cursor: pointer;
   background-color: $bg-white;
   border: 0;
-
-  & + & {
-    // Add a top border only if the above element also is a list item
-    border-top: $border-width $border-style $border-gray-light;
-  }
+  border-bottom: $border-width $border-style $border-gray-light;
 
   @include breakpoint(sm) {
     padding-top: $spacer-2;
@@ -274,6 +273,10 @@
 //
 // A container used to show different kinds of content. Like a message, a blankslate or the loading animation.
 
+.SelectMenu-message {
+  border-bottom: $border-width $border-style $border-gray-light;
+}
+
 .SelectMenu-message,
 .SelectMenu-blankslate,
 .SelectMenu-loading {
@@ -293,16 +296,7 @@
   font-weight: $font-weight-bold;
   color: $text-gray-light;
   background-color: $bg-gray;
-  border-top: $border;
-  border-bottom: $border;
-
-  &:first-child {
-    border-top: 0;
-  }
-
-  &:last-child {
-    border-bottom: 0;
-  }
+  border-bottom: $border-width $border-style $border-gray-light;
 }
 
 // Footer
@@ -310,6 +304,7 @@
 // A container at the bottom.
 
 .SelectMenu-footer {
+  z-index: 0; // Avoid top border from getting covered by the negative margin of the list
   padding: $spacer-2 $spacer-3;
   font-size: $font-size-small;
   color: $text-gray-light;
@@ -333,15 +328,9 @@
 
     @include breakpoint(sm) {
       height: auto;
-      max-height: 350px;
+      max-height: $SelectMenu-max-height;
       margin-top: $spacer-1;
     }
-  }
-
-  // Show bottom "border" for the last item when the list doesn't take up the whole height
-  .SelectMenu-item:last-child {
-    // stylelint-disable-next-line primer/box-shadow
-    box-shadow: 0 $border-width 0 lighten($gray-200, 3%);
   }
 }
 

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -3,7 +3,7 @@
 // selector-max-type is needed for body:not(.intent-mouse) to target keyboard only styles.
 // TODO: Introduce an additional .intent-keyboard class
 
-$SelectMenu-max-height: 480px;
+$SelectMenu-max-height: 480px !default;
 
 // Select Menu
 //
@@ -165,6 +165,7 @@ $SelectMenu-max-height: 480px;
   position: relative;
   padding: 0;
   margin: 0;
+  // stylelint-disable-next-line primer/spacing
   margin-bottom: -$border-width; // Hides the last border in the list
   flex: auto;
   overflow-x: hidden;


### PR DESCRIPTION
This adds a few more improvements to the `.SelectMenu `.

## TODO:

- [x] Fix top border
- [x] Increase max height
- [x] Introduce `.SelectMenu-icon--check`
- [x] Prevent shrinking of the icon
- [x] Deprecate the removed selectors

## TODO on dotcom:

- [ ] Add `SelectMenu-icon--check` to all check icons.
- [ ] The hack added in https://github.com/github/github/pull/127223/files#r336699321 could probably be removed again.

---

While testing the SelectMenu for the "branch picker" [more issues](https://github.com/github/github/pull/116285#issuecomment-531636279) came up:

## 1. When filtering, a top border is visible

When using `fuzzy-list` to filter, the DOM nodes get removed, but for the branch picker `display: none` is used. This has the effect that `:first/:last-child` can't be used anymore.

**Fix**: Use a `bottom-border` and then `margin-bottom: -1px` on the list to hide the "last" border https://github.com/primer/css/commit/fb3a10aa9a3249a5ef7c7b6945cd58bd1a4fd63d

Using `box-shadow` would be an alternative because it gets cut off within `overflow-y: auto;`. But it seems scrolling performance suffers.

Before | After
--- | ---
![Before](https://user-images.githubusercontent.com/378023/64933468-71501d00-d880-11e9-8934-76d9c81aa006.png) | ![After](https://user-images.githubusercontent.com/378023/64933467-70b78680-d880-11e9-8364-12b9ac75da1a.png)

## 2. The branch list is not as tall

**Fix**: Increase `max-height` a bit. https://github.com/primer/css/commit/279c87ebea72cef5fb9395bafb616439c0a35896

Before | After
--- | ---
![Before](https://user-images.githubusercontent.com/378023/64934246-65665a00-d884-11e9-8223-73165ba68bf3.png) | ![After](https://user-images.githubusercontent.com/378023/64934245-64cdc380-d884-11e9-8b20-253d75f4e671.png)

## 3. Introduce `.SelectMenu-icon--check`

Currently we use the `SelectMenu-icon` class specifically for the check icon to show if an item is selected or not. But there have been cases where a SelectMenu uses different icons unrelated to the selected/checked state. This PR:

- Makes the `.SelectMenu-icon` more generic. It only cares about the size and margin and can be used for **any** icon.
- Adds an additional `.SelectMenu-icon--check` modifier class that toggles based on the `aria-checked="true"` attribute.

```html
<button class="SelectMenu-item" role="menuitemcheckbox" aria-checked="true">
  <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %>
  Selectable item with a check icon
</button>
<button class="SelectMenu-item" role="menuitem">
  <%= octicon "pin", class: "SelectMenu-icon" %>
  Item with a pin icon
</button>
```

Above markup renders as:

![image](https://user-images.githubusercontent.com/378023/67858115-bd6ace80-fb5b-11e9-9bf5-a04719cfeff9.png)

It allows to mix check and other icons in the same list and have them aligned without fiddling with margin utilities.

#### Alternatives

Some alternative names instead of `SelectMenu-icon--check`:

- `.SelectMenu-icon--checked` might be confused for adding a state
- `.SelectMenu-icon--selected` same
- `.SelectMenu--showWhenChecked` could be used for anything, not just icons. People might expect it to be `display: none` by default, instead of `visibility: hidden`. But that would make the text jump.

## 4. Prevent shrinking of the icon

Happens when the text starts to wrap, see #961. A `flex-shrink-0` can be used, but might be convenient to "bake that in". 