### PR TITLE
Responsive line-height utilities

### DIFF
--- a/docs/content/utilities/typography.md
+++ b/docs/content/utilities/typography.md
@@ -8,7 +8,7 @@ bundle: utilities
 
 Type utilities are designed to work in combination with line-height utilities so as to result in more sensible numbers wherever possible. These also exist as [variables](/css/support/typography#typography-variables) that you can use in components or custom CSS.
 
- 
+
 
 Font sizes are smaller on mobile and scale up at the `md` [breakpoint](/css/support/breakpoints) to be larger on desktop.
 
@@ -67,7 +67,8 @@ Lighter font-weight utilities are available in a limited range. Lighter font-wei
 ```
 
 ## Line height styles
-Change the line height density with these utilities.
+
+Change the line height density with these utilities. Responsive variants are also available (e.g. `.lh-sm-condensed`).
 
 ```html live
 <p class="lh-default">

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -161,14 +161,19 @@
 // Close to commonly used line-heights. Most line-heights
 // combined with type size equate to whole pixels.
 // Will be improved with future typography scale updates.
-/* Set the line height to ultra condensed */
-.lh-condensed-ultra { line-height: $lh-condensed-ultra !important; }
-/* Set the line height to condensed */
-.lh-condensed { line-height: $lh-condensed !important; }
-/* Set the line height to default */
-.lh-default { line-height: $lh-default !important; }
-/* Set the line height to zero */
-.lh-0 { line-height: 0 !important; }
+// Responsive line-height
+@each $breakpoint, $variant in $responsive-variants {
+  @include breakpoint($breakpoint) {
+    /* Set the line height to ultra condensed */
+    .lh#{$variant}-condensed-ultra { line-height: $lh-condensed-ultra !important; }
+    /* Set the line height to condensed */
+    .lh#{$variant}-condensed { line-height: $lh-condensed !important; }
+    /* Set the line height to default */
+    .lh#{$variant}-default { line-height: $lh-default !important; }
+    /* Set the line height to zero */
+    .lh#{$variant}-0 { line-height: 0 !important; }
+  }
+}
 
 // Text alignments
 // Responsive text alignment


### PR DESCRIPTION
This adds responsive variants to the line-height utilities.

- `.lh-[sm|md|lg|xl]-condensed-ultra`
- `.lh-[sm|md|lg|xl]-condensed`
- `.lh-[sm|md|lg|xl]-default`
- `.lh-[sm|md|lg|xl]-0`

![rlh](https://user-images.githubusercontent.com/378023/70691416-64ff2300-1cfc-11ea-8d9c-b008aaf87ce8.gif)

## Bundle size changes

```
┌─────────────────────┬───────────┬───────┬───────────┬──────────┬──────────┬───────────┬──────────────────────────────┐
│ name                │ selectors │     ± │ gzip size │        ± │ raw size │         ± │ path                         │
├─────────────────────┼───────────┼───────┼───────────┼──────────┼──────────┼───────────┼──────────────────────────────┤
│ primer              │      3386 │  + 16 │   27.47 K │   + 90 B │ 172.64 K │   + 786 B │ dist/primer.css              │
│ core                │      2254 │  + 16 │   17.95 K │   + 92 B │ 114.15 K │   + 786 B │ dist/core.css                │
│ utilities           │      1381 │  + 16 │    8.75 K │   + 91 B │  66.76 K │   + 786 B │ dist/utilities.css           │
```

`+ 90 B` gzipped should be fine. 👍 

---

Closes #993 