### PR TITLE
Add bold weight to marketing font variables

### DIFF
--- a/src/marketing/support/variables.scss
+++ b/src/marketing/support/variables.scss
@@ -17,6 +17,14 @@ $marketing-font-path: "/fonts/" !default;
   font-display: swap;
 }
 
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: $font-weight-bold;
+  src: local("Inter Bold"), local("Inter-Bold"), url("#{$marketing-font-path}Inter-Bold.woff") format("woff");
+  font-display: swap;
+}
+
 $font-mktg: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
 
 // Builds upon @primer/css/support/variables/typography.scss


### PR DESCRIPTION
The Site Design team has new designs that require a bolder type than our medium/semibold weight. 

cc @ohaicristina @teenage-witch 