### PR TITLE
Fix Box--overlay example

### DIFF
--- a/docs/content/components/box-overlay.md
+++ b/docs/content/components/box-overlay.md
@@ -12,8 +12,6 @@ Use the `Box--overlay` with the `<details>` and [`<details-dialog>`](https://git
 
 Box overlays come in three widths. The default `Box--overlay` is 440px wide, `Box-overlay--narrow` is 320px wide, and `Box-overlay--wide` is 640px wide.
 
-**Note:** `position: fixed` has been disabled in this example
-
 ```html live
 
 <details class="details-reset details-overlay details-overlay-dark">

--- a/docs/content/components/box-overlay.md
+++ b/docs/content/components/box-overlay.md
@@ -14,13 +14,15 @@ Box overlays come in three widths. The default `Box--overlay` is 440px wide, `Bo
 
 **Note:** `position: fixed` has been disabled in this example
 
-```erb
+```html live
+
 <details class="details-reset details-overlay details-overlay-dark">
   <summary class="btn" aria-haspopup="dialog">Open dialog</summary>
   <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
     <div class="Box-header">
       <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog>
-        <%= octicon "x" %>
+        <!-- <%= octicon "x" %> -->
+        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"></path></svg>
       </button>
       <h3 class="Box-title">Box title</h3>
     </div>

--- a/docs/content/components/box-overlay.md
+++ b/docs/content/components/box-overlay.md
@@ -52,6 +52,10 @@ Box overlays come in three widths. The default `Box--overlay` is 440px wide, `Bo
     </div>
   </details-dialog>
 </details>
+
+<!-- Temporary overrides (don't use in production) -->
+<style> .frame-example { min-height: 500px; } </style>
+<link href="https://unpkg.com/@github/details-dialog-element/index.css" rel="stylesheet" />
 ```
 
 In github.com there is a shared dialog partial. You will only have to pass in the modal content:

--- a/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
@@ -7,7 +7,7 @@ function LivePreviewWrapper({children}) {
     <Frame>
       <link rel="stylesheet" href="https://github.com/site/assets/styleguide.css" />
       <style>{primerStyles}</style>
-      <div className="p-3">{children}</div>
+      <div className="frame-example p-3">{children}</div>
     </Frame>
   )
 }


### PR DESCRIPTION
This fixes the `.Box--overlay` [example](https://primer.style/css/components/box-overlay) by:

- [x] using `<svg>` for the octicon.
- [x] linking the [details-dialog-element](https://github.com/github/details-dialog-element/blob/0869b97631e2cce9726ba2eca5d49e7433ea59b1/index.css) styles that `.Box--overlay` depends on.
- [x] adding a `.frame-example` class that then gets used to customize the example. It adds some `min-height` so the dialog doesn't get cut off. It lets us avoid using extra wrapper elements that then might get copy&pasted for use in production. It still shows up in the code part, but it's more separated at the bottom with a warning.

![image](https://user-images.githubusercontent.com/378023/66629819-d4459180-ec3d-11e9-963c-dd742a17392d.png)

---

Closes https://github.com/primer/css/issues/936 (for now)

