### PR TITLE
🚚 Add Flash Banner

### DIFF
--- a/docs/content/components/alerts.md
+++ b/docs/content/components/alerts.md
@@ -120,3 +120,15 @@ A flash message that is full width and removes border and border radius.
   </div>
 </div>
 ```
+
+## Flash banner
+
+A flash message that is fixed positioned at the top of the page. Use for more global events where the content of the page is unknown.
+
+```html live
+<div class="ml-n3" style="min-height: 50px">
+  <div class="flash flash-banner">
+    Flash banner message.
+  </div>
+</div>
+```

--- a/src/alerts/flash.scss
+++ b/src/alerts/flash.scss
@@ -72,6 +72,18 @@
   border-radius: 0;
 }
 
+// A banner rendered at the top of the page.
+.flash-banner {
+  position: fixed;
+  top: 0;
+  z-index: 90;
+  width: 100%;
+  border-top: 0;
+  border-right: 0;
+  border-left: 0;
+  border-radius: 0;
+}
+
 // FIXME deprecate this
 .warning {
   padding: $em-spacer-5;


### PR DESCRIPTION
This moves the `.flash-banner` styles from [github/github](https://github.com/github/github/blob/7e2ae5bde5a862b896d9978fa1061b8f048b3b9f/app/assets/stylesheets/components/flash-banner.scss) to Primer CSS.

## TODO

- [x] Add styles
- [x] Add documentation

## TODO on .com

- [x] Remove `.stale-session-flash` https://github.com/github/github/pull/125613
- [ ] :fire: Remove [flash-banner.scss](https://github.com/github/github/blob/master/app/assets/stylesheets/components/flash-banner.scss).

---

Tracking https://github.com/github/design-systems/issues/684
