### PR TITLE
SelectMenu icon improvements

### DIFF
--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -85,7 +85,7 @@ In case the Select Menu should be aligned to the right, use `SelectMenu right-0`
 
 ## Selected state
 
-Add a `.SelectMenu-icon .octicon-check` icon and it will show up when `aria-checked="true"` is set.
+If the `SelectMenu` should show a check icon for selected items, use the `SelectMenu-icon SelectMenu-icon--check` classes. It will make the check icon show when `aria-checked="true"` is set.
 
 ```html live
 <details class="details-reset details-overlay" open>
@@ -108,68 +108,28 @@ Add a `.SelectMenu-icon .octicon-check` icon and it will show up when `aria-chec
       </header>
       <div class="SelectMenu-list">
         <button class="SelectMenu-item" role="menuitemcheckbox" aria-checked="true">
-          <!-- <%= octicon "check", class: "SelectMenu-icon" %> -->
-          <svg
-            width="12"
-            height="16"
-            viewBox="0 0 12 16"
-            class="octicon octicon-check SelectMenu-icon"
-            aria-hidden="true"
-          >
-            <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" />
-          </svg>
+          <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
           Selected state
         </button>
         <button class="SelectMenu-item" role="menuitemcheckbox">
-          <!-- <%= octicon "check", class: "SelectMenu-icon" %> -->
-          <svg
-            width="12"
-            height="16"
-            viewBox="0 0 12 16"
-            class="octicon octicon-check SelectMenu-icon"
-            aria-hidden="true"
-          >
-            <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" />
-          </svg>
+          <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
           Default state
         </button>
         <button class="SelectMenu-item" role="menuitemcheckbox" aria-checked="true">
-          <!-- <%= octicon "check", class: "SelectMenu-icon" %> -->
-          <svg
-            width="12"
-            height="16"
-            viewBox="0 0 12 16"
-            class="octicon octicon-check SelectMenu-icon"
-            aria-hidden="true"
-          >
-            <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" />
-          </svg>
+          <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
           Selected state
         </button>
         <button class="SelectMenu-item" role="menuitemcheckbox">
-          <!-- <%= octicon "check", class: "SelectMenu-icon" %> -->
-          <svg
-            width="12"
-            height="16"
-            viewBox="0 0 12 16"
-            class="octicon octicon-check SelectMenu-icon"
-            aria-hidden="true"
-          >
-            <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" />
-          </svg>
+          <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
           Default state
         </button>
         <button class="SelectMenu-item" role="menuitemcheckbox">
-          <!-- <%= octicon "check", class: "SelectMenu-icon" %> -->
-          <svg
-            width="12"
-            height="16"
-            viewBox="0 0 12 16"
-            class="octicon octicon-check SelectMenu-icon"
-            aria-hidden="true"
-          >
-            <path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" />
-          </svg>
+          <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
           Default state
         </button>
       </div>
@@ -183,7 +143,7 @@ Add a `.SelectMenu-icon .octicon-check` icon and it will show up when `aria-chec
 
 ## List items
 
-The list of items is arguably the most important subcomponent within the menu. Build them out of anchors, buttons, or just about any [interactive content](http://w3c.github.io/html/dom.html#interactive-content). List items are also customizable with options for avatars, additional icons, and multiple lines of text. Use utility classes like `mr-2`, `d-flex` or `float-right` in case more custom styling is needed.
+The list of items is arguably the most important subcomponent within the menu. Build them out of anchors, buttons, or just about any [interactive content](http://w3c.github.io/html/dom.html#interactive-content). List items are also customizable with options for avatars, additional icons, and multiple lines of text. Use utility classes in case more custom styling is needed.
 
 ```html live
 <details class="details-reset details-overlay" open>
@@ -207,6 +167,11 @@ The list of items is arguably the most important subcomponent within the menu. B
       <div class="SelectMenu-list">
         <button class="SelectMenu-item" role="menuitem">
           Text only
+        </button>
+        <button class="SelectMenu-item" role="menuitem">
+          <!-- <%= octicon "pin", class: "SelectMenu-icon" %> -->
+          <svg class="SelectMenu-icon octicon octicon-pin" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 1.2V2l.5 1L6 6H2.2c-.44 0-.67.53-.34.86L5 10l-4 5 5-4 3.14 3.14a.5.5 0 00.86-.34V10l3-4.5 1 .5h.8c.44 0 .67-.53.34-.86L10.86.86a.5.5 0 00-.86.34z"></path></svg>
+          With an icon
         </button>
         <button class="SelectMenu-item" role="menuitem">
           <img
@@ -247,7 +212,7 @@ The list of items is arguably the most important subcomponent within the menu. B
 </details>
 
 <div class="d-sm-none" style="height: 600px"><!-- min height for < sm --></div>
-<div class="d-none d-sm-block" style="height: 300px"><!-- min height for > sm --></div>
+<div class="d-none d-sm-block" style="height: 320px"><!-- min height for > sm --></div>
 ```
 
 ## Divider

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -3,7 +3,6 @@
 // selector-max-type is needed for body:not(.intent-mouse) to target keyboard only styles.
 // TODO: Introduce an additional .intent-keyboard class
 
-$SelectMenu-border: $border-width $border-style lighten($gray-200, 3%);
 $SelectMenu-max-height: 480px;
 
 // Select Menu
@@ -188,7 +187,7 @@ $SelectMenu-max-height: 480px;
   cursor: pointer;
   background-color: $bg-white;
   border: 0;
-  border-bottom: $SelectMenu-border;
+  border-bottom: $border-width $border-style $border-gray-light;
 
   @include breakpoint(sm) {
     padding-top: $spacer-2;
@@ -270,7 +269,7 @@ $SelectMenu-max-height: 480px;
 // A container used to show different kinds of content. Like a message, a blankslate or the loading animation.
 
 .SelectMenu-message {
-  border-bottom: $SelectMenu-border;
+  border-bottom: $border-width $border-style $border-gray-light;
 }
 
 .SelectMenu-message,
@@ -292,7 +291,7 @@ $SelectMenu-max-height: 480px;
   font-weight: $font-weight-bold;
   color: $text-gray-light;
   background-color: $gray-100;
-  border-bottom: $SelectMenu-border;
+  border-bottom: $border-width $border-style $border-gray-light;
 }
 
 // Footer

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -197,11 +197,15 @@ $SelectMenu-max-height: 480px;
 
 // Icon
 //
-// The icon shown on the left of a list item. Typically a check icon.
+// Icon shown on the left of a list item.
 
 .SelectMenu-icon {
   width: $spacer-3; // fixed width to make sure following content aligns
   margin-right: $spacer-2;
+}
+
+// Check icon
+.SelectMenu-icon--check {
   visibility: hidden;
   transition: transform 0.12s cubic-bezier(0.5, 0.1, 1, 0.5), visibility 0s 0.12s linear;
   transform: scale(0);
@@ -352,7 +356,7 @@ $SelectMenu-max-height: 480px;
   font-weight: $font-weight-semibold;
   color: $text-gray-dark;
 
-  .SelectMenu-icon {
+  .SelectMenu-icon--check {
     visibility: visible;
     transition: transform 0.12s cubic-bezier(0, 0, 0.2, 1), visibility 0s linear;
     transform: scale(1);

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -202,6 +202,7 @@ $SelectMenu-max-height: 480px;
 .SelectMenu-icon {
   width: $spacer-3; // fixed width to make sure following content aligns
   margin-right: $spacer-2;
+  flex-shrink: 0;
 }
 
 // Check icon


### PR DESCRIPTION
This is on top of #922 and adds even more improvements. YAY :zany:

## 1. Introduce `.SelectMenu-icon--check`

Currently we use the `SelectMenu-icon` class specifically for the check icon to show if an item is selected or not. But there have been cases where a SelectMenu uses different icons unrelated to the selected/checked state. This PR:

- Makes the `.SelectMenu-icon` more generic. It only cares about the size and margin and can be used for **any** icon.
- Adds an additional `.SelectMenu-icon--check` modifier class that toggles based on the `aria-checked="true"` attribute.

```html
<button class="SelectMenu-item" role="menuitemcheckbox" aria-checked="true">
  <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %>
  Selectable item with a check icon
</button>
<button class="SelectMenu-item" role="menuitem">
  <%= octicon "pin", class: "SelectMenu-icon" %>
  Item with a pin icon
</button>
```

Above markup renders as:

![image](https://user-images.githubusercontent.com/378023/67858115-bd6ace80-fb5b-11e9-9bf5-a04719cfeff9.png)

It allows to mix check and other icons in the same list and have them aligned without fiddling with margin utilities.

#### Alternatives

Some alternative names instead of `SelectMenu-icon--check`:

- `.SelectMenu-icon--checked` might be confused for adding a state
- `.SelectMenu-icon--selected` same
- `.SelectMenu--showWhenChecked` could be used for anything, not just icons. People might expect it to be `display: none` by default, instead of `visibility: hidden`. But that would make the text jump.

## 2. Prevent shrinking of the icon

Happens when the text starts to wrap, see #961. A `flex-shrink-0` can be used, but might be convenient to "bake that in". 

Was also wondering if we need some kind of `SelectMenu--truncate`. Similar to `css-truncate` but without the need for overriding `max-width`. Maybe in another PR as a utility.

/cc @muan 

---

Closes #961
