### PR TITLE
Remove negative margin from Box-header

### DIFF
--- a/src/box/box.scss
+++ b/src/box/box.scss
@@ -72,12 +72,10 @@
 
 .Box-header {
   padding: $spacer-3;
-  // stylelint-disable-next-line primer/spacing
-  margin: (-$border-width) (-$border-width) 0;
   background-color: $bg-gray;
   border-color: $border-gray-dark;
   border-style: $border-style;
-  border-width: $border-width;
+  border-width: 0 0 $border-width;
   border-top-left-radius: $border-radius;
   border-top-right-radius: $border-radius;
 }


### PR DESCRIPTION
This removes the negative margin from `Box-header` because we're running into rendering issues with it on responsive pages. https://github.com/github/github/pull/134877

There's a white line across the nav and a white line along the side of the page. Toggling the negative margin off fixes this issue.

![image](https://user-images.githubusercontent.com/54012/74057705-59954480-4999-11ea-92ae-c0583b954f43.png)


