### PR TITLE
Autocomplete + Suggester components

### DIFF
--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -1,0 +1,70 @@
+---
+title: Autocomplete
+path: components/autocomplete
+status: Stable
+source: 'https://github.com/primer/css/tree/master/src/autocomplete'
+bundle: autocomplete
+---
+
+## Autocomplete
+
+A list of items used to show autocompleted results. Use the [`<auto-complete>`](https://github.com/github/auto-complete-element) element to add functionality.
+
+```html live
+<div class="position-relative">
+  <input class="form-control input-block" type="text" aria-label="Search" placeholder="Search">
+  <ul class="autocomplete-results">
+    <li class="autocomplete-item" aria-selected="true">Option 1</li>
+    <li class="autocomplete-item">Option 2</li>
+    <li class="autocomplete-item">Option 3</li>
+  </ul>
+</div>
+
+<style>.frame-example {width:300px;height:160px;}</style>
+```
+
+Autocomplete items can contain attional content, like an `.avatar`. Or use utility classes to cusotmize the text style.
+
+```html live
+<div class="position-relative">
+  <input class="form-control input-block" type="text" aria-label="Search by user" placeholder="Search by user">
+  <ul class="autocomplete-results">
+    <li class="autocomplete-item" aria-selected="true">
+      <img src="https://github.com/github.png" width="20" class="avatar mr-1" alt="">
+      <span>GitHub Inc.</span>
+      <span class="text-normal">@github</span>
+    </li>
+    <li class="autocomplete-item">
+      <img src="https://github.com/hubot.png" width="20" class="avatar mr-1" alt="">
+      <span>Hubot</span>
+      <span class="text-normal">@hubot</span>
+    </li>
+    <li class="autocomplete-item">
+      <img src="https://github.com/octocat.png" width="20" class="avatar mr-1" alt="">
+      <span>Monalisa Octocat</span>
+      <span class="text-normal">@octocat</span>
+    </li>
+  </ul>
+</div>
+
+<style>.frame-example {width:300px;height:160px;}</style>
+```
+
+## Suggester
+
+The `.suggester` component is meant for showing suggestions while typing in a larger text area. Use the [`<text-expander>`](https://github.com/github/text-expander-element) element to add functionality.
+
+```html live
+<div class="form-group position-relative">
+  <textarea class="form-control width-full" placeholder="Leave a comment" aria-label="Comment body">#</textarea>
+  <ul class="suggester-container suggester suggestions list-style-none position-absolute" role="listbox" style="top: 4px; left: 18px;">
+    <li aria-selected="true"> <small>#924</small> <span>Markdown tables are inaccessible</span> </li>
+    <li> <small>#980</small> <span>Use actual book emoji in Flexbox docs</span> </li>
+    <li> <small>#979</small> <span>Add `.radio-group` component</span> </li>
+    <li> <small>#925</small> <span>Release 14.0.0</span> </li>
+    <li> <small>#978</small> <span>Add `.css-truncate-overflow`</span> </li>
+  </ul>
+</div>
+
+<style>.frame-example {height:260px;}</style>
+```

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -56,8 +56,8 @@ The `.suggester` component is meant for showing suggestions while typing in a la
 
 ```html live
 <div class="form-group position-relative">
-  <textarea class="form-control width-full" placeholder="Leave a comment" aria-label="Comment body">#</textarea>
-  <ul class="suggester-container suggester suggestions list-style-none position-absolute" role="listbox" style="top: 4px; left: 18px;">
+  <textarea class="form-control width-full" placeholder="Leave a comment" aria-label="Comment body">This is on top of #</textarea>
+  <ul class="suggester suggester-container" role="listbox" style="top: 4px; left: 125px;">
     <li aria-selected="true"> <small>#924</small> <span>Markdown tables are inaccessible</span> </li>
     <li> <small>#980</small> <span>Use actual book emoji in Flexbox docs</span> </li>
     <li> <small>#979</small> <span>Add `.radio-group` component</span> </li>

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -63,6 +63,8 @@
   children:
     - title: Alerts
       url: /components/alerts
+    - title: Autocomplete
+      url: /components/autocomplete
     - title: Avatars
       url: /components/avatars
     - title: Blankslate

--- a/src/autocomplete/README.md
+++ b/src/autocomplete/README.md
@@ -1,0 +1,25 @@
+---
+bundle: "autocomplete"
+generated: true
+---
+
+# Primer CSS: `autocomplete` bundle
+
+## Usage
+
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
+
+```scss
+@import "@primer/css/autocomplete/index.scss";
+```
+
+## Build
+
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/autocomplete.css`.
+
+## License
+
+[MIT](https://github.com/primer/css/blob/master/LICENSE) &copy; [GitHub](https://github.com/)
+
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -19,8 +19,7 @@
 
 .autocomplete-item {
   display: block;
-  // stylelint-disable-next-line primer/spacing
-  padding: 5px;
+  padding: $spacer-1 $spacer-2;
   overflow: hidden;
   font-weight: $font-weight-bold;
   text-decoration: none;

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -1,0 +1,65 @@
+// A pop up list of items used to show autocompleted results
+.autocomplete-results {
+  position: absolute;
+  z-index: 99;
+  width: 100%;
+  max-height: 20em;
+  overflow-y: auto;
+  // stylelint-disable-next-line primer/variables
+  font-size: 13px;
+  list-style: none;
+  background: $bg-white;
+  border-radius: $border-radius;
+  // stylelint-disable-next-line primer/variables
+  box-shadow: 0 0 5px $black-fade-30;
+}
+
+// One of the items that appears within an autocomplete group
+// Bold black text on white background
+
+.autocomplete-item {
+  display: block;
+  // stylelint-disable-next-line primer/variables
+  padding: 5px;
+  overflow: hidden;
+  font-weight: $font-weight-bold;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+
+  // stylelint-disable-next-line primer/no-override
+  &:hover,
+  &[aria-selected="true"],
+  &.selected,
+  &.navigation-focus {
+    color: $text-white;
+    text-decoration: none;
+    background-color: $bg-blue;
+
+    .organization-member,
+    .ldap-group-dn {
+      // stylelint-disable-next-line primer/variables
+      color: $gray-100;
+    }
+  }
+
+  .secondary-label {
+    font-weight: $font-weight-normal;
+  }
+
+  .organization-member {
+    float: right;
+    // stylelint-disable-next-line primer/variables
+    padding-top: 1px;
+    color: $text-gray-light;
+  }
+}
+
+// stylelint-disable-next-line primer/no-override
+.is-auto-complete-loading .form-control {
+  // stylelint-disable-next-line primer/variables
+  padding-right: 30px;
+  background-image: url("/images/spinners/octocat-spinner-32.gif");
+  background-size: 16px;
+}

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -28,7 +28,6 @@
   white-space: nowrap;
   cursor: pointer;
 
-  // stylelint-disable-next-line primer/no-override
   &:hover,
   &[aria-selected="true"],
   &.selected,
@@ -56,7 +55,6 @@
   }
 }
 
-// stylelint-disable-next-line primer/no-override
 .is-auto-complete-loading .form-control {
   // stylelint-disable-next-line primer/spacing
   padding-right: 30px;

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -42,10 +42,3 @@
     }
   }
 }
-
-.is-auto-complete-loading .form-control {
-  // stylelint-disable-next-line primer/spacing
-  padding-right: 30px;
-  background-image: url("/images/spinners/octocat-spinner-32.gif");
-  background-size: 16px;
-}

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -36,18 +36,10 @@
     text-decoration: none;
     background-color: $bg-blue;
 
-    .organization-member,
-    .ldap-group-dn {
-      // stylelint-disable-next-line primer/colors
-      color: $gray-100;
+    // Inherit color on all child elements to ensure enough contrast
+    * {
+      color: inherit !important;
     }
-  }
-
-  .organization-member {
-    float: right;
-    // stylelint-disable-next-line primer/spacing
-    padding-top: 1px;
-    color: $text-gray-light;
   }
 }
 

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -43,10 +43,6 @@
     }
   }
 
-  .secondary-label {
-    font-weight: $font-weight-normal;
-  }
-
   .organization-member {
     float: right;
     // stylelint-disable-next-line primer/spacing

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -5,12 +5,12 @@
   width: 100%;
   max-height: 20em;
   overflow-y: auto;
-  // stylelint-disable-next-line primer/variables
+  // stylelint-disable-next-line primer/typography
   font-size: 13px;
   list-style: none;
   background: $bg-white;
   border-radius: $border-radius;
-  // stylelint-disable-next-line primer/variables
+  // stylelint-disable-next-line primer/box-shadow
   box-shadow: 0 0 5px $black-fade-30;
 }
 
@@ -19,7 +19,7 @@
 
 .autocomplete-item {
   display: block;
-  // stylelint-disable-next-line primer/variables
+  // stylelint-disable-next-line primer/spacing
   padding: 5px;
   overflow: hidden;
   font-weight: $font-weight-bold;
@@ -39,7 +39,7 @@
 
     .organization-member,
     .ldap-group-dn {
-      // stylelint-disable-next-line primer/variables
+      // stylelint-disable-next-line primer/colors
       color: $gray-100;
     }
   }
@@ -50,7 +50,7 @@
 
   .organization-member {
     float: right;
-    // stylelint-disable-next-line primer/variables
+    // stylelint-disable-next-line primer/spacing
     padding-top: 1px;
     color: $text-gray-light;
   }
@@ -58,7 +58,7 @@
 
 // stylelint-disable-next-line primer/no-override
 .is-auto-complete-loading .form-control {
-  // stylelint-disable-next-line primer/variables
+  // stylelint-disable-next-line primer/spacing
   padding-right: 30px;
   background-image: url("/images/spinners/octocat-spinner-32.gif");
   background-size: 16px;

--- a/src/autocomplete/index.scss
+++ b/src/autocomplete/index.scss
@@ -1,0 +1,4 @@
+// support files
+@import "../support/index.scss";
+@import "./autocomplete.scss";
+@import "./suggester.scss";

--- a/src/autocomplete/suggester.scss
+++ b/src/autocomplete/suggester.scss
@@ -33,11 +33,9 @@
   margin-top: $spacer-4;
   cursor: pointer;
   background: $bg-white;
-  // stylelint-disable-next-line primer/borders
-  border: $border-width $border-style lighten($gray-300, 5%);
+  border: $border;
   border-radius: $border-radius;
-  // stylelint-disable-next-line primer/box-shadow
-  box-shadow: 0 0 5px rgba($black, 0.1);
+  box-shadow: $box-shadow-medium;
 
   ul {
     padding: 0;
@@ -49,8 +47,7 @@
     display: block;
     padding: $spacer-1 $spacer-2;
     font-weight: $font-weight-bold;
-    // stylelint-disable-next-line primer/borders
-    border-bottom: $border-width $border-style lighten($gray-300, 5%);
+    border-bottom: $border;
 
     small {
       font-weight: $font-weight-normal;

--- a/src/autocomplete/suggester.scss
+++ b/src/autocomplete/suggester.scss
@@ -5,11 +5,11 @@
   position: relative;
   top: 0;
   left: 0;
+  min-width: 180px;
   padding: 0;
   margin: 0;
-  list-style: none;
-  min-width: 180px;
   margin-top: $spacer-4;
+  list-style: none;
   cursor: pointer;
   background: $bg-white;
   border: $border;

--- a/src/autocomplete/suggester.scss
+++ b/src/autocomplete/suggester.scss
@@ -5,11 +5,6 @@
   top: 0;
   left: 0;
   z-index: 30;
-
-  // resizers and scrollbars in textareas float above suggester in Chrome, this stops that
-  // https://cloud.githubusercontent.com/assets/1153134/2996237/dcfab1f6-dcea-11e3-8918-63bad19a617b.gif
-  // https://code.google.com/p/chromium/issues/detail?id=158426
-  transform: translateZ(0);
 }
 
 .page-responsive {

--- a/src/autocomplete/suggester.scss
+++ b/src/autocomplete/suggester.scss
@@ -63,7 +63,7 @@
       border-bottom-left-radius: $border-radius;
     }
 
-    &:first-child a {
+    &:first-child {
       border-top-left-radius: $border-radius;
       border-top-right-radius: $border-radius;
     }

--- a/src/autocomplete/suggester.scss
+++ b/src/autocomplete/suggester.scss
@@ -68,7 +68,6 @@
       border-top-right-radius: $border-radius;
     }
 
-    // stylelint-disable-next-line primer/no-override
     &:hover,
     &[aria-selected="true"],
     &.navigation-focus {

--- a/src/autocomplete/suggester.scss
+++ b/src/autocomplete/suggester.scss
@@ -1,0 +1,84 @@
+// Needs refactoring
+// stylelint-disable selector-max-type, selector-no-qualifying-type
+.suggester-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 30;
+
+  // resizers and scrollbars in textareas float above suggester in Chrome, this stops that
+  // https://cloud.githubusercontent.com/assets/1153134/2996237/dcfab1f6-dcea-11e3-8918-63bad19a617b.gif
+  // https://code.google.com/p/chromium/issues/detail?id=158426
+  transform: translateZ(0);
+}
+
+.page-responsive {
+  @media (max-width: $width-sm) {
+    .suggester-container {
+      right: $spacer-2 !important;
+      left: $spacer-2 !important;
+    }
+
+    .suggester li {
+      padding: $spacer-2 $spacer-3;
+    }
+  }
+}
+
+.suggester {
+  position: relative;
+  top: 0;
+  left: 0;
+  min-width: 180px;
+  margin-top: $spacer-4;
+  cursor: pointer;
+  background: $bg-white;
+  // stylelint-disable-next-line primer/variables
+  border: $border-width $border-style lighten($gray-300, 5%);
+  border-radius: $border-radius;
+  // stylelint-disable-next-line primer/variables
+  box-shadow: 0 0 5px rgba($black, 0.1);
+
+  ul {
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  li {
+    display: block;
+    padding: $spacer-1 $spacer-2;
+    font-weight: $font-weight-bold;
+    // stylelint-disable-next-line primer/variables
+    border-bottom: $border-width $border-style lighten($gray-300, 5%);
+
+    small {
+      font-weight: $font-weight-normal;
+      color: $text-gray;
+    }
+
+    &:last-child {
+      border-bottom: 0;
+      border-bottom-right-radius: $border-radius;
+      border-bottom-left-radius: $border-radius;
+    }
+
+    &:first-child a {
+      border-top-left-radius: $border-radius;
+      border-top-right-radius: $border-radius;
+    }
+
+    // stylelint-disable-next-line primer/no-override
+    &:hover,
+    &[aria-selected="true"],
+    &.navigation-focus {
+      color: $text-white;
+      text-decoration: none;
+      background: $bg-blue;
+
+      small {
+        color: $text-white;
+      }
+    }
+  }
+}

--- a/src/autocomplete/suggester.scss
+++ b/src/autocomplete/suggester.scss
@@ -33,10 +33,10 @@
   margin-top: $spacer-4;
   cursor: pointer;
   background: $bg-white;
-  // stylelint-disable-next-line primer/variables
+  // stylelint-disable-next-line primer/borders
   border: $border-width $border-style lighten($gray-300, 5%);
   border-radius: $border-radius;
-  // stylelint-disable-next-line primer/variables
+  // stylelint-disable-next-line primer/box-shadow
   box-shadow: 0 0 5px rgba($black, 0.1);
 
   ul {
@@ -49,7 +49,7 @@
     display: block;
     padding: $spacer-1 $spacer-2;
     font-weight: $font-weight-bold;
-    // stylelint-disable-next-line primer/variables
+    // stylelint-disable-next-line primer/borders
     border-bottom: $border-width $border-style lighten($gray-300, 5%);
 
     small {

--- a/src/autocomplete/suggester.scss
+++ b/src/autocomplete/suggester.scss
@@ -1,29 +1,13 @@
 // Needs refactoring
 // stylelint-disable selector-max-type, selector-no-qualifying-type
-.suggester-container {
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 30;
-}
-
-.page-responsive {
-  @media (max-width: $width-sm) {
-    .suggester-container {
-      right: $spacer-2 !important;
-      left: $spacer-2 !important;
-    }
-
-    .suggester li {
-      padding: $spacer-2 $spacer-3;
-    }
-  }
-}
 
 .suggester {
   position: relative;
   top: 0;
   left: 0;
+  padding: 0;
+  margin: 0;
+  list-style: none;
   min-width: 180px;
   margin-top: $spacer-4;
   cursor: pointer;
@@ -31,12 +15,6 @@
   border: $border;
   border-radius: $border-radius;
   box-shadow: $box-shadow-medium;
-
-  ul {
-    padding: 0;
-    margin: 0;
-    list-style: none;
-  }
 
   li {
     display: block;
@@ -70,6 +48,28 @@
       small {
         color: $text-white;
       }
+    }
+  }
+}
+
+.suggester-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 30;
+}
+
+// Responsive
+
+.page-responsive {
+  @media (max-width: $width-sm) {
+    .suggester-container {
+      right: $spacer-2 !important;
+      left: $spacer-2 !important;
+    }
+
+    .suggester li {
+      padding: $spacer-2 $spacer-3;
     }
   }
 }

--- a/src/product/index.scss
+++ b/src/product/index.scss
@@ -10,6 +10,7 @@
 
 // Product specific css modules
 @import "../alerts/index.scss";
+@import "../autocomplete/index.scss";
 @import "../avatars/index.scss";
 @import "../blankslate/index.scss";
 @import "../branch-name/index.scss";


### PR DESCRIPTION
This adds the Autocomplete and Suggester components from dotcom.

`.autocomplete-results` | `.suggester`
--- | ---
![image](https://user-images.githubusercontent.com/378023/68913127-a653ef80-079d-11ea-8b77-25b7900c940e.png) | ![suggester](https://user-images.githubusercontent.com/378023/68918410-5da63180-07b1-11ea-9acd-8f1b3a37923a.png)

📖 [Docs Preview](https://primer-css-git-autocomplete.primer.now.sh/css/components/autocomplete)

## TODO

- [x] Add styles from dotcom
- [x] Add documentation
- [x] Refactor (partially)

### TODO on dotcom

- [ ] Remove `autocomplete.scss` https://github.com/github/github/pull/129266
- [ ] Remove `autosuggest.scss` https://github.com/github/github/pull/129266

/cc @primer/ds-core
