### PR TITLE
Add IssueLabel component

### DIFF
--- a/docs/content/components/labels.md
+++ b/docs/content/components/labels.md
@@ -62,6 +62,25 @@ Use `Label--outline-green` in combination with `Label--outline` to communicate a
 <span title="Label: green outline label" class="Label Label--outline Label--outline-green">green outlined label</span>
 ```
 
+## Issue Labels
+
+Issue Labels are used for adding labels to issues and pull requests. They also come with emoji support.
+
+```html live
+<span class="IssueLabel bg-blue text-white mr-1" title="Label: good first issue">good first issue</span>
+<span class="IssueLabel bg-red text-white mr-1" title="Label: bug">bug 🐛</span>
+<span class="IssueLabel bg-green text-white" title="Label: bug">help wanted</span>
+```
+
+If an Issue Label needs to be bigger, add the `.IssueLabel--big` modifier.
+
+```html live
+<span class="IssueLabel IssueLabel--big bg-blue text-white mr-1" title="Label: good first issue">good first issue</span>
+<span class="IssueLabel IssueLabel--big bg-red text-white mr-1" title="Label: bug">bug 🐛</span>
+<span class="IssueLabel IssueLabel--big bg-green text-white" title="Label: bug">help wanted</span>
+```
+
+
 ## States
 
 Use state labels to inform users of an items status. States are large labels with bolded text. The default state has a gray background.

--- a/src/labels/index.scss
+++ b/src/labels/index.scss
@@ -1,4 +1,5 @@
 @import "../support/index.scss";
+@import "./issue-labels.scss";
 @import "./labels.scss";
 @import "./states.scss";
 @import "./counters.scss";

--- a/src/labels/issue-labels.scss
+++ b/src/labels/issue-labels.scss
@@ -2,15 +2,11 @@
 
 .IssueLabel {
   height: 20px;
-  // stylelint-disable-next-line primer/variables
   padding: 0.15em $spacer-1;
   font-size: $h6-size;
   font-weight: $font-weight-bold;
-  // stylelint-disable-next-line primer/variables
   line-height: 15px;
-  // stylelint-disable-next-line primer/variables
   border-radius: 2px;
-  // stylelint-disable-next-line primer/variables
   box-shadow: inset 0 -1px 0 rgba($black, 0.12);
 
   .g-emoji {
@@ -35,7 +31,6 @@
 
   .g-emoji {
     display: inline-block;
-    // stylelint-disable-next-line primer/variables
     margin-top: -1px;
   }
 

--- a/src/labels/issue-labels.scss
+++ b/src/labels/issue-labels.scss
@@ -1,0 +1,45 @@
+// Issue Labels
+
+.IssueLabel {
+  height: 20px;
+  // stylelint-disable-next-line primer/variables
+  padding: 0.15em $spacer-1;
+  font-size: $h6-size;
+  font-weight: $font-weight-bold;
+  // stylelint-disable-next-line primer/variables
+  line-height: 15px;
+  // stylelint-disable-next-line primer/variables
+  border-radius: 2px;
+  // stylelint-disable-next-line primer/variables
+  box-shadow: inset 0 -1px 0 rgba($black, 0.12);
+
+  .g-emoji {
+    position: relative;
+    top: -0.05em;
+    display: inline-block;
+    font-size: 1em;
+    line-height: $lh-condensed-ultra;
+  }
+
+  &:hover {
+    text-decoration: none;
+  }
+}
+
+.IssueLabel--big {
+  padding: $spacer-1 $spacer-2;
+  font-size: $h5-size;
+  font-weight: $font-weight-bold;
+  border-radius: $border-radius;
+  transition: opacity 0.2s linear;
+
+  .g-emoji {
+    display: inline-block;
+    // stylelint-disable-next-line primer/variables
+    margin-top: -1px;
+  }
+
+  &:hover {
+    opacity: 0.85;
+  }
+}


### PR DESCRIPTION
This adds the `.IssueLabel` component to Primer CSS.

<img width="306" alt="Screen Shot 2019-10-22 at 10 21 36 PM" src="https://user-images.githubusercontent.com/378023/67289922-56756600-f51a-11e9-8c4b-580226802444.png">

## TODO

- [x] Add styles
- [x] Add documentation
- [ ] ~~Refactor?~~

## TODO on dotcom

- [ ] Remove [components/labels.scss](https://github.com/github/github/blob/6d7f52782b42b821e98200065e6b18c0548b8ccc/app/assets/stylesheets/components/labels.scss)

/cc @primer/ds-core
