### PR TITLE
Add `.css-truncate-overflow`

### DIFF
--- a/docs/content/components/truncate.md
+++ b/docs/content/components/truncate.md
@@ -7,11 +7,11 @@ bundle: truncate
 ---
 
 
-The `css-truncate` class will shorten text with an ellipsis. Unless the full text is so long that it affects performance, always add a `title` attribute to the truncated element so the full text remains accessible.
+The `css-truncate` class will shorten text with an ellipsis. Always add a `title` attribute to the truncated element so the full text remains accessible.
 
 ## Truncate overflow
 
-Use `.css-truncate .css-truncate-overflow` to prevent text that overflows from wrapping.
+Combine the `css-truncate` and `css-truncate-overflow` classes to prevent text that overflows from wrapping.
 
 ```html live
 <div class="col-3">
@@ -27,7 +27,7 @@ Use `.css-truncate .css-truncate-overflow` to prevent text that overflows from w
 
 ## Truncate target
 
-Use `.css-truncate .css-truncate-target` for inline elements to add a maximum width.
+Combine the `css-truncate` and `css-truncate-target` classes for inline (or inline-block) elements with a fixed maximum width (default: `125px`).
 
 ```html live
 Some text with a
@@ -37,7 +37,7 @@ Some text with a
 </strong>
 ```
 
-The maximum width of the truncated text can be changed by overriding the `max-width` of `.css-truncate-target`.
+You can override the maximum width of the truncated text with an inline `style` attribute:
 
 ```html live
 Some text with a

--- a/docs/content/components/truncate.md
+++ b/docs/content/components/truncate.md
@@ -7,7 +7,7 @@ bundle: truncate
 ---
 
 
-`.css-truncate` will shorten text with an ellipsis. Unless the full text is so long that it affects performace, always add `title` to the truncated element so the full text can still be seen.
+The `css-truncate` class will shorten text with an ellipsis. Unless the full text is so long that it affects performance, always add a `title` attribute to the truncated element so the full text remains accessible.
 
 ## Truncate overflow
 

--- a/docs/content/components/truncate.md
+++ b/docs/content/components/truncate.md
@@ -7,18 +7,52 @@ bundle: truncate
 ---
 
 
-`.css-truncate` will shorten text with an ellipsis. The maximum width of the truncated text can be changed by overriding the max-width of `.css-truncate-target`. Unless the full text is so long that it affects performace, always add `title` to the truncated element so the full text can still be seen.
+`.css-truncate` will shorten text with an ellipsis. Unless the full text is so long that it affects performace, always add `title` to the truncated element so the full text can still be seen.
 
-```html live title="Truncate"
-<span class="branch-ref css-truncate css-truncate-target" title="really-long-branch-name">
-  really-long-branch-name
-</span>
+## Truncate overflow
+
+Use `.css-truncate .css-truncate-overflow` to prevent text that overflows from wrapping.
+
+```html live
+<div class="col-3">
+  <div class="css-truncate css-truncate-overflow border p-3"
+    title="branch-name-that-is-really-long">
+    branch-name-that-is-really-long
+  </div>
+  <div class="border p-3 mt-3">
+    branch-name-that-is-really-long
+  </div>
+</div>
+```
+
+## Truncate target
+
+Use `.css-truncate .css-truncate-target` for inline elements to add a maximum width.
+
+```html live
+Some text with a
+<strong class="css-truncate css-truncate-target"
+  title="branch-name-that-is-really-long">
+  branch-name-that-is-really-long
+</strong>
+```
+
+The maximum width of the truncated text can be changed by overriding the `max-width` of `.css-truncate-target`.
+
+```html live
+Some text with a
+<strong class="css-truncate css-truncate-target" style="max-width: 180px"
+  title="branch-name-that-is-really-long">
+  branch-name-that-is-really-long
+</strong>
 ```
 
 You can reveal the entire string on hover with the addition of `.expandable`.
 
-```html live title="Truncate Expandable"
-<span class="css-truncate expandable">
-  <span class="branch-ref css-truncate-target">this-is-a-really-long-branch-name</span>
-</span>
+```html live
+Some text with a
+<strong class="css-truncate css-truncate-target expandable"
+  title="branch-name-that-is-really-long">
+  branch-name-that-is-really-long
+</strong>
 ```

--- a/src/truncate/truncate.scss
+++ b/src/truncate/truncate.scss
@@ -3,18 +3,22 @@
 // css-truncate will shorten text with an ellipsis.
 
 .css-truncate {
-  // Truncate double target
-  //
-  // css-truncate will shorten text with an ellipsis. The maximum width
-  // of the truncated text can be changed by overriding the max-width
-  // of the .css-truncate-target
+
+  // css-truncate-auto will shorten text with an ellipsis when overflowing
+  &.css-truncate-overflow,
+  .css-truncate-overflow,
+  &.css-truncate-target,
+  .css-truncate-target {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  // css-truncate-target will shorten text with an ellipsis and a max width
   &.css-truncate-target,
   .css-truncate-target {
     display: inline-block;
     max-width: 125px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     vertical-align: top;
   }
 


### PR DESCRIPTION
This adds a `.css-truncate-overflow` modifier that truncates any overflowing text regardless of the element's width.

![truncate-overflow](https://user-images.githubusercontent.com/378023/68373334-0509df80-0186-11ea-8675-261d418d369c.gif)

📖 [Docs preview](https://primer-css-git-truncate.primer.now.sh/css/components/truncate)

## Motivation

Currently `.css-truncate-target` is meant for "inline" elements. It has `display: inline-block;` and `max-width: 125px;`. To truncate "block" elements, a `.d-block` class (or similar) with an inline style of `max-width: none;` is needed.

Having just a single class (`.css-truncate-overflow`) should make it easier and less confusing.

#### Before

```html
<div class="css-truncate css-truncate-target d-block" style="max-width: none">
```

#### After

```html
<div class="css-truncate css-truncate-overflow">
```

## TODO

- [x] Add styles
- [x] Update documentation

#### TODO on dotcom

Nothing **is** necessary. But we _could_ clean up some of the overrides.

---

Closes #970

/cc @primer/ds-core
