### PR TITLE
Update contributing guide for a general audience

### DIFF
--- a/docs/content/getting-started/contributing.md
+++ b/docs/content/getting-started/contributing.md
@@ -39,7 +39,7 @@ Many of the same questions can be applied to objects and utilities, however the 
 
 It's usually better to open an issue before investing time in spiking out a new pattern. This gives the design systems team a heads up and allows other designers to share thoughts. Here's an outline of what's helpful to include in a new style issue:
 
-1. What the pattern is and how it's being used across the site - post screenshots and urls where possible. If you need help identifying where the pattern is being used, call that out here and cc the relevant team and/or cc `@product-design` to help.
+1. What the pattern is and how it's being used across the site - post screenshots and urls where possible. If you need help identifying where the pattern is being used, call that out in the issue.
 2. Why you think a new pattern is needed (this should answer the relevant questions above).
 3. If you intend to work on these new styles yourself, let us know what your timeline and next steps are. If you need help and this is a dependency for shipping another project, please make that clear here and what the timeline is.
 4. Add the `type: new styles` label, or `type: refactor` where appropriate.

--- a/docs/content/getting-started/contributing.md
+++ b/docs/content/getting-started/contributing.md
@@ -9,7 +9,7 @@ description: Guidelines for contributing to GitHub's CSS
 
 [Components](/css/components) are frequently used visual patterns we've abstracted into a set of convenient styles, that would be otherwise difficult to achieve with utilities and layout objects.
 
-Making a decision on whether new components should be added is done on a case by case basis. It's not always easy to make that decision but here are some questions you should ask yourself before moving forward with a pull request. The design systems team will help you make this decision.
+Making a decision on whether new components should be added is done on a case by case basis. It's not always easy to make that decision but here are some questions you should ask yourself before moving forward with a pull request. 
 
 - How often is this pattern used across the site?
 - Could these styles be achieved with existing components, objects, and utilities?
@@ -62,7 +62,7 @@ New styles we add should be used in as many places as makes sense to in producti
 
 If you get to this step you've helped contribute to a style guide that many of your colleagues use on a daily basis, you've contributed to an open source project that's referenced and used by many others, and you've helped improve the usability and consistency of GitHub for our users. Thank you!
 
-Let the [design systems team](https://github.com/github/design-systems) know if we can improve these guidelines and make following this process any easier.
+[Please open an issue](#step-1-open-an-issue) if we can improve these guidelines and make following this process any easier.
 
 ## Documentation structure
 

--- a/docs/content/getting-started/contributing.md
+++ b/docs/content/getting-started/contributing.md
@@ -96,4 +96,4 @@ Check out Doctocat's [live code](https://primer.style/doctocat/usage/live-code) 
 
 Primer CSS follows [semantic versioning](http://semver.org/) conventions. This helps others know when a change is a patch, minor, or breaking change.
 
-To understand what choice to make, you'll need to understand semver and know if one of the changes shown is a major, minor, or patch. Semver is confusing at first, so I recommend reviewing [semver](http://semver.org/) and/or ask in [#design-systems](https://github.slack.com/archives/design-systems) or and experienced open-source contributor.
+To understand what choice to make, you'll need to understand semver and know if one of the changes shown is a major, minor, or patch. Semver is confusing at first, so we recommend reviewing [semver](http://semver.org/) and/or asking the team by [opening an issue](#step-1-open-an-issue).

--- a/docs/content/getting-started/contributing.md
+++ b/docs/content/getting-started/contributing.md
@@ -5,6 +5,8 @@ description: Guidelines for contributing to GitHub's CSS
 
 ## Decision process for adding new styles
 
+While this contributing guide is for GitHub employees, all contributions from the community are welcome.
+
 ### Components
 
 [Components](/css/components) are frequently used visual patterns we've abstracted into a set of convenient styles, that would be otherwise difficult to achieve with utilities and layout objects.


### PR DESCRIPTION
This PR updates the repo's contributing guide for a general audience.

Fixes #940.

> Finally, tell us more about the change here, in the description.

I'm interested in reducing confusion for first-time and existing contributors who happen to come across this guide. 😎 

/cc @primer/ds-core
