### PR TITLE
Use a gray background when hovering SelectMenu items

### DIFF
--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -254,11 +254,47 @@ The Select Menu's list can be divided into multiple parts by adding a `.SelectMe
 <div class="d-none d-sm-block" style="height: 260px"><!-- min height for > sm --></div>
 ```
 
-## Additional filter and footer
+## Footer
+
+Use a `.SelectMenu-footer` at the bottom for additional information. As a side effect it can greatly improve the scrolling performance because the list doesn't need to be repainted due to the rounded corners.
+
+```html live
+<details class="details-reset details-overlay" open>
+  <summary class="btn" aria-haspopup="true">
+    Choose an item
+  </summary>
+  <div class="SelectMenu">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <h3 class="SelectMenu-title">Title</h3>
+        <button class="SelectMenu-closeButton" type="button">
+          <!-- <%= octicon "x" %> -->
+          <svg width="12" height="16" viewBox="0 0 12 16" class="octicon octicon-x" aria-hidden="true">
+            <path fill-rule="evenodd"
+              d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
+            />
+          </svg>
+        </button>
+      </header>
+      <div class="SelectMenu-list">
+        <button class="SelectMenu-item" role="menuitem">Item 1</button>
+        <button class="SelectMenu-item" role="menuitem">Item 2</button>
+        <button class="SelectMenu-item" role="menuitem">Item 3</button>
+        <button class="SelectMenu-item" role="menuitem">Item 4</button>
+        <button class="SelectMenu-item" role="menuitem">Item 5</button>
+      </div>
+      <footer class="SelectMenu-footer">Footer</footer>
+    </div>
+  </div>
+</details>
+
+<div class="d-sm-none" style="height: 600px"><!-- min height for < sm --></div>
+<div class="d-none d-sm-block" style="height: 260px"><!-- min height for > sm --></div>
+```
+
+## Filter
 
 If the list is expected to get long, consider adding a `.SelectMenu-filter` input. Be sure to also include the `.SelectMenu--hasFilter` modifier class. On mobile devices it will add a fixed height and anchor the Select Menu to the top of the screen. This makes sure the filter input stays at the same position while typing.
-
-Also consider adding a `.SelectMenu-footer` at the bottom. It can be used for additional information, but can also greatly improve the scrolling performance because the list doesn't need to be repainted due to the rounded corners.
 
 ```html live
 <details class="details-reset details-overlay" open>

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -264,6 +264,7 @@ $SelectMenu-max-height: 480px !default;
   &[aria-selected="true"] {
     z-index: 1; // Keeps box-shadow visible when hovering
     color: $text-gray-dark;
+    cursor: default;
     background-color: $bg-white;
     // stylelint-disable-next-line primer/box-shadow
     box-shadow: 0 0 0 1px $border-color;
@@ -392,13 +393,13 @@ $SelectMenu-max-height: 480px !default;
     background-color: $blue-100;
   }
 
-  .SelectMenu-tab:not([aria-checked="true"]):hover {
+  .SelectMenu-tab:not([aria-selected="true"]):hover {
     color: $text-gray-dark;
     // stylelint-disable-next-line primer/colors
     background-color: $gray-200;
   }
 
-  .SelectMenu-tab:not([aria-checked="true"]):active {
+  .SelectMenu-tab:not([aria-selected="true"]):active {
     color: $text-gray-dark;
     background-color: $bg-gray;
   }

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -378,14 +378,11 @@ $SelectMenu-max-height: 480px !default;
 @media (hover: hover) {
   body:not(.intent-mouse) .SelectMenu-item:focus,
   .SelectMenu-item:hover {
-    color: $text-white;
-    background-color: $bg-blue;
+    background-color: $bg-gray;
   }
 
   .SelectMenu-item:active {
-    color: $text-white;
-    // stylelint-disable-next-line primer/colors
-    background-color: $blue-400;
+    background-color: $bg-gray-light;
   }
 
   body:not(.intent-mouse) .SelectMenu-tab:focus {


### PR DESCRIPTION
This is a follow-up for https://github.com/github/github/pull/130408 and moves the changes "downstream".

- [x] Fix hover of selected tabs
- [x] Use gray background when an item gets hovered/focused
- [x] Split filter and footer in the docs (bonus)

Here the biggest visual change: Replace the blue background with gray:

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/378023/70906047-cc90d780-2048-11ea-8bc5-49d31bc5ca90.png) | ![image](https://user-images.githubusercontent.com/378023/70905994-acf9af00-2048-11ea-92c3-e9490a06756b.png)

## Motivation

The main motivation behind the change to use a gray background is to avoid clashing of colors. On dotcom there are cases where SelectMenu items can contain colored icons or color swatches. Using a light gray background makes sure those colors stand out enough.

![Screen Shot 2019-12-11 at 11 54 10 AM](https://user-images.githubusercontent.com/378023/70906573-08786c80-204a-11ea-98de-33a122321a36.png)

Note: Dropdown menus are unchanged and keep the blue background.

## Concerns

- GitHub's iconic "blue on hover" is lost.
- The hover effect with gray is also more subtle and maybe harder to see.