### PR TITLE
Add Diffstat component

### DIFF
--- a/docs/content/components/labels.md
+++ b/docs/content/components/labels.md
@@ -155,3 +155,26 @@ Counters can also be used in `Box` headers to indicate the number of items in a 
   </ul>
 </div>
 ```
+
+## Diffstat
+
+Diffstats show how many deletions or additions a diff has. It's typically a row of 5 blocks that get colored with green or red.
+
+```html live
+<span class="diffstat tooltipped tooltipped-e" aria-label="6 changes: 3 additions &amp; 3 deletions">
+  6
+  <span class="diffstat-block-added"></span><span class="diffstat-block-added"></span><span class="diffstat-block-deleted"></span><span class="diffstat-block-deleted"></span><span class="diffstat-block-neutral"></span>
+</span>
+```
+
+Use the `text-green` and `text-red` utilities to add addtitional information about the size of the diff.
+
+```html live
+<span class="diffstat">
+    <span class="text-green">+7</span>
+    <span class="text-red">−2</span>
+    <span class="tooltipped tooltipped-e" aria-label="9 lines changed">
+      <span class="diffstat-block-added"></span><span class="diffstat-block-added"></span><span class="diffstat-block-added"></span><span class="diffstat-block-deleted"></span><span class="diffstat-block-neutral"></span>
+    </span>
+</span>
+```

--- a/src/labels/diffstat.scss
+++ b/src/labels/diffstat.scss
@@ -24,7 +24,7 @@
 }
 
 .diffstat-block-added {
-  background-color: $green-400;
+  background-color: darken($green-400, 5%);
 }
 
 .diffstat-block-neutral {

--- a/src/labels/diffstat.scss
+++ b/src/labels/diffstat.scss
@@ -20,7 +20,7 @@
 }
 
 .diffstat-block-deleted {
-  background-color: $red-600;
+  background-color: $bg-diffstat-deleted;
 }
 
 .diffstat-block-added {
@@ -28,5 +28,5 @@
 }
 
 .diffstat-block-neutral {
-  background-color: $gray-300;
+  background-color: $bg-diffstat-neutral;
 }

--- a/src/labels/diffstat.scss
+++ b/src/labels/diffstat.scss
@@ -16,21 +16,17 @@
   display: inline-block;
   width: $spacer-2;
   height: $spacer-2;
-  // stylelint-disable-next-line primer/variables
   margin-left: 1px;
 }
 
 .diffstat-block-deleted {
-  // stylelint-disable-next-line primer/variables
   background-color: $red-600;
 }
 
 .diffstat-block-added {
-  // stylelint-disable-next-line primer/variables
-  background-color: darken($green-400, 5%);
+  background-color: $green-400;
 }
 
 .diffstat-block-neutral {
-  // stylelint-disable-next-line primer/variables
   background-color: $gray-300;
 }

--- a/src/labels/diffstat.scss
+++ b/src/labels/diffstat.scss
@@ -1,0 +1,36 @@
+// diffstat
+//
+// Green/red blocks showing additions and deletions
+
+.diffstat {
+  font-size: $h6-size;
+  font-weight: $font-weight-bold;
+  color: $text-gray;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.diffstat-block-deleted,
+.diffstat-block-added,
+.diffstat-block-neutral {
+  display: inline-block;
+  width: $spacer-2;
+  height: $spacer-2;
+  // stylelint-disable-next-line primer/variables
+  margin-left: 1px;
+}
+
+.diffstat-block-deleted {
+  // stylelint-disable-next-line primer/variables
+  background-color: $red-600;
+}
+
+.diffstat-block-added {
+  // stylelint-disable-next-line primer/variables
+  background-color: darken($green-400, 5%);
+}
+
+.diffstat-block-neutral {
+  // stylelint-disable-next-line primer/variables
+  background-color: $gray-300;
+}

--- a/src/labels/diffstat.scss
+++ b/src/labels/diffstat.scss
@@ -24,7 +24,7 @@
 }
 
 .diffstat-block-added {
-  background-color: darken($green-400, 5%);
+  background-color: $bg-diffstat-added;
 }
 
 .diffstat-block-neutral {

--- a/src/labels/index.scss
+++ b/src/labels/index.scss
@@ -2,3 +2,4 @@
 @import "./labels.scss";
 @import "./states.scss";
 @import "./counters.scss";
+@import "./diffstat.scss";

--- a/src/support/variables/colors.scss
+++ b/src/support/variables/colors.scss
@@ -54,6 +54,11 @@ $bg-yellow:         $yellow-500 !default;
 $bg-yellow-light:   $yellow-200 !default;
 $bg-yellow-dark:    $yellow-700 !default;
 
+// diffstat background colors
+$bg-diffstat-added: darken($green-400, 5%) !default;
+$bg-diffstat-deleted: $red-600 !default;
+$bg-diffstat-neutral: $gray-300 !default;
+
 // Text colors
 $text-blue:         $blue-500 !default;
 $text-gray-dark:    $gray-900 !default;

--- a/src/support/variables/misc.scss
+++ b/src/support/variables/misc.scss
@@ -37,3 +37,8 @@ $max_tab_size: 12;
 $form-control-shadow: inset 0 1px 2px rgba($black, 0.075);
 $btn-input-focus-shadow: 0 0 0 0.2em rgba($blue, 0.3);
 $btn-active-shadow: inset 0 0.15em 0.3em $black-fade-15;
+
+// diffstat
+$bg-diffstat-added: darken($green-400, 5%);
+$bg-diffstat-deleted: $red-600;
+$bg-diffstat-neutral: $gray-300;

--- a/src/support/variables/misc.scss
+++ b/src/support/variables/misc.scss
@@ -37,8 +37,3 @@ $max_tab_size: 12;
 $form-control-shadow: inset 0 1px 2px rgba($black, 0.075);
 $btn-input-focus-shadow: 0 0 0 0.2em rgba($blue, 0.3);
 $btn-active-shadow: inset 0 0.15em 0.3em $black-fade-15;
-
-// diffstat
-$bg-diffstat-added: darken($green-400, 5%);
-$bg-diffstat-deleted: $red-600;
-$bg-diffstat-neutral: $gray-300;


### PR DESCRIPTION
This adds the `.diffstat` component to Primer CSS.

✨ [Docs Preview](https://primer-css-git-diffstat.primer.now.sh/css/components/labels#diffstat)

Simple | With more details
--- | ---
![Screen Shot 2019-10-21 at 1 37 27 PM](https://user-images.githubusercontent.com/378023/67177114-fbebe500-f407-11e9-8cdf-f9d774ac46de.png) | ![Screen Shot 2019-10-21 at 1 37 44 PM](https://user-images.githubusercontent.com/378023/67177115-fc847b80-f407-11e9-8694-f054e6d91789.png)

## TODO

- [x] Add styles from dotcom
- [x] Add documentation
- [ ] ~~Maybe tweak colors to not use `darken()`~~

## TODO on dotcom

- [x] Rename and refactor https://github.com/github/github/pull/127113
- [ ] Remove `diffstat.scss`

/cc @primer/ds-core
