### PR TITLE
Add Animated Ellipsis

### DIFF
--- a/docs/content/components/loaders.md
+++ b/docs/content/components/loaders.md
@@ -1,0 +1,19 @@
+---
+title: Loaders
+path: components/loaders
+status: New
+source: 'https://github.com/primer/css/tree/master/src/loaders'
+bundle: loaders
+---
+
+Loaders inform users that an action is still in progress and might take a while to complete.
+
+## Animated ellipsis
+
+The `.animated-ellipsis` can be used for any kind of text to add an animated ellipsis.
+
+
+```html live
+<span>Loading</span>
+<span class="animated-ellipsis-container"><span class="animated-ellipsis">...</span></span>
+```

--- a/docs/content/components/loaders.md
+++ b/docs/content/components/loaders.md
@@ -8,12 +8,19 @@ bundle: loaders
 
 Loaders inform users that an action is still in progress and might take a while to complete.
 
-## Animated ellipsis
+## Animated Ellipsis
 
-The `.animated-ellipsis` can be used for any kind of text to add an animated ellipsis.
-
+Add an animated ellipsis at the end of text with `<span class="AnimatedEllipsis"></span>`.
 
 ```html live
-<span>Loading</span>
-<span class="animated-ellipsis-container"><span class="animated-ellipsis">...</span></span>
+<span>Loading</span><span class="AnimatedEllipsis"></span>
+```
+
+It can also be used in combination with other components.
+
+```html live
+<h2><span>Loading</span><span class="AnimatedEllipsis"></span></h2>
+<span class="branch-name mt-2"><span>Loading</span><span class="AnimatedEllipsis"></span></span><br>
+<span class="Label bg-blue mt-3"><span>Loading</span><span class="AnimatedEllipsis"></span></span><br>
+<button class="btn mt-3"><span>Loading</span><span class="AnimatedEllipsis"></span></button>
 ```

--- a/docs/content/components/loaders.md
+++ b/docs/content/components/loaders.md
@@ -22,5 +22,5 @@ It can also be used in combination with other components.
 <h2><span>Loading</span><span class="AnimatedEllipsis"></span></h2>
 <span class="branch-name mt-2"><span>Loading</span><span class="AnimatedEllipsis"></span></span><br>
 <span class="Label bg-blue mt-3"><span>Loading</span><span class="AnimatedEllipsis"></span></span><br>
-<button class="btn mt-3"><span>Loading</span><span class="AnimatedEllipsis"></span></button>
+<button class="btn mt-3" disabled><span>Loading</span><span class="AnimatedEllipsis"></span></button>
 ```

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -89,6 +89,8 @@
       url: /components/header
     - title: Labels
       url: /components/labels
+    - title: Loaders
+      url: /components/loaders
     - title: Markdown
       url: /components/markdown
     - title: Marketing buttons

--- a/src/loaders/README.md
+++ b/src/loaders/README.md
@@ -1,0 +1,25 @@
+---
+bundle: "loaders"
+generated: true
+---
+
+# Primer CSS: `loaders` bundle
+
+## Usage
+
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
+
+```scss
+@import "@primer/css/loaders/index.scss";
+```
+
+## Build
+
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/loaders.css`.
+
+## License
+
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
+
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/loaders/index.scss
+++ b/src/loaders/index.scss
@@ -1,0 +1,2 @@
+@import "../support/index.scss";
+@import "./loaders.scss";

--- a/src/loaders/loaders.scss
+++ b/src/loaders/loaders.scss
@@ -8,9 +8,9 @@
   vertical-align: bottom;
 
   &::after {
-    content: "...";
     display: inline-block;
-    animation: AnimatedEllipsis-keyframes 1.2s steps(4,jump-none) infinite;
+    content: "...";
+    animation: AnimatedEllipsis-keyframes 1.2s steps(4, jump-none) infinite;
   }
 
   @keyframes AnimatedEllipsis-keyframes {

--- a/src/loaders/loaders.scss
+++ b/src/loaders/loaders.scss
@@ -1,0 +1,30 @@
+// Loaders
+
+// Animated Ellipsis
+
+.animated-ellipsis-container {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  overflow: hidden;
+  transform: translateZ(0);
+
+  > .animated-ellipsis {
+    display: inline-block;
+    overflow: hidden;
+    vertical-align: bottom;
+    animation: ellipsis 1s infinite;
+  }
+}
+
+@keyframes ellipsis {
+  from { width: 2px; }
+
+  to { width: 12px; }
+}
+
+.large-loading-area {
+  // stylelint-disable-next-line primer/variables
+  padding: 100px 0;
+  text-align: center;
+}

--- a/src/loaders/loaders.scss
+++ b/src/loaders/loaders.scss
@@ -2,30 +2,18 @@
 
 // Animated Ellipsis
 
-.animated-ellipsis-container {
+.AnimatedEllipsis {
   display: inline-block;
-  width: 12px;
-  height: 12px;
-  // TODO@14.0.0: Remove `overflow: visible`. Used to override styleguide.css
-  overflow: visible;
-  transform: translateZ(0);
+  overflow: hidden;
+  vertical-align: bottom;
 
-  > .animated-ellipsis {
+  &::after {
+    content: "...";
     display: inline-block;
-    overflow: hidden;
-    vertical-align: bottom;
-    animation: ellipsis 1s infinite;
+    animation: AnimatedEllipsis-keyframes 1.2s steps(4,jump-none) infinite;
   }
-}
 
-@keyframes ellipsis {
-  from { width: 2px; }
-
-  to { width: 12px; }
-}
-
-.large-loading-area {
-  // stylelint-disable-next-line primer/variables
-  padding: 100px 0;
-  text-align: center;
+  @keyframes AnimatedEllipsis-keyframes {
+    0% { transform: translateX(-100%); }
+  }
 }

--- a/src/loaders/loaders.scss
+++ b/src/loaders/loaders.scss
@@ -6,7 +6,8 @@
   display: inline-block;
   width: 12px;
   height: 12px;
-  overflow: hidden;
+  // TODO@14.0.0: Remove `overflow: visible`. Used to override styleguide.css
+  overflow: visible;
   transform: translateZ(0);
 
   > .animated-ellipsis {

--- a/src/product/index.scss
+++ b/src/product/index.scss
@@ -21,6 +21,7 @@
 @import "../dropdown/index.scss";
 @import "../header/index.scss";
 @import "../labels/index.scss";
+@import "../loaders/index.scss";
 @import "../markdown/index.scss";
 @import "../popover/index.scss";
 @import "../progress/index.scss";


### PR DESCRIPTION
This adds the `.AnimatedEllipsis` component to Primer CSS.

✨ [Docs Preview](https://primer-css-git-loaders.primer.now.sh/css/components/loaders)

![loading2](https://user-images.githubusercontent.com/378023/68188191-f7b8ed80-ffeb-11e9-99ce-2fe5057c8602.gif)

Some improvements over the current [`animated-ellipsis`](https://github.com/github/github/blob/2c8aff6d8af5b06488300934bd303bbdae5bf6fd/app/assets/stylesheets/components/loader-behavior.scss) component:

- Can be used with any font size
- Uses only a single element/class
- Reduced CSS 
- Improved performance by avoiding repainting

## TODO

- [x] Add styles from dotcom
- [x] Add documentation
- [x] Refactor

#### TODO on dotcom

- [ ] Remove `loader-behavior.scss` https://github.com/github/github/pull/128803

/cc @primer/ds-core
