### PR TITLE
Add responsive variants to dropdown

### DIFF
--- a/docs/content/components/dropdown.md
+++ b/docs/content/components/dropdown.md
@@ -226,3 +226,32 @@ Align the direction of dropdown menus and their arrows with modifier classes.
   </details>
 </div>
 ```
+
+### Responsive variants
+
+The following directions have responsive variants:
+
+```
+.dropdown-menu-s
+.dropdown-menu-sw
+.dropdown-menu-se
+```
+
+Use them to make sure the `.dropdown-menu` doesn't get cut off when moving the dropdown close to an edge.
+
+```html live
+<div class="text-sm-center text-md-right" style="min-height: 140px;">
+  <details class="dropdown details-reset details-overlay d-inline-block text-left">
+    <summary class="btn" aria-haspopup="true">
+      Dropdown
+      <div class="dropdown-caret"></div>
+    </summary>
+
+    <ul class="dropdown-menu dropdown-menu-se dropdown-menu-sm-s dropdown-menu-md-sw">
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+      <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+    </ul>
+  </details>
+</div>
+```

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -201,50 +201,57 @@
   }
 }
 
-.dropdown-menu-s {
-  right: 50%;
-  left: auto;
-  transform: translateX(50%);
+// South directions have responsive variants
 
-  &::before {
-    top: -$spacer-3;
-    right: 50%;
-    transform: translateX(50%);
-  }
+@each $breakpoint, $variant in $responsive-variants {
+  @include breakpoint($breakpoint) {
+    .dropdown-menu#{$variant}-s {
+      right: 50%;
+      left: auto;
+      transform: translateX(50%);
 
-  &::after {
-    top: -14px;
-    right: 50%;
-    transform: translateX(50%);
-  }
-}
+      &::before {
+        top: -$spacer-3;
+        right: 50%;
+        transform: translateX(50%);
+      }
 
-.dropdown-menu-sw {
-  right: 0;
-  left: auto;
+      &::after {
+        top: -14px;
+        right: 50%;
+        transform: translateX(50%);
+      }
+    }
 
-  &::before {
-    top: -$spacer-3;
-    right: 9px;
-    left: auto;
-  }
+    .dropdown-menu#{$variant}-sw {
+      right: 0;
+      left: auto;
 
-  &::after {
-    top: -14px;
-    right: 10px;
-    left: auto;
-  }
-}
+      &::before {
+        top: -$spacer-3;
+        right: 9px;
+        left: auto;
+      }
 
-.dropdown-menu-se {
-  &::before {
-    top: -$spacer-3;
-    left: 9px;
-  }
+      &::after {
+        top: -14px;
+        right: 10px;
+        left: auto;
+      }
+    }
 
-  &::after {
-    top: -14px;
-    left: 10px;
+    .dropdown-menu#{$variant}-se {
+      &::before {
+        top: -$spacer-3;
+        left: 9px;
+      }
+
+      &::after {
+        top: -14px;
+        left: 10px;
+      }
+    }
+
   }
 }
 

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -213,12 +213,14 @@
       &::before {
         top: -$spacer-3;
         right: 50%;
+        left: auto;
         transform: translateX(50%);
       }
 
       &::after {
         top: -14px;
         right: 50%;
+        left: auto;
         transform: translateX(50%);
       }
     }
@@ -226,29 +228,40 @@
     .dropdown-menu#{$variant}-sw {
       right: 0;
       left: auto;
+      transform: none;
 
       &::before {
         top: -$spacer-3;
         right: 9px;
         left: auto;
+        transform: none;
       }
 
       &::after {
         top: -14px;
         right: 10px;
         left: auto;
+        transform: none;
       }
     }
 
     .dropdown-menu#{$variant}-se {
+      right: auto;
+      left: auto;
+      transform: none;
+
       &::before {
         top: -$spacer-3;
+        right: auto;
         left: 9px;
+        transform: none;
       }
 
       &::after {
         top: -14px;
+        right: auto;
         left: 10px;
+        transform: none;
       }
     }
 


### PR DESCRIPTION
This makes the `dropdown-menu` have responsive variants. But to keep bundle size down, **only** to the "south" directions:

```
.dropdown-menu-s
.dropdown-menu-sw
.dropdown-menu-se
```

![dropdown](https://user-images.githubusercontent.com/378023/68007279-747f5b00-fcbe-11e9-9697-9db046624a86.gif)

👀 [Preview](https://primer-css-git-dropdown-responsive-variants.primer.now.sh/css/components/dropdown#responsive-variants)

Hopefully this covers most of the use cases. On dotcom we also have the [`hx_dropdown-fullscreen`](https://github.com/github/github/pull/125952) to cover the rest of edge cases.

## Motivation

When making a page responsive, dropdowns can shift around causing the `.dropdown-menu` getting cut off. See https://github.com/github/pe-issues-projects/issues/364.

Having responsive variants makes it possible to change direction. 

## Concerns

Increase of bundle size. Unfortunately not used properties still [need to be included](https://github.com/primer/css/commit/96a8220efeb399601d44098cbc0440e80ecc5c59) so they can override other breakpoints. The damage would be `+2.77K`, although gzipped only `+206B`. [Full report](https://github.com/primer/css/pull/969/checks?check_run_id=284387143#step:8:21). 

```
┌─────────────────────┬───────────┬──────┬───────────┬─────────┬──────────┬──────────┬──────────────────────────────┐
│ name                │ selectors │    ± │ gzip size │       ± │ raw size │        ± │ path                         │
├─────────────────────┼───────────┼──────┼───────────┼─────────┼──────────┼──────────┼──────────────────────────────┤
│ dropdown            │        88 │ + 37 │     1.2 K │ + 206 B │   6.78 K │ + 2.77 K │ dist/dropdown.css            │
```

Worth it? 🤔 Or should we just use [`hx_dropdown-fullscreen`](https://github.com/github/github/pull/125952) every time a `.dropdown-menu` gets cut off?

## TODO

- [x] Add variants
- [x] Add documentation

/cc @primer/ds-core
