### PR TITLE
Deprecate variables in 14.0.0

### DIFF
--- a/deprecations.js
+++ b/deprecations.js
@@ -14,6 +14,10 @@ const versionDeprecations = {
       message: `This variable is deprecated.`
     },
     {
+      variables: ['$highlight-yellow'],
+      message: `This variable is deprecated.`
+    },
+    {
       variables: ['$repo-private-text', '$repo-private-bg', '$repo-private-icon'],
       message: `These variables are deprecated.`
     },

--- a/script/dist.js
+++ b/script/dist.js
@@ -110,7 +110,11 @@ if (require.main === module) {
 
 function writeVariableData() {
   const analyzeVariables = require('./analyze-variables')
-  return analyzeVariables('src/support/index.scss').then(data =>
+  return Promise.all([
+    analyzeVariables('src/support/index.scss'),
+    analyzeVariables('src/marketing/support/index.scss')
+  ]).then(([support, marketing]) => {
+    const data = Object.assign({}, support, marketing)
     writeFile(join(outDir, 'variables.json'), JSON.stringify(data, null, 2))
-  )
+  })
 }

--- a/script/test-deprecations.js
+++ b/script/test-deprecations.js
@@ -76,8 +76,7 @@ async function checkSelectorDeprecations(options = {}) {
   for (const {selectors = []} of deprecations) {
     for (const selector of selectors) {
       if (!removed.includes(selector)) {
-        const error = `"${selector}" deprecated, but not removed`
-        errors.push(error)
+        errors.push(`"${selector}" deprecated, but not removed`)
       } else {
         console.log(`${V} selector "${selector}" is officially deprecated`)
       }
@@ -87,8 +86,7 @@ async function checkSelectorDeprecations(options = {}) {
 
   for (const removedSelector of removed) {
     if (!deprecatedSelectors.includes(removedSelector)) {
-      const error = `"${removedSelector}" has been removed, but was not listed in versionDeprecations['${currentVersion}']`
-      errors.push(error)
+      errors.push(`"${removedSelector}" has been removed, but was not listed in versionDeprecations['${currentVersion}']`)
     } else {
       // console.log(`${V} "${removedSelector}" removed and deprecated!`)
     }
@@ -128,8 +126,11 @@ async function checkVariableDeprecations(options = {}) {
   for (const {variables = []} of deprecations) {
     for (const variable of variables) {
       if (!removed.includes(variable)) {
-        const error = `variable "${variable}" deprecated, but not removed`
-        errors.push(error)
+        if (remote[variable]) {
+          errors.push(`variable "${variable}" deprecated, but not removed`)
+        } else {
+          console.log(`${I} variable "${variable}" doesn't exist in data for version: ${version}`)
+        }
       } else {
         console.log(`${V} variable "${variable}" is officially deprecated`)
       }
@@ -139,8 +140,7 @@ async function checkVariableDeprecations(options = {}) {
 
   for (const removedVariable of removed) {
     if (!deprecatedVariables.includes(removedVariable)) {
-      const error = `"${removedVariable}" has been removed, but was not listed in versionDeprecations['${currentVersion}']`
-      errors.push(error)
+      errors.push(`"${removedVariable}" has been removed, but was not listed in versionDeprecations['${currentVersion}']`)
     } else {
       // console.log(`${V} "${removedVariable}" removed and deprecated!`)
     }

--- a/script/test-deprecations.js
+++ b/script/test-deprecations.js
@@ -86,7 +86,9 @@ async function checkSelectorDeprecations(options = {}) {
 
   for (const removedSelector of removed) {
     if (!deprecatedSelectors.includes(removedSelector)) {
-      errors.push(`"${removedSelector}" has been removed, but was not listed in versionDeprecations['${currentVersion}']`)
+      errors.push(
+        `"${removedSelector}" has been removed, but was not listed in versionDeprecations['${currentVersion}']`
+      )
     } else {
       // console.log(`${V} "${removedSelector}" removed and deprecated!`)
     }
@@ -140,7 +142,9 @@ async function checkVariableDeprecations(options = {}) {
 
   for (const removedVariable of removed) {
     if (!deprecatedVariables.includes(removedVariable)) {
-      errors.push(`"${removedVariable}" has been removed, but was not listed in versionDeprecations['${currentVersion}']`)
+      errors.push(
+        `"${removedVariable}" has been removed, but was not listed in versionDeprecations['${currentVersion}']`
+      )
     } else {
       // console.log(`${V} "${removedVariable}" removed and deprecated!`)
     }

--- a/src/marketing/support/variables.scss
+++ b/src/marketing/support/variables.scss
@@ -39,11 +39,6 @@ $spacer-10: $spacer * 12 !default; // 96px
 $spacer-11: $spacer * 14 !default; // 112px
 $spacer-12: $spacer * 16 !default; // 128px
 
-// TODO@14.0.0: remove $marketingSpacers (unused)
-$marketingSpacers: $spacer-7, $spacer-8, $spacer-9, $spacer-10, $spacer-11, $spacer-12 !default;
-// TODO@14.0.0: remove $allSpacers (unused)
-$allSpacers: $spacer-1, $spacer-2, $spacer-3, $spacer-4, $spacer-5, $spacer-6, $spacer-7, $spacer-8, $spacer-9, $spacer-10, $spacer-11, $spacer-12 !default;
-
 $marketing-spacers: (
   7: $spacer-7,
   8: $spacer-8,

--- a/src/support/variables/colors.scss
+++ b/src/support/variables/colors.scss
@@ -1,21 +1,6 @@
 @import "color-system.scss";
 // Color variables
 
-// State indicators.
-// TODO@14.0.0: remove $status-pending (unused)
-$status-pending:    desaturate($yellow-700, 15%) !default;
-
-// Repository type colors
-// Should be able to deprecate these in future
-// TODO@14.0.0: remove $repo-private-text, $repo-private-bg, and $repo-private-icon
-$repo-private-text: $black-fade-70 !default;
-$repo-private-bg:   $yellow-000 !default;
-$repo-private-icon: rgba($yellow-900, 0.5) !default;
-
-// Highlight used for things like search
-// TODO@14.0.0: remove $highlight-yellow (unused)
-$highlight-yellow: rgba(255, 247, 140, 0.5) !default;
-
 // Border colors
 $border-white:       $white !default;
 $border-black-fade:  $black-fade-15 !default;

--- a/src/support/variables/misc.scss
+++ b/src/support/variables/misc.scss
@@ -24,19 +24,3 @@ $tooltip-background-color: $black !default;
 $tooltip-text-color: $white !default;
 $tooltip-delay: 0.4s !default;
 $tooltip-duration: 0.1s !default;
-
-// Custom explore grid border
-// TODO@14.0.0: move $exploregrid-item-border-radius to github/github
-$exploregrid-item-border-radius: 4px !default;
-
-// TODO@14.0.0: remove $stats-switcher-py (unused)
-$stats-switcher-py: 10px !default;
-// Future proof this `height` value by finding the computed line-height, then
-// adding the total value of the vertical padding. This var is used to toggle
-// between the stats bar and language breakdown.
-// TODO@14.0.0: remove $stats-viewport-height (unused)
-$stats-viewport-height: ($body-font-size * $body-line-height) + ($stats-switcher-py * 2) !default;
-
-// TODO@14.0.0: move $min_tab_size, $max_tab_size to github/github
-$min_tab_size: 1 !default;
-$max_tab_size: 12 !default;


### PR DESCRIPTION
This formally deletes the following variable declarations:

- [x] `$marketingSpacers` and `$allSpacers` (use `$marketing-spacers` and `$marketing-all-spacers` instead)
- [x] `$status-pending`
- [x] `$repo-private-text`, `$repo-private-bg`, and `$repo-private-icon`
- [x] `$highlight-yellow`
- [x] `$exploregrid-item-border-radius`
- [x] `$stats-switcher-py`
- [x] `$stats-viewport-height`
- [x] `$min_tab_size`, `$max_tab_size`

I also had to make two fixes on the tool side:
1. `script/dist.js` now includes marketing variables `dist/variables.json` (so that we can compare them in `script/test-deprecations.js`)
2. `script/test-deprecations.js` doesn't throw an error if a variable that was supposed to be deprecated and doesn't exist in the most recent version of Primer. This is the case with all of our marketing variables, because we weren't previously publishing marketing variable data. 😬 