### PR TITLE
Fix marketing utilities II

### DIFF
--- a/src/marketing/utilities/index.scss
+++ b/src/marketing/utilities/index.scss
@@ -3,5 +3,5 @@
 @import "./filters.scss";
 @import "./borders.scss";
 @import "./layout.scss";
-@import "./margin.scss";
-@import "./padding.scss";
+// @import "./margin.scss";
+// @import "./padding.scss";

--- a/src/support/variables/layout.scss
+++ b/src/support/variables/layout.scss
@@ -40,6 +40,13 @@ $spacer-4: $spacer * 3 !default;        // 24px
 $spacer-5: $spacer * 4 !default;        // 32px
 $spacer-6: $spacer * 5 !default;        // 40px
 
+$spacer-7:  $spacer * 6 !default;  // 48px
+$spacer-8:  $spacer * 8 !default;  // 64px
+$spacer-9:  $spacer * 10 !default; // 80px
+$spacer-10: $spacer * 12 !default; // 96px
+$spacer-11: $spacer * 14 !default; // 112px
+$spacer-12: $spacer * 16 !default; // 128px
+
 // The list of spacer values
 $spacers: (
   $spacer-0,
@@ -49,6 +56,12 @@ $spacers: (
   $spacer-4,
   $spacer-5,
   $spacer-6,
+  $spacer-7,
+  $spacer-8,
+  $spacer-9,
+  $spacer-10,
+  $spacer-11,
+  $spacer-12
 ) !default;
 
 // And the map of spacers, for easier looping:
@@ -61,6 +74,12 @@ $spacer-map: (
   4: $spacer-4,
   5: $spacer-5,
   6: $spacer-6,
+  7: $spacer-7,
+  8: $spacer-8,
+  9: $spacer-9,
+  10: $spacer-10,
+  11: $spacer-11,
+  12: $spacer-12
 ) !default;
 
 // Em spacer variables


### PR DESCRIPTION
This is an alternative to #1002. It moves the marketing spacers (7-12) to core.

It should fix an issue where you couldn't use `mb-9 mb-md-4`, see https://github.com/github/site-design/issues/809.

## Concerns

The marketing bundle would shrink by `- 11.87 K` (`- 1.3 K` gzipped) and the core bundle would increase by `+ 23.39 K` (`+ 2.53 K` gzipped).

```
┌─────────────────────┬───────────┬───────┬───────────┬──────────┬──────────┬───────────┬──────────────────────────────┐
│ name                │ selectors │     ± │ gzip size │        ± │ raw size │         ± │ path                         │
├─────────────────────┼───────────┼───────┼───────────┼──────────┼──────────┼───────────┼──────────────────────────────┤
│ primer              │      3658 │ + 270 │   28.63 K │ + 1.12 K │ 184.96 K │ + 11.53 K │ dist/primer.css              │
│ core                │      2794 │ + 540 │   20.48 K │ + 2.53 K │ 137.54 K │ + 23.39 K │ dist/core.css                │
│ utilities           │      1921 │ + 540 │   11.17 K │ + 2.43 K │  90.16 K │ + 23.39 K │ dist/utilities.css           │
│ product             │       474 │     0 │    6.36 K │        0 │  31.15 K │         0 │ dist/product.css             │
│ forms               │       200 │     0 │     3.1 K │        0 │  12.51 K │         0 │ dist/forms.css               │
│ marketing           │       390 │ - 270 │    2.71 K │  - 1.3 K │  16.16 K │ - 11.87 K │ dist/marketing.css           │
│ buttons             │       137 │     0 │    1.79 K │        0 │   8.56 K │         0 │ dist/buttons.css             │
│ marketing-utilities │       348 │ - 270 │    1.75 K │ - 1.28 K │  11.92 K │ - 11.87 K │ dist/marketing-utilities.css │
```

I guess because marketing pages also use core, it would be more like:

- Product pages `+ 2.53 K` gzipped
- Marketing pages `+ 1.12 K` gzipped

Maybe #1003 is still the better option?