### PR TITLE
Update unpkg CDN links

### DIFF
--- a/docs/content/getting-started/index.md
+++ b/docs/content/getting-started/index.md
@@ -100,5 +100,5 @@ Don't forget to add the compiled CSS to the `<head>` section of your page.
 You won't need to install any node modules or Sass compilers for a static site; you can use the built CSS. The best thing to do is to [download the built CSS](https://unpkg.com/@primer/css/dist/primer.css) from the [unpkg.com](https://unpkg.com) and host it yourself. If that's not an option, you can include a CDN link in your HTML:
 
 ```html
-<link href="https://unpkg.com/primer/build/build.css" rel="stylesheet" />
+<link href="https://unpkg.com/@primer/css/dist/primer.css" rel="stylesheet" />
 ```

--- a/docs/content/tools/prototyping.md
+++ b/docs/content/tools/prototyping.md
@@ -19,7 +19,7 @@ This method requires no dev environment set up and is useful for when you want t
   <head>
     <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="https://unpkg.com/primer/build/build.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@primer/css/dist/primer.css" />
   </head>
   <body></body>
 </html>


### PR DESCRIPTION
This updates the `unpkg.com` URLs for:

- [x] [Getting Started](https://primer.style/css/getting-started#using-primer-css-on-a-static-site)
- [x] [Prototyping](https://primer.style/css/tools/prototyping)

Fixes the issue where the old `https://unpkg.com/primer/build/build.css` is stuck at Primer CSS `11.0.0`. 

---

Reported by @keeran in Slack. 🙇 ❤️ 