### PR TITLE
Add `.radio-group` component

### DIFF
--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -305,6 +305,23 @@ Content that is hidden by default should only be done so if it is non-essential 
 </form>
 ```
 
+#### Radio group
+
+Radio groups are tab-like inputs. Their blue border gives extra emphasis to what is selected.
+
+```html live
+<form>
+  <div class="radio-group">
+    <input class="radio-input" id="option-a" type="radio" name="options">
+    <label class="radio-label" for="option-a">Option A</label>
+    <input class="radio-input" id="option-b" type="radio" name="options">
+    <label class="radio-label" for="option-b">Option B</label>
+    <input class="radio-input" id="option-c" type="radio" name="options">
+    <label class="radio-label" for="option-c">Option C</label>
+  </div>
+</form>
+```
+
 #### Input group
 
 Attached an input and button to one another.

--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -307,7 +307,7 @@ Content that is hidden by default should only be done so if it is non-essential 
 
 #### Radio group
 
-Radio groups are tab-like inputs. Their blue border gives extra emphasis to what is selected.
+Radio groups are tab like controls. Their blue border gives extra emphasis to what is selected.
 
 ```html live
 <form>

--- a/src/forms/index.scss
+++ b/src/forms/index.scss
@@ -4,3 +4,4 @@
 @import "./form-group.scss";
 @import "./form-validation.scss";
 @import "./input-group.scss";
+@import "./radio-group.scss";

--- a/src/forms/radio-group.scss
+++ b/src/forms/radio-group.scss
@@ -20,11 +20,6 @@
     border-color: $border-blue;
   }
 
-  .octicon {
-    // stylelint-disable-next-line primer/spacing
-    padding-right: 5px;
-  }
-
   &:first-of-type {
     margin-left: 0;
     border-top-left-radius: $border-radius;

--- a/src/forms/radio-group.scss
+++ b/src/forms/radio-group.scss
@@ -1,0 +1,57 @@
+// Tab like radio group
+//
+// ``` html
+// <div class="radio-group">
+//   <input type="radio" class="radio-input" id="option-a">
+//   <label class="radio-label" for="option-a">Option A</label>
+//   <input type="radio" class="radio-input" id="option-b">
+//   <label class="radio-label" for="option-b">Option B</label>
+// </div>
+// ```
+// Needs refactoring
+
+.radio-group {
+  @include clearfix;
+}
+
+.radio-label {
+  float: left;
+  // stylelint-disable-next-line primer/variables
+  padding: $spacer-2 10px $spacer-2 35px;
+  // stylelint-disable-next-line primer/variables
+  margin-left: -1px;
+  color: $text-gray-dark;
+  cursor: pointer;
+  border: $border-width $border-style $border-gray-dark;
+
+  :checked + & {
+    position: relative;
+    z-index: 1;
+    // stylelint-disable-next-line primer/variables
+    border-color: $blue;
+  }
+
+  .octicon {
+    // stylelint-disable-next-line primer/variables
+    padding-right: 5px;
+  }
+
+  &:first-of-type {
+    margin-left: 0;
+    border-top-left-radius: $border-radius;
+    border-bottom-left-radius: $border-radius;
+  }
+
+  &:last-of-type {
+    padding-right: $spacer-3;
+    border-top-right-radius: $border-radius;
+    border-bottom-right-radius: $border-radius;
+  }
+}
+
+.radio-input {
+  z-index: 3;
+  float: left;
+  // stylelint-disable-next-line primer/variables
+  margin: 14px -35px 0 14px;
+}

--- a/src/forms/radio-group.scss
+++ b/src/forms/radio-group.scss
@@ -6,7 +6,6 @@
 
 .radio-label {
   float: left;
-  // stylelint-disable-next-line primer/spacing
   padding: $spacer-2 10px $spacer-2 35px;
   // stylelint-disable-next-line primer/spacing
   margin-left: -1px;

--- a/src/forms/radio-group.scss
+++ b/src/forms/radio-group.scss
@@ -6,9 +6,13 @@
 
 .radio-label {
   float: left;
-  padding: $spacer-2 10px $spacer-2 35px;
+  // stylelint-disable-next-line primer/spacing
+  padding: 6px $spacer-3 6px ($spacer-3 + 12px + $spacer-2); // 12px is the size of the radio-input
   // stylelint-disable-next-line primer/spacing
   margin-left: -1px;
+  font-size: $body-font-size;
+  // stylelint-disable-next-line primer/typography
+  line-height: 20px; // Specifically not inherit our `<body>` default
   color: $text-gray-dark;
   cursor: pointer;
   border: $border-width $border-style $border-gray-dark;
@@ -26,7 +30,6 @@
   }
 
   &:last-of-type {
-    padding-right: $spacer-3;
     border-top-right-radius: $border-radius;
     border-bottom-right-radius: $border-radius;
   }
@@ -36,5 +39,5 @@
   z-index: 3;
   float: left;
   // stylelint-disable-next-line primer/spacing
-  margin: 14px -35px 0 14px;
+  margin: 10px (-$spacer-5) 0 $spacer-3;
 }

--- a/src/forms/radio-group.scss
+++ b/src/forms/radio-group.scss
@@ -1,14 +1,4 @@
 // Tab like radio group
-//
-// ``` html
-// <div class="radio-group">
-//   <input type="radio" class="radio-input" id="option-a">
-//   <label class="radio-label" for="option-a">Option A</label>
-//   <input type="radio" class="radio-input" id="option-b">
-//   <label class="radio-label" for="option-b">Option B</label>
-// </div>
-// ```
-// Needs refactoring
 
 .radio-group {
   @include clearfix;
@@ -16,9 +6,9 @@
 
 .radio-label {
   float: left;
-  // stylelint-disable-next-line primer/variables
+  // stylelint-disable-next-line primer/spacing
   padding: $spacer-2 10px $spacer-2 35px;
-  // stylelint-disable-next-line primer/variables
+  // stylelint-disable-next-line primer/spacing
   margin-left: -1px;
   color: $text-gray-dark;
   cursor: pointer;
@@ -27,12 +17,11 @@
   :checked + & {
     position: relative;
     z-index: 1;
-    // stylelint-disable-next-line primer/variables
-    border-color: $blue;
+    border-color: $border-blue;
   }
 
   .octicon {
-    // stylelint-disable-next-line primer/variables
+    // stylelint-disable-next-line primer/spacing
     padding-right: 5px;
   }
 
@@ -52,6 +41,6 @@
 .radio-input {
   z-index: 3;
   float: left;
-  // stylelint-disable-next-line primer/variables
+  // stylelint-disable-next-line primer/spacing
   margin: 14px -35px 0 14px;
 }


### PR DESCRIPTION
This adds the `.radio-group` component from dotcom.

![radio-group](https://user-images.githubusercontent.com/378023/68455918-d94b3000-023f-11ea-9d60-a0d6d55d26aa.gif)

📖 [Docs Preview](https://primer-css-git-radio-group.primer.now.sh/css/components/forms#radio-group)

## TODO

- [x] Add styles from dotcom
- [x] Add documentation
- [x] Adjust spacing

### TODO on dotcom

- [ ] Remove `radio-group.scss` https://github.com/github/github/pull/128984

/cc @primer/ds-core

