### PR TITLE
Introduce .flex-column-reverse utility

### DIFF
--- a/docs/content/utilities/flexbox.md
+++ b/docs/content/utilities/flexbox.md
@@ -9,7 +9,7 @@ bundle: utilities
 
 Flex utilities can be used to apply `flexbox` behaviors to elements by using utility classes.
 
- 
+
 
 ## Required reading
 
@@ -64,9 +64,10 @@ Use these classes to define the orientation of the main axis (`row` or `column`)
 #### CSS
 
 ```css
-.flex-row         { flex-direction: row; }
-.flex-row-reverse { flex-direction: row-reverse; }
-.flex-column      { flex-direction: column; }
+.flex-row            { flex-direction: row; }
+.flex-row-reverse    { flex-direction: row-reverse; }
+.flex-column         { flex-direction: column; }
+.flex-column-reverse { flex-direction: column-reverse; }
 ```
 
 #### Classes
@@ -76,11 +77,24 @@ Use these classes to define the orientation of the main axis (`row` or `column`)
 | `.flex-row` | The main axis runs left to right (default). |
 | `.flex-row-reverse` | The main axis runs right to left. |
 | `.flex-column` | The main axis runs top to bottom. |
+| `.flex-column-reverse` | The main axis runs bottom to top. |
 
 #### Example using `.flex-column`
 
 ```html live
 <div class="border d-flex flex-column">
+  <div class="p-5 border bg-gray-light">Item 1</div>
+  <div class="p-5 border bg-gray-light">Item 2</div>
+  <div class="p-5 border bg-gray-light">Item 3</div>
+</div>
+```
+
+#### Example using `.flex-column-reverse`
+
+This example uses the responsive variant `.flex-md-column-reverse` to override `.flex-column` Learn more about responsive flexbox utilities **[here](#responsive-flex-utilities)**.
+
+```html live
+<div class="border d-flex flex-column flex-md-column-reverse">
   <div class="p-5 border bg-gray-light">Item 1</div>
   <div class="p-5 border bg-gray-light">Item 2</div>
   <div class="p-5 border bg-gray-light">Item 3</div>

--- a/docs/content/utilities/flexbox.md
+++ b/docs/content/utilities/flexbox.md
@@ -91,7 +91,7 @@ Use these classes to define the orientation of the main axis (`row` or `column`)
 
 #### Example using `.flex-column-reverse`
 
-This example uses the responsive variant `.flex-md-column-reverse` to override `.flex-column` Learn more about responsive flexbox utilities **[here](#responsive-flex-utilities)**.
+This example uses the responsive variant `.flex-md-column-reverse` to override `.flex-column` Learn more about responsive flexbox utilities **[here](#responsive-flex-utilities)**. Keep in mind that it won't affect screen readers or navigating with the keyboard and it's advised to keep the markup in a logical source order.
 
 ```html live
 <div class="border d-flex flex-column flex-md-column-reverse">
@@ -115,7 +115,7 @@ This example uses the responsive variant `.flex-md-row` to override `.flex-colum
 
 #### Example using `.flex-row-reverse`
 
-This example uses the responsive variant `.flex-md-row-reverse` to override `.flex-column` Learn more about responsive flexbox utilities **[here](#responsive-flex-utilities)**.
+This example uses the responsive variant `.flex-md-row-reverse` to override `.flex-column` Learn more about responsive flexbox utilities **[here](#responsive-flex-utilities)**. Keep in mind that it won't affect screen readers or navigating with the keyboard and it's advised to keep the markup in a logical source order.
 
 ```html live
 <div class="border d-flex flex-column flex-md-row-reverse">

--- a/src/utilities/flexbox.scss
+++ b/src/utilities/flexbox.scss
@@ -6,9 +6,10 @@
   @include breakpoint($breakpoint) {
     // Flexbox classes
     // Container
-    .flex#{$variant}-row         { flex-direction: row !important; }
-    .flex#{$variant}-row-reverse { flex-direction: row-reverse !important; }
-    .flex#{$variant}-column      { flex-direction: column !important; }
+    .flex#{$variant}-row            { flex-direction: row !important; }
+    .flex#{$variant}-row-reverse    { flex-direction: row-reverse !important; }
+    .flex#{$variant}-column         { flex-direction: column !important; }
+    .flex#{$variant}-column-reverse { flex-direction: column-reverse !important; }
 
     .flex#{$variant}-wrap     { flex-wrap: wrap !important; }
     .flex#{$variant}-nowrap   { flex-wrap: nowrap !important; }


### PR DESCRIPTION
This adds the `.flex-column-reverse` utilities to complete the rest of the directional classes.

## TODO

- [x] Add utility
- [x] Add documentation

## Size changes

```
┌─────────────────────┬───────────┬─────┬───────────┬────────┬──────────┬─────────┬──────────────────────────────┐
│ name                │ selectors │   ± │ gzip size │      ± │ raw size │       ± │ path                         │
├─────────────────────┼───────────┼─────┼───────────┼────────┼──────────┼─────────┼──────────────────────────────┤
│ primer              │      3290 │ + 5 │    26.3 K │ + 24 B │ 165.73 K │ + 322 B │ dist/primer.css              │
│ core                │      2206 │ + 5 │   17.52 K │ + 23 B │  111.2 K │ + 322 B │ dist/core.css                │
│ utilities           │      1357 │ + 5 │    8.61 K │ + 24 B │  65.55 K │ + 322 B │ dist/utilities.css           │
```

Closes #915

/cc @primer/ds-core
