### PR TITLE
actions/setup-node: "version" -> "node-version"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          version: 11
+          node-version: 11
       - name: install
         run: npm install
       - name: lint


### PR DESCRIPTION
I noticed a check annotation today warning us about the `version` option in `actions/setup-node` being deprecated in favor of `node-version`. This changes it from the former to the latter.