### PR TITLE
Rename `.flex-item-equal` to `.flex-1`

### DIFF
--- a/docs/content/utilities/flexbox.md
+++ b/docs/content/utilities/flexbox.md
@@ -693,7 +693,6 @@ All flexbox utilities can be adjusted per [breakpoint](/css/objects/grid#breakpo
 
 - `d-[breakpoint]-[property]` for `display`
 - `flex-[breakpoint]-[property]-[behavior]` for various flex properties
-- `flex-[breakpoint]-item-equal` for equal width and equal height flex items
 
 Each responsive style is applied to the specified breakpoint and up.
 
@@ -712,8 +711,6 @@ Each responsive style is applied to the specified breakpoint and up.
 .flex-lg-nowrap {}
 
 .flex-lg-self-start {}
-
-.flex-md-item-equal {}
 ```
 
 #### Example usage
@@ -725,16 +722,6 @@ Mixing flex properties:
   <div class="p-5 border bg-gray-light flex-md-self-stretch">.flex-self-stretch</div>
   <div class="p-5 border bg-gray-light">&nbsp;</div>
   <div class="p-5 border bg-gray-light">&nbsp;</div>
-</div>
-```
-
-Using the equal width, equal height utilities:
-
-```html live
-<div class="border d-flex">
-  <div class="flex-md-item-equal p-3 border bg-gray-light">Stuff and things</div>
-  <div class="flex-md-item-equal p-3 border bg-gray-light">More stuff<br> on multiple lines</div>
-  <div class="flex-md-item-equal p-3 border bg-gray-light">Hi mom</div>
 </div>
 ```
 

--- a/docs/content/utilities/flexbox.md
+++ b/docs/content/utilities/flexbox.md
@@ -487,6 +487,7 @@ When the main axis wraps, this creates multiple main axis lines and adds extra s
 Use this class to specify the ability of a flex item to alter its dimensions to fill available space.
 
 ```css
+.flex-1          { flex: 1; }
 .flex-auto       { flex: 1 1 auto; }
 .flex-grow-0     { flex-grow: 0; }
 .flex-shrink-0   { flex-shrink: 0; }
@@ -494,9 +495,20 @@ Use this class to specify the ability of a flex item to alter its dimensions to 
 
 | Class | Description |
 | --- | --- |
+| `.flex-1` | Sets default values for  `flex-grow` (1), `flex-shrink` (1) and `flex-basis` (0%)  |
 | `.flex-auto` | Sets default values for  `flex-grow` (1), `flex-shrink` (1) and `flex-basis` (auto)  |
 | `.flex-grow-0` | Prevents growing of a flex item  |
 | `.flex-shrink-0` | Prevents shrinking of a flex item  |
+
+#### flex-1
+
+```html live
+<div class="border d-flex">
+  <div class="p-5 border bg-gray-light flex-1">.flex-1</div>
+  <div class="p-5 border bg-gray-light flex-1">.flex-1</div>
+  <div class="p-5 border bg-gray-light flex-1">.flex-1</div>
+</div>
+```
 
 #### flex-auto
 

--- a/docs/content/utilities/flexbox.md
+++ b/docs/content/utilities/flexbox.md
@@ -487,20 +487,32 @@ When the main axis wraps, this creates multiple main axis lines and adds extra s
 Use this class to specify the ability of a flex item to alter its dimensions to fill available space.
 
 ```css
-.flex-1          { flex: 1; }
-.flex-auto       { flex: 1 1 auto; }
-.flex-grow-0     { flex-grow: 0; }
-.flex-shrink-0   { flex-shrink: 0; }
+.flex-1        { flex: 1; }
+.flex-auto     { flex: auto; }
+.flex-grow-0   { flex-grow: 0; }
+.flex-shrink-0 { flex-shrink: 0; }
 ```
 
 | Class | Description |
 | --- | --- |
-| `.flex-1` | Sets default values for  `flex-grow` (1), `flex-shrink` (1) and `flex-basis` (0%)  |
-| `.flex-auto` | Sets default values for  `flex-grow` (1), `flex-shrink` (1) and `flex-basis` (auto)  |
-| `.flex-grow-0` | Prevents growing of a flex item  |
-| `.flex-shrink-0` | Prevents shrinking of a flex item  |
+| `.flex-1` | Fills available space |
+| `.flex-auto` | Fills available space and auto-sizes based on the content |
+| `.flex-grow-0` | Prevents growing of a flex item |
+| `.flex-shrink-0` | Prevents shrinking of a flex item |
 
 #### flex-1
+
+Adding `.flex-1` makes the item grow in size to take up all the space that is available.
+
+```html live
+<div class="border d-flex">
+  <div class="p-5 border bg-gray-light">flex item</div>
+  <div class="p-5 border bg-gray-light flex-1">.flex-1</div>
+  <div class="p-5 border bg-gray-light">flex item</div>
+</div>
+```
+
+Adding `.flex-1` to all flex items results in each item having the same size.
 
 ```html live
 <div class="border d-flex">
@@ -512,31 +524,37 @@ Use this class to specify the ability of a flex item to alter its dimensions to 
 
 #### flex-auto
 
+Using `.flex-auto` fills the available space but also takes the size of the content into account. Type in the editor below to see the effect.
+
 ```html live
 <div class="border d-flex">
-  <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
-  <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
-  <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
+  <div class="p-5 border bg-gray-light flex-1">.flex-1</div>
+  <div class="p-5 border bg-gray-light flex-auto">.flex-auto with a bit more text</div>
+  <div class="p-5 border bg-gray-light flex-1">.flex-1</div>
 </div>
 ```
 
 #### flex-grow-0
 
+Add `.flex-grow-0` to prevent an item from growing. This can be useful when used as a responsive variant. For example to stop growing when the viewport gets wider.
+
 ```html live
 <div class="border d-flex">
-  <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
-  <div class="p-5 border bg-gray-light flex-auto flex-grow-0">.flex-auto .flex-grow-0</div>
-  <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
+  <div class="p-5 border bg-gray-light">flex item</div>
+  <div class="p-5 border bg-gray-light flex-auto flex-md-grow-0">.flex-auto .flex-md-grow-0</div>
+  <div class="p-5 border bg-gray-light">flex item</div>
 </div>
 ```
 
 #### flex-shrink-0
 
+Add `.flex-shrink-0` to prevent an item from shrinking. Note that for example text will not wrap and the flex items start to overflow if there is not enough space.
+
 ```html live
-<div class="border d-flex" style="width: 450px">
-  <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
-  <div class="p-5 border bg-gray-light flex-auto flex-shrink-0">.flex-auto .flex-shrink-0</div>
-  <div class="p-5 border bg-gray-light flex-auto">.flex-auto</div>
+<div class="p-2 border d-flex" style="max-width: 340px">
+  <div class="p-5 border bg-gray-light">flex item</div>
+  <div class="p-5 border bg-gray-light flex-shrink-0">.flex-shrink-0</div>
+  <div class="p-5 border bg-gray-light">flex item</div>
 </div>
 ```
 

--- a/src/utilities/flexbox.scss
+++ b/src/utilities/flexbox.scss
@@ -32,9 +32,9 @@
     .flex#{$variant}-content-stretch  { align-content: stretch !important; }
 
     // Item
-    .flex#{$variant}-1 { flex: 1 !important; }
-    .flex#{$variant}-auto { flex: auto !important; }
-    .flex#{$variant}-grow-0 { flex-grow: 0 !important; }
+    .flex#{$variant}-1        { flex: 1 !important; }
+    .flex#{$variant}-auto     { flex: auto !important; }
+    .flex#{$variant}-grow-0   { flex-grow: 0 !important; }
     .flex#{$variant}-shrink-0 { flex-shrink: 0 !important; }
 
     .flex#{$variant}-self-auto        { align-self: auto !important; }

--- a/src/utilities/flexbox.scss
+++ b/src/utilities/flexbox.scss
@@ -44,12 +44,6 @@
     .flex#{$variant}-self-baseline    { align-self: baseline !important; }
     .flex#{$variant}-self-stretch     { align-self: stretch !important; }
 
-    // Shorthand for equal width and height cols
-    .flex#{$variant}-item-equal {
-      flex-grow: 1;
-      flex-basis: 0;
-    }
-
     .flex#{$variant}-order-1 { order: 1 !important; }
     .flex#{$variant}-order-2 { order: 2 !important; }
     .flex#{$variant}-order-none { order: inherit !important; }

--- a/src/utilities/flexbox.scss
+++ b/src/utilities/flexbox.scss
@@ -32,6 +32,7 @@
     .flex#{$variant}-content-stretch  { align-content: stretch !important; }
 
     // Item
+    .flex#{$variant}-1 { flex: 1 !important; }
     .flex#{$variant}-auto { flex: 1 1 auto !important; }
     .flex#{$variant}-grow-0 { flex-grow: 0 !important; }
     .flex#{$variant}-shrink-0 { flex-shrink: 0 !important; }

--- a/src/utilities/flexbox.scss
+++ b/src/utilities/flexbox.scss
@@ -33,7 +33,7 @@
 
     // Item
     .flex#{$variant}-1 { flex: 1 !important; }
-    .flex#{$variant}-auto { flex: 1 1 auto !important; }
+    .flex#{$variant}-auto { flex: auto !important; }
     .flex#{$variant}-grow-0 { flex-grow: 0 !important; }
     .flex#{$variant}-shrink-0 { flex-shrink: 0 !important; }
 


### PR DESCRIPTION
This renames the `.flex-item-equal` utility to `.flex-1`.

## Motivation

Currently when using `.flex-auto` and a sibling element is an image or icon, the image or icon can start to shrink. A workaround is to add `.flex-shrink-0` to the sibling element.

Another workaround would be to use `flex: 1` instead of `flex: auto`. It's similar but has a `flex-basis` value of `0%`. It seems to be less "aggressive" and respect the min-width of sibling elements. And thus no `.flex-shrink-0` is necessary on the avatar:

![flex-1](https://user-images.githubusercontent.com/378023/67930965-43425480-fc04-11e9-8b1f-9ec5d970398b.gif)

Turns out that [`.flex-item-equal`](https://github.com/primer/css/blob/de91594b5fc878dfa889145830699e359c24a2f4/src/utilities/flexbox.scss#L46-L50) could be used. Because `flex-shrink: 1` is the default, is has the same computed values as using the shorthand `flex: 1` -> `flex: 1 1 0%` -> `flex-grow: 1; flex-shrink: 1; flex-basis: 0%`. Maybe it doesn't get used as much because:

- It's only documented under [Responsive flex utilities](https://primer.style/css/utilities/flexbox#responsive-flex-utilities)
- Is longer to type than just `flex-auto`.
- The name could be misleading when you only want one flex item to take up the available space.
- It currently doesn't use `!important` and can't be used to override.

So renaming the utility might help. The recommendation would be:

- Use `.flex-1`. In most situations it should be enough.
- Use `.flex-auto` if a flex item should take up space based on its content. Add `.flex-shrink-0` to sibling elements that are images or icons.

👀 See [docs preview](https://primer-css-git-flex-utilities.primer.now.sh/css/utilities/flexbox#flex).

## TODO

- [x] Remove `.flex-item-equal`
- [x] Add `.flex-1`
- [x] Update documentation

#### TODO in `release-14.0.0`

- [ ] Deprecate `.flex-item-equal` class

#### TODO on dotcom

- [ ] Replace `.flex-item-equal` with `.flex-1`

---

```
┌─────────────────────┬───────────┬─────┬───────────┬────────┬──────────┬─────────┬──────────────────────────────┐
│ name                │ selectors │   ± │ gzip size │      ± │ raw size │       ± │ path                         │
├─────────────────────┼───────────┼─────┼───────────┼────────┼──────────┼─────────┼──────────────────────────────┤
│ primer              │      3332 │   0 │   26.87 K │ - 17 B │ 168.89 K │ - 100 B │ dist/primer.css              │
│ core                │      2224 │   0 │    17.7 K │ - 17 B │ 112.26 K │ - 100 B │ dist/core.css                │
│ utilities           │      1360 │   0 │    8.62 K │ - 20 B │   65.6 K │ - 100 B │ dist/utilities.css           │
```

---

/cc @primer/ds-core
