### PR TITLE
Add .selected back to the .UnderlineNav

### DIFF
--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -32,6 +32,7 @@
     }
   }
 
+  &.selected,
   &[role=tab][aria-selected=true],
   &[aria-current] {
     font-weight: $font-weight-bold;


### PR DESCRIPTION
This PR adds the `.selected` class back to the `.UnderlineNav` component.

## Reasoning

It was removed in [#971](https://github.com/primer/css/pull/971/files?file-filters%5B%5D=.scss#diff-44cbb5c5d67ae1194e10ef94b0de061b
). But `.selected` still gets used on dotcom in various places. So a temporary fix was added with https://github.com/github/github/pull/131624.

Maybe one day we can remove `.selected` again. As well as the rest https://github.com/primer/css/pull/983. But before we release it, it would be good to first refactor dotcom and change everything to use `aria-selected=true`.

## TODO on dotcom

- [ ] Revert https://github.com/github/github/pull/131624