### PR TITLE
Add aria-disabled state

### DIFF
--- a/docs/content/components/buttons.md
+++ b/docs/content/components/buttons.md
@@ -75,28 +75,28 @@ Use `.btn-large` with a type scale utility to transform the text to a bigger siz
 
 ## Disabled state
 
-Disable `<button>` elements with the boolean `disabled` attribute and `<a>` elements with the `.disabled` class.
+Disable `<button>` and `<a>` elements with the `aria-disabled="true"` attribute.
 
 ```html live
-<button class="btn mr-2" type="button" disabled>Disabled button</button>
-<a class="btn disabled" href="#url" role="button">Disabled button</a>
+<button class="btn mr-2" type="button" aria-disabled="true">Disabled button</button>
+<a class="btn" href="#url" role="button" aria-disabled="true">Disabled button</a>
 ```
 
 Similar styles are applied to primary, danger, and outline buttons:
 
 ```html live
-<button class="btn btn-primary mr-2" type="button" disabled>Disabled button</button>
-<a class="btn btn-primary disabled" href="#url" role="button">Disabled button</a>
+<button class="btn btn-primary mr-2" type="button" aria-disabled="true">Disabled button</button>
+<a class="btn btn-primary" href="#url" role="button" aria-disabled="true">Disabled button</a>
 ```
 
 ```html live
-<button class="btn btn-danger mr-2" type="button" disabled>Disabled button</button>
-<a class="btn btn-danger disabled" href="#url" role="button">Disabled button</a>
+<button class="btn btn-danger mr-2" type="button" aria-disabled="true">Disabled button</button>
+<a class="btn btn-danger" href="#url" role="button" aria-disabled="true">Disabled button</a>
 ```
 
 ```html live
-<button class="btn btn-outline mr-2" type="button" disabled>Disabled button</button>
-<a class="btn btn-outline disabled" href="#url" role="button">Disabled button</a>
+<button class="btn btn-outline mr-2" type="button" aria-disabled="true">Disabled button</button>
+<a class="btn btn-outline" href="#url" role="button" aria-disabled="true">Disabled button</a>
 ```
 
 ## Block button

--- a/docs/content/components/loaders.md
+++ b/docs/content/components/loaders.md
@@ -22,5 +22,5 @@ It can also be used in combination with other components.
 <h2><span>Loading</span><span class="AnimatedEllipsis"></span></h2>
 <span class="branch-name mt-2"><span>Loading</span><span class="AnimatedEllipsis"></span></span><br>
 <span class="Label bg-blue mt-3"><span>Loading</span><span class="AnimatedEllipsis"></span></span><br>
-<button class="btn mt-3" disabled><span>Loading</span><span class="AnimatedEllipsis"></span></button>
+<button class="btn mt-3" aria-disabled="true"><span>Loading</span><span class="AnimatedEllipsis"></span></button>
 ```

--- a/docs/content/components/pagination.md
+++ b/docs/content/components/pagination.md
@@ -10,12 +10,12 @@ Use the pagination component to apply button styles to a connected set of links 
 
 ## Previous/next pagination
 
-You can make a very simple pagination container with just the Previous and Next buttons. Add the class `disabled` to the `Previous` button if there isn't a preceding page, or to the `Next` button if there isn't a succeeding page.
+You can make a very simple pagination container with just the Previous and Next buttons. Add the `aria-disabled="true"` attribute to the `Previous` button if there isn't a preceding page, or to the `Next` button if there isn't a succeeding page.
 
 ```html live
 <nav class="paginate-container" aria-label="Pagination">
   <div class="pagination">
-    <span class="previous_page disabled">Previous</span>
+    <span class="previous_page" aria-disabled="true">Previous</span>
     <a class="next_page" rel="next" href="#url" aria-label="Next Page">Next</a>
   </div>
 </nav>
@@ -25,7 +25,7 @@ You can make a very simple pagination container with just the Previous and Next 
 
 For pagination across multiple pages, make sure it's clear to the user where they are in a set of pages.
 
-To do this, add anchor links to the `pagination` element. Previous and Next buttons should always be present. Add the class `disabled` to the Previous button if you're on the first page. Apply the class `current` to the current numbered page.
+To do this, add anchor links to the `pagination` element. Previous and Next buttons should always be present. Add the `aria-disabled="true"` attribute to the Previous button if you're on the first page. Apply the class `current` to the current numbered page.
 
 As always, make sure to include the appropriate `aria` attributes to make the element accessible.
 
@@ -36,7 +36,7 @@ As always, make sure to include the appropriate `aria` attributes to make the el
 ```html live
 <nav class="paginate-container" aria-label="Pagination">
   <div class="pagination">
-    <span class="previous_page disabled">Previous</span>
+    <span class="previous_page" aria-disabled="true">Previous</span>
     <em class="current selected" aria-current="true">1</em>
     <a href="#url" aria-label="Page 2">2</a>
     <a href="#url" aria-label="Page 3">3</a>

--- a/docs/content/principles/html.md
+++ b/docs/content/principles/html.md
@@ -3,7 +3,7 @@ title: HTML
 path: principles/html
 ---
 
- 
+
 
 ## General formatting
 
@@ -24,11 +24,9 @@ path: principles/html
 
 ## Boolean attributes
 
-Many attributes don't require a value to be set, like `disabled` or `checked`, so don't set them.
+Many attributes don't require a value to be set, like `checked`, so don't set them.
 
 ```html inert=true
-<input type="text" disabled>
-
 <input type="checkbox" value="1" checked>
 
 <select>

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -50,7 +50,8 @@
   }
 
   &:disabled,
-  &.disabled {
+  &.disabled,
+  &[aria-disabled=true] {
     cursor: default;
     // Repeat `background-position` because `:hover`
     background-position: 0 0;
@@ -130,7 +131,8 @@
     text-decoration: underline;
   }
 
-  &:disabled {
+  &:disabled,
+  &[aria-disabled=true] {
     &,
     &:hover {
       // stylelint-disable-next-line primer/colors
@@ -181,7 +183,8 @@
 
   &:hover { color: $text-blue; }
 
-  &.disabled {
+  &.disabled,
+  &[aria-disabled=true] {
     // stylelint-disable-next-line primer/colors
     color: $gray-400;
     cursor: default;

--- a/src/marketing/buttons/button.scss
+++ b/src/marketing/buttons/button.scss
@@ -29,7 +29,8 @@
   }
 
   &:disabled,
-  &.disabled {
+  &.disabled,
+  &[aria-disabled=true] {
     pointer-events: none; // Disable hover styles
     cursor: default;
     opacity: 0.65;

--- a/src/pagination/pagination.scss
+++ b/src/pagination/pagination.scss
@@ -58,8 +58,10 @@
 
   .gap,
   .disabled,
+  [aria-disabled=true],
   .gap:hover,
-  .disabled:hover {
+  .disabled:hover,
+  [aria-disabled=true]:hover {
     // stylelint-disable-next-line primer/colors
     color: $gray-300;
     cursor: default;

--- a/src/support/mixins/buttons.scss
+++ b/src/support/mixins/buttons.scss
@@ -30,7 +30,8 @@
     }
 
     &:disabled,
-    &.disabled {
+    &.disabled,
+    &[aria-disabled=true] {
       color: rgba($color, 0.4);
       background-color: $bg2;
       background-image: none;
@@ -63,7 +64,8 @@
     }
 
     &:disabled,
-    &.disabled {
+    &.disabled,
+    &[aria-disabled=true] {
       color: rgba($color, 0.75);
       background-color: mix($bg2, $white, 50%);
       background-image: none;
@@ -110,7 +112,8 @@
   }
 
   &:disabled,
-  &.disabled {
+  &.disabled,
+  &[aria-disabled=true] {
     color: rgba($color, 0.4);
     background-color: $bg2;
     background-image: none;
@@ -150,7 +153,8 @@
   }
 
   &:disabled,
-  &.disabled {
+  &.disabled,
+  &[aria-disabled=true] {
     color: $black-fade-30;
     background-color: $bg-white;
     border-color: $black-fade-15;


### PR DESCRIPTION
This is an alternative to #983 and in the same spirit as #1006.

But instead of _replacing_ the `.disabled` class, it only adds `[aria-disabled=true]`. Making it easier to introduce without the need to refactor dotcom's many places where currently the `.disabled` class and `disabled` attribute is being used.

- [x] Add `[aria-disabled=true]`
- [x] Update docs

**Note**: The `disabled` attribute and `.disabled` class can still be used for styling, it's just not encouraged and therefore not documented.

---

Ref. #791
Superseeds and closes #983
