### PR TITLE
Add variable deprecation data and tests

### DIFF
--- a/deprecations.js
+++ b/deprecations.js
@@ -6,6 +6,10 @@
 const versionDeprecations = {
   '14.0.0': [
     {
+      selectors: ['.UnderlineNav-item.selected', '.UnderlineNav-item.selected .UnderlineNav-octicon'],
+      message: `Please use aria-selected="true" to indicate the selected state of an UnderlineNav item.`
+    },
+    {
       variables: ['$status-pending'],
       message: `This variable is deprecated.`
     },

--- a/deprecations.js
+++ b/deprecations.js
@@ -4,6 +4,32 @@
  * array and a "message" string.
  */
 const versionDeprecations = {
+  '14.0.0': [
+    {
+      variables: ['$status-pending'],
+      message: `This variable is deprecated.`
+    },
+    {
+      variables: ['$repo-private-text', '$repo-private-bg', '$repo-private-icon'],
+      message: `These variables are deprecated.`
+    },
+    {
+      variables: ['$marketingSpacers', '$allSpacers'],
+      message: `Please use the $marketing-spacers and $marketing-all-spacers variables.`
+    },
+    {
+      variables: ['$exploregrid-item-border-radius'],
+      message: `This variable is deprecated. Use "4px" instead.`
+    },
+    {
+      variables: ['$stats-switcher-py', '$stats-viewport-height'],
+      message: `These variables are deprecated.`
+    },
+    {
+      variables: ['$min_tab_size', '$max_tab_size'],
+      message: `These variables are deprecated.`
+    }
+  ],
   '13.0.0': [
     {
       selectors: [
@@ -68,10 +94,14 @@ const semver = require('semver')
 
 // map selectors to the version and message of their deprecation
 const selectorDeprecations = new Map()
+const variableDeprecations = new Map()
 for (const [version, deps] of Object.entries(versionDeprecations)) {
-  for (const {selectors, message} of deps) {
+  for (const {selectors = [], variables = [], message} of deps) {
     for (const selector of selectors) {
       selectorDeprecations.set(selector, {version, message})
+    }
+    for (const variable of variables) {
+      variableDeprecations.set(variable, {version, message})
     }
   }
 }
@@ -81,4 +111,15 @@ function isSelectorDeprecated(selector, version = CURRENT_VERSION) {
   return deprecation ? semver.gte(deprecation.version, version) : false
 }
 
-module.exports = {versionDeprecations, selectorDeprecations, isSelectorDeprecated}
+function isVariableDeprecated(variable, version = CURRENT_VERSION) {
+  const deprecation = variableDeprecations.get(variable)
+  return deprecation ? semver.gte(deprecation.version, version) : false
+}
+
+module.exports = {
+  versionDeprecations,
+  selectorDeprecations,
+  variableDeprecations,
+  isSelectorDeprecated,
+  isVariableDeprecated
+}

--- a/docs/content/getting-started/contributing.md
+++ b/docs/content/getting-started/contributing.md
@@ -71,7 +71,7 @@ Let the [design systems team](https://github.com/github/design-systems) know if 
 
 ## Removing styles and variables
 
-Removing styles and SCSS variables can be a scary. How do you know if the thing you're deleting (or just planning to delete) isn't used in other projects? [Semantic versioning] provides us with an answer: We **don't** know, but we can use "major" version increments (from, say, `13.4.0` to `14.0.0`) to signal that the release includes potentially breaking changes. The rule is simple:
+Removing styles and SCSS variables can be scary. How do you know if the thing you're deleting (or just planning to delete) isn't used in other projects? [Semantic versioning] provides us with an answer: We **don't** know, but we can use "major" version increments (from, say, `13.4.0` to `14.0.0`) to signal that the release includes potentially breaking changes. The rule is simple:
 
 **Whenever we delete a CSS selector or SCSS variable, we will increment to the next major version.**
 

--- a/docs/content/getting-started/contributing.md
+++ b/docs/content/getting-started/contributing.md
@@ -42,7 +42,11 @@ It's usually better to open an issue before investing time in spiking out a new 
 1. What the pattern is and how it's being used across the site - post screenshots and urls where possible. If you need help identifying where the pattern is being used, call that out here and cc the relevant team and/or cc `@product-design` to help.
 2. Why you think a new pattern is needed (this should answer the relevant questions above).
 3. If you intend to work on these new styles yourself, let us know what your timeline and next steps are. If you need help and this is a dependency for shipping another project, please make that clear here and what the timeline is.
-4. Add the `type: new styles` label, or `type: refactor` where appropriate.
+4. Add the appropriate label(s):
+    - `Type: Enhancement` for new styles
+    - `Type: Bug Fix` for—you guessed it!—bug fixes
+    - `Type: Polish` for refactors of existing styles
+    - `Type: Breaking Change` for any change that [removes CSS selectors or SCSS variables](#removing-styles-and-variables)
 
 ### Step 2: Design and build the new styles
 

--- a/docs/content/tools/deprecations.md
+++ b/docs/content/tools/deprecations.md
@@ -2,28 +2,25 @@
 title: Deprecation data
 ---
 
-As of version 12.7.0, we publish CSS selector deprecation data with
-`@primer/css`. You can access the data via the [Node API](#node) or as
-[JSON](#json).
+As of version 12.7.0, we publish CSS selector and SCSS variable deprecation data (as of 14.0.0) with `@primer/css`. You can access the data via the [Node API](#node) or as [JSON](#json).
 
-Deprecation messages strings may include Markdown so that they can be included
-in the [changelog].
-
-**Keep in mind that this data includes both active and _planned_
-deprecations.** You can determine whether a CSS selector is deprecated for the
-version of `@primer/css` you've installed via the [Node API](#node), or by
-comparing the version of a selector deprecation with the installed version in
-your own environment.
+**Keep in mind that this data includes both active and _planned_ deprecations.** The [Node API](#node) is the best way to determine whether a selector or variable is deprecated for the version of `@primer/css` you've installed.
 
 ## JSON
 
 The JSON data is available in the unpacked node module's `dist/deprecations.json`, and is an object with the following structure:
 
-* `versions` is an object whose keys are version numbers (e.g. `13.0.0`) and values are deprecation messages: objects with a `selectors` array and a `message`:
+* `versions` is an object whose keys are version numbers (e.g. `13.0.0`) and values are deprecation messages, each of which has a `message` string and a `selectors` and/or `variables` array:
 
     ```json
     {
       "versions": {
+        "14.0.0": [
+          {
+            "variables": ["$min_tab_size", "$max_tab_size"],
+            "message": "These variables have been deprecated."
+          }
+        ],
         "13.0.0": [
           {
             "selectors": [".btn-purple"],
@@ -33,6 +30,8 @@ The JSON data is available in the unpacked node module's `dist/deprecations.json
       }
     }
     ```
+    
+    Deprecation messages strings may include Markdown so that they can be included in the [changelog].
 
 * `selectors` is an object mapping CSS selectors (e.g. `.btn-purple`) to the version in which they are _or will be_ deprecated:
 
@@ -46,6 +45,20 @@ The JSON data is available in the unpacked node module's `dist/deprecations.json
       }
     }
     ```
+    
+* `variables` is an object mapping SCSS variables (including the leading `$`, e.g. `$status-pending`) to the version in which they are or will be deprecated:
+
+    ```json
+    {
+      "variables": {
+        "$status-pending": {
+          "version": "14.0.0",
+          "message": "This variable is unused in Primer, and is deprecated."
+        }
+      }
+    }
+    ```
+    
 
 ## Node
 
@@ -89,6 +102,27 @@ console.log(`Purple buttons are bad? ${isSelectorDeprecated('.btn-purple')}`)
 console.log(`Primary buttons are bad? ${isSelectorDeprecated('.btn-primary')}`)
 // "Primary buttons are bad? false"
 ```
+
+### `variableDeprecations`
+This is a [Map] object with keys for each SCSS variable mapped to the deprecation info:
+
+```js
+const {selectorDeprecations} = require('@primer/css/deprecations')
+console.log(`Will $status-pending be deprecated? ${variableDeprecations.has('$status-pending')}`)
+// "Will $status-pending be deprecated? true"
+```
+
+### `isVariableDeprecated(variable[, version])`
+Returns `true` if the named SCSS variable (including the leading `$`) will have been deprecated (removed) _by_ the specified [semver] version.
+
+```js
+const {isVariableDeprecated} = require('@primer/css/deprecations')
+console.log(`$status-pending deprecated? ${isVariableDeprecated('$status-pending')}`)
+// "$status-pending deprecated? true"
+console.log(`$yellow-700 deprecated? ${isVariableDeprecated('$yellow-700')}`)
+// "$yellow-700 deprecated false"
+```
+
 
 [semver]: https://npm.im/semver
 [changelog]: https://github.com/primer/css/tree/master/CHANGELOG.md

--- a/script/dist.js
+++ b/script/dist.js
@@ -88,15 +88,20 @@ function getPathName(path) {
 }
 
 function writeDeprecationData() {
-  const {versionDeprecations, selectorDeprecations} = require('../deprecations')
+  const {versionDeprecations, selectorDeprecations, variableDeprecations} = require('../deprecations')
   const data = {
     versions: versionDeprecations,
-    selectors: Array.from(selectorDeprecations.entries()).reduce((obj, [selector, deprecation]) => {
-      obj[selector] = deprecation
+    selectors: mapToObject(selectorDeprecations),
+    variables: mapToObject(variableDeprecations)
+  }
+  return writeFile(join(outDir, 'deprecations.json'), JSON.stringify(data, null, 2))
+
+  function mapToObject(map) {
+    return Array.from(map.entries()).reduce((obj, [key, value]) => {
+      obj[key] = value
       return obj
     }, {})
   }
-  return writeFile(join(outDir, 'deprecations.json'), JSON.stringify(data, null, 2))
 }
 
 if (require.main === module) {

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -31,7 +31,8 @@
     }
   }
 
-  &.selected, // TODO@14.0.0: remove &.selected
+  // TODO@14.0.0: remove &.selected
+  &.selected,
   &[role=tab][aria-selected=true],
   &[aria-current] {
     font-weight: $font-weight-bold;

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -31,8 +31,6 @@
     }
   }
 
-  // TODO@14.0.0: remove &.selected
-  &.selected,
   &[role=tab][aria-selected=true],
   &[aria-current] {
     font-weight: $font-weight-bold;


### PR DESCRIPTION
👀 **Updated docs: [contributing](https://primer-css-git-variable-deprecations.primer.now.sh/css/getting-started/contributing#removing-styles-and-variables), [deprecation data](https://primer-css-git-variable-deprecations.primer.now.sh/css/tools/deprecations)**

This adds planned variable declaration messages for 14.0.0 (#925) and adds deprecation tests for variables in `script/test-deprecations.js`. The output looks like this (but with colored symbols!):

```
i no variables changed (latest -> 14.0.0)
i 11 variables to be deprecated in 14.0.0
i no selectors changed in bundle "primer" (latest -> 14.0.0)
i 6 selectors to be deprecated in 14.0.0

11 errors:
𐄂 variable "$status-pending" deprecated, but not removed
𐄂 variable "$repo-private-text" deprecated, but not removed
𐄂 variable "$repo-private-bg" deprecated, but not removed
𐄂 variable "$repo-private-icon" deprecated, but not removed
𐄂 variable "$marketingSpacers" deprecated, but not removed
𐄂 variable "$allSpacers" deprecated, but not removed
𐄂 variable "$exploregrid-item-border-radius" deprecated, but not removed
𐄂 variable "$stats-switcher-py" deprecated, but not removed
𐄂 variable "$stats-viewport-height" deprecated, but not removed
𐄂 variable "$min_tab_size" deprecated, but not removed
𐄂 variable "$max_tab_size" deprecated, but not removed
```

The errors come from new entries in `deprecations.js`, and the test script has been updated to look for `selectors` and/or `variables` arrays in any of the version deprecation "entries", e.g.

```js
const versionDeprecations = {
  '14.0.0': [
    {selectors: ['.selector-a', '.selector-b'], message: 'These selectors have been deprecated.'},
    {variables: ['$variable-a', '$variable-b'], message: 'These variables have been deprecated.'}
  ]
}
```

The diff from one version to the next is determined from the keys of the `dist/variables.json` data generated in `script/dist.js` before publication, so `script/test-deprecations.js` should always be run on a fresh `dist` directory built by `script/dist.js`.

When this is merged into #925 with #968 (or if we merge #968 first, then update this branch) it should trigger a bunch of errors that we'll need to fix in the release branch. 🤞 