### PR TITLE
New button style

### DIFF
--- a/docs/content/components/buttons.md
+++ b/docs/content/components/buttons.md
@@ -166,6 +166,37 @@ When using the `octicon-x` icon for a close button, add `.close-button` to remov
 </button>
 ```
 
+## Button with icons
+
+Icons can be added to any button.
+
+```html live
+<button class="btn mr-2" type="button">
+  <!-- <%= octicon "search" %> -->
+  <svg class="octicon octicon-search" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0013 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 000-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"></path></svg>
+  <span>Find file</span>
+</button>
+
+<button class="btn btn-primary mr-2" type="button">
+  <!-- <%= octicon "cloud-download" %> -->
+  <svg class="octicon octicon-cloud-download" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9 12h2l-3 3-3-3h2V7h2v5zm3-8c0-.44-.91-3-4.5-3C5.08 1 3 2.92 3 5 1.02 5 0 6.52 0 8c0 1.53 1 3 3 3h3V9.7H3C1.38 9.7 1.3 8.28 1.3 8c0-.17.05-1.7 1.7-1.7h1.3V5c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V11h2c2.08 0 4-1.16 4-3.5C16 5.06 14.08 4 12 4z"></path></svg>
+  <span>Clone</span>
+  <span class="dropdown-caret"></span>
+</button>
+
+<button class="btn btn-danger mr-2" type="button">
+  <!-- <%= octicon "trashcan" %> -->
+  <svg class="octicon octicon-trashcan" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"></path></svg>
+  <span>Delete</span>
+</button>
+
+<button class="btn btn-outline" type="button">
+  <!-- <%= octicon "device-desktop" %> -->
+  <svg class="octicon octicon-device-desktop" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15 2H1c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h5.34c-.25.61-.86 1.39-2.34 2h8c-1.48-.61-2.09-1.39-2.34-2H15c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 9H1V3h14v8z"></path></svg>
+  <span>Open in Desktop</span>
+</button>
+```
+
 ## Button with counts
 
 You can easily append a count to a **small button**. Add the `.with-count` class to the `.btn-sm` and then add the `.social-count` after the button.

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -184,6 +184,10 @@
     border-color: $border;
     box-shadow: 0 1px 0 rgba($shadow, 0.1), inset 0 1px 0 rgba($white, 0.03);
 
+    &:focus {
+      box-shadow: 0 0 0 3px rgba($bg, 0.4);
+    }
+
     .Counter {
       background-color: darken($bg, 12%);
     }

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -19,7 +19,7 @@
   background-size: 110% 110%;
   border: $border-width $border-style $border-color-button;
   // stylelint-disable-next-line primer/borders
-  border-radius: 0.25em;
+  border-radius: $border-radius;
   appearance: none; // Corrects inability to style clickable `input` types in iOS.
 
   i {

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -5,44 +5,22 @@
   position: relative;
   display: inline-block;
   // stylelint-disable-next-line primer/spacing
-  padding: 6px 12px;
+  padding: 6px $spacer-3;
   font-size: $body-font-size;
-  font-weight: $font-weight-bold;
+  // stylelint-disable-next-line primer/typography
+  font-weight: 500;
   // stylelint-disable-next-line primer/typography
   line-height: 20px; // Specifically not inherit our `<body>` default
   white-space: nowrap;
   vertical-align: middle;
   cursor: pointer;
   user-select: none;
-  background-repeat: repeat-x;
-  background-position: -1px -1px;
-  background-size: 110% 110%;
-  border: $border-width $border-style $border-color-button;
-  // stylelint-disable-next-line primer/borders
+  border: $border-width $border-style;
   border-radius: $border-radius;
   appearance: none; // Corrects inability to style clickable `input` types in iOS.
 
-  i {
-    font-style: normal;
-    font-weight: $font-weight-semibold;
-    opacity: 0.75;
-  }
-
-  .octicon {
-    vertical-align: text-top;
-  }
-
-  // Darken for just a tad more contrast against the button background
-  .Counter {
-    color: $text-gray;
-    text-shadow: none;
-    // stylelint-disable-next-line primer/colors
-    background-color: rgba($black, 0.1);
-  }
-
   &:hover {
     text-decoration: none;
-    background-repeat: repeat-x;
   }
 
   &:focus {
@@ -53,31 +31,229 @@
   &.disabled,
   &[aria-disabled=true] {
     cursor: default;
-    // Repeat `background-position` because `:hover`
-    background-position: 0 0;
+  }
+
+  i {
+    font-style: normal;
+    font-weight: $font-weight-semibold;
+    opacity: 0.75;
+  }
+
+  .octicon {
+    margin-right: $spacer-1;
+    color: $text-gray-light;
+    vertical-align: text-bottom;
+  }
+
+  // Darken for just a tad more contrast against the button background
+  .Counter {
+    // stylelint-disable-next-line primer/spacing
+    margin-left: 2px;
+    color: $text-gray;
+    text-shadow: none;
+    // stylelint-disable-next-line primer/colors
+    background-color: rgba($black, 0.1);
+  }
+
+  .dropdown-caret {
+    margin-left: $spacer-1;
+    opacity: 0.6;
+  }
+}
+
+// Default button
+
+.btn {
+  $bg-hover: #f3f4f6; // custom gray
+
+  color: $text-gray-dark;
+  background-color: $bg-gray-light;
+  border-color: $border-color-button;
+  // stylelint-disable-next-line primer/box-shadow
+  box-shadow: 0 1px 0 rgba($gray-400, 0.1), inset 0 1px 0 rgba($white, 0.25);
+
+  &:focus,
+  &.focus {
+    border-color: transparent;
+    box-shadow: $btn-input-focus-shadow;
+  }
+
+  &:hover,
+  &.hover {
+    background-color: $bg-hover;
   }
 
   &:active,
   &.selected,
-  &[aria-selected=true] {
-    background-image: none;
+  &[aria-selected=true],
+  [open] > & {
+    background-color: $bg-hover;
+    border-color: $border-gray-dark;
+    box-shadow: none;
+  }
+
+  &:disabled,
+  &.disabled,
+  &[aria-disabled=true] {
+    // stylelint-disable-next-line primer/colors
+    color: $gray-400;
+    background-color: $bg-hover;
+    border-color: $border-color-button;
   }
 }
 
-.btn         { @include btn-solid($text-gray-dark, $gray-000, darken($gray-100, 2%)); }
-.btn-primary { @include btn-solid($text-white, $green-400, $green-500); }
-.btn-blue    { @include btn-solid($text-white, lighten($blue-500, 8%), darken($blue-500, 2%)); }
-.btn-danger  { @include btn-inverse($red-600, $gray-000, darken($gray-100, 2%)); }
+// Primary button
+
+.btn-primary {
+  $bg: #159739; // custom green
+  $border-color: $green-600;
+  $shadow: $green-900;
+  $box-shadow: 0 1px 0 rgba($shadow, 0.1), inset 0 1px 0 rgba($white, 0.03);
+
+  $bg-hover: #138934; // custom green
+  $border-hover: $green-700;
+  $bg-disabled: #94d3a2; // custom green
+
+  color: $text-white;
+  // stylelint-disable-next-line primer/colors
+  background-color: $bg;
+  border-color: $border-color;
+  box-shadow: $box-shadow;
+
+  &:focus,
+  &.focus {
+    // stylelint-disable-next-line primer/colors
+    background-color: $bg;
+    border-color: transparent;
+    // stylelint-disable-next-line primer/box-shadow
+    box-shadow: 0 0 0 3px rgba($bg, 0.4);
+  }
+
+  &:hover,
+  &.hover {
+    background-color: $bg-hover;
+    border-color: $border-hover;
+  }
+
+  &:active,
+  &.selected,
+  &[aria-selected=true],
+  [open] > & {
+    background-color: $bg-hover;
+    border-color: $border-color;
+    // stylelint-disable-next-line primer/box-shadow
+    box-shadow: inset 0 1px 0 rgba($shadow, 0.2);
+  }
+
+  &:disabled,
+  &.disabled,
+  &[aria-disabled=true] {
+    // stylelint-disable-next-line primer/colors
+    color: rgba($text-white, 0.5);
+    background-color: $bg-disabled;
+    // stylelint-disable-next-line primer/borders
+    border-color: rgba($green-600, 0.1);
+    box-shadow: $box-shadow;
+  }
+
+  .Counter {
+    // stylelint-disable-next-line primer/colors
+    color: darken($bg, 6%);
+    background-color: $bg-white;
+  }
+
+  .octicon {
+    color: inherit;
+  }
+}
+
+// Mixin: btn-inverse-on-hover
+//
+// Args: $color, $bg, $border
+@mixin btn-inverse-on-hover( $color, $bg, $border, $shadow ) {
+  color: $color;
+
+  &:focus {
+    border-color: transparent;
+    box-shadow: 0 0 0 3px rgba($bg, 0.4);
+  }
+
+  &:hover {
+    color: $text-white;
+    background-color: $bg;
+    border-color: $border;
+    box-shadow: 0 1px 0 rgba($shadow, 0.1), inset 0 1px 0 rgba($white, 0.03);
+
+    .Counter {
+      background-color: darken($bg, 12%);
+    }
+
+    .octicon {
+      color: inherit;
+    }
+  }
+
+  &:active,
+  &.selected,
+  &[aria-selected=true],
+  [open] > & {
+    color: $text-white;
+    background-color: $bg;
+    border-color: $border;
+    box-shadow: inset 0 1px 0 rgba($shadow, 0.2);
+  }
+
+  &:disabled,
+  &.disabled,
+  &[aria-disabled=true] {
+    color: rgba($color, 0.5);
+    background-color: #f3f4f6;
+    border-color: $border-color-button;
+    box-shadow: 0 1px 0 rgba($gray-400, 0.1), inset 0 1px 0 rgba($white, 0.25);
+  }
+
+  .Counter {
+    color: inherit;
+    background-color: rgba($color, 0.1);
+  }
+}
+
+// Danger button
+
+.btn-danger {
+  @include btn-inverse-on-hover(
+    $color: $text-red,
+    $bg: $red-600,
+    $border: $red-700,
+    $shadow: $red-900
+  );
+}
 
 // Outline button
-//
-// For when we need a linky-action that's not too heavy in busier
-// areas like conversation timelines.
+
 .btn-outline {
-  @include btn-outline($text-blue);
+  @include btn-inverse-on-hover(
+    $color: $blue-600,
+    $bg: $blue-500,
+    $border: $blue-600,
+    $shadow: $blue-900
+  );
+}
+
+// Solid buttons TODO: Deprecate?
+//
+//
+.btn-blue {
+  @include btn-solid(
+    $text-white,
+    lighten($blue-500, 8%),
+    darken($blue-500, 2%)
+  );
 }
 
 // Social button count
+// TODO: Deprecate? Use BtnGroup instead?
+
 .btn-with-count {
   float: left;
   border-top-right-radius: 0;
@@ -89,7 +265,7 @@
 // Tweak `line-height` to make them smaller.
 .btn-sm {
   // stylelint-disable-next-line primer/spacing
-  padding: 3px 10px;
+  padding: 3px 12px;
   font-size: $font-size-small;
   // stylelint-disable-next-line primer/typography
   line-height: 20px;
@@ -97,10 +273,10 @@
 
 // Large button adds more padding around text. Use font-size utils to increase font-size.. e.g, <p class="text-gamma"><button class="btn btn-large btn-primary" type="button">Big green button</button></p>
 .btn-large {
-  padding: $em-spacer-6 1.25em;
+  padding: $em-spacer-6 1.5em;
   font-size: inherit;
   // stylelint-disable-next-line primer/borders
-  border-radius: 6px;
+  border-radius: 0.5em;
 }
 
 // Full-width button
@@ -148,9 +324,10 @@
 // Typically used as a "cancel" button next to a .btn
 .btn-invisible {
   color: $text-blue;
-  background-color: $bg-white; // Reset default gradient backgrounds and colors
-  background-image: none;
+  background-color: transparent; // Reset default gradient backgrounds and colors
   border: 0;
+  border-radius: 0;
+  box-shadow: none;
 
   &:hover,
   &:active,

--- a/src/buttons/misc.scss
+++ b/src/buttons/misc.scss
@@ -65,7 +65,7 @@
 .social-count {
   float: left;
   // stylelint-disable-next-line primer/spacing
-  padding: 3px 10px;
+  padding: 3px 12px;
   font-size: $font-size-small;
   font-weight: $font-weight-bold;
   // stylelint-disable-next-line primer/typography
@@ -77,6 +77,8 @@
   border-left: 0;
   border-top-right-radius: $border-radius;
   border-bottom-right-radius: $border-radius;
+  // stylelint-disable-next-line primer/box-shadow
+  box-shadow: 0 1px 0 rgba($gray-400, 0.1), inset 0 1px 0 rgba($white, 0.25);
 
   &:hover,
   &:active {

--- a/src/support/mixins/buttons.scss
+++ b/src/support/mixins/buttons.scss
@@ -1,3 +1,8 @@
+
+// TODO: See if the mixins below can be deprecated
+// Might still be needed for .btn-blue
+// ------------------------------------------------------------------
+
 // Button color generator for primary and themed buttons
 
 // New button hotness

--- a/src/support/variables/colors.scss
+++ b/src/support/variables/colors.scss
@@ -18,9 +18,6 @@ $border-red:         $red !default;
 $border-red-light:   desaturate($red-300, 60%) !default;
 $border-yellow:      desaturate($yellow-300, 60%) !default;
 
-// Buttons have a slightly more opaque border than $border-black-fade (15% alpha)
-$border-color-button: rgba($black, 0.2) !default;
-
 // Background colors
 $bg-white:          $white !default;
 $bg-black:          $black !default;
@@ -41,11 +38,6 @@ $bg-red-light:      $red-100 !default;
 $bg-yellow:         $yellow-500 !default;
 $bg-yellow-light:   $yellow-200 !default;
 $bg-yellow-dark:    $yellow-700 !default;
-
-// diffstat background colors
-$bg-diffstat-added: darken($green-400, 5%) !default;
-$bg-diffstat-deleted: $red-600 !default;
-$bg-diffstat-neutral: $gray-300 !default;
 
 // Text colors
 $text-black:        $black !default;

--- a/src/support/variables/misc.scss
+++ b/src/support/variables/misc.scss
@@ -18,9 +18,16 @@ $form-control-shadow: inset 0 1px 2px rgba($black, 0.075) !default;
 $btn-input-focus-shadow: 0 0 0 0.2em rgba($blue, 0.3) !default;
 $btn-active-shadow: inset 0 0.15em 0.3em $black-fade-15 !default;
 
+$border-color-button: $border-color !default;
+
 // Tooltips
 $tooltip-max-width: 250px !default;
 $tooltip-background-color: $black !default;
 $tooltip-text-color: $white !default;
 $tooltip-delay: 0.4s !default;
 $tooltip-duration: 0.1s !default;
+
+// diffstat background colors
+$bg-diffstat-added: darken($green-400, 5%) !default;
+$bg-diffstat-deleted: $red-600 !default;
+$bg-diffstat-neutral: $gray-300 !default;

--- a/src/support/variables/misc.scss
+++ b/src/support/variables/misc.scss
@@ -15,8 +15,10 @@ $box-shadow-extra-large: 0 10px 50px rgba($black, 0.07) !default;
 
 // Button and form variables
 $form-control-shadow: inset 0 1px 2px rgba($black, 0.075) !default;
-$btn-input-focus-shadow: 0 0 0 0.2em rgba($blue, 0.3) !default;
-$btn-active-shadow: inset 0 0.15em 0.3em $black-fade-15 !default;
+$btn-input-focus-shadow: 0 0 0 0.2em rgba($blue, 0.3) !default; // TODO: Deprecate? Replaced by $focus-shadow
+$btn-active-shadow: inset 0 0.15em 0.3em $black-fade-15 !default; // TODO: Deprecate? It's now unused.
+
+$focus-shadow: 0 0 0 3px rgba($blue, 0.4) !default;
 
 $border-color-button: $border-color !default;
 


### PR DESCRIPTION
This updates the buttons.

<img width="530" alt="Screen Shot 2020-02-18 at 6 01 25 PM" src="https://user-images.githubusercontent.com/378023/74720457-2f853180-5279-11ea-9276-c9627822e25e.png">

👀 [Preview](https://primer-css-git-buttons.primer.now.sh/css/components/buttons)

It's probably not the final version, but maybe ok to start testing on dotcom.

## TODO

- [x] Replace colors
- [x] Increase border radius
- [x] Increase padding (only on the sides, height doesn't change)
- [x] Move "components" variables out of [`colors.scss`](https://github.com/primer/css/pull/1027/files?file-filters%5B%5D=.scss#diff-7c47abf661051dac7fed7ed5b737fbd3)


## TODO in a next phase

- Deprecate the `.btn-blue` button. It's rare, but still gets used.
- Maybe deprecate [`.social-count`](https://primer.style/css/components/buttons#button-with-counts)? Instead we could use a [`BtnGroup`](https://primer.style/css/components/buttons#button-groups).
- Probably a few fixes and maybe some refactoring.