### PR TITLE
Update UnderlineNav-item to not wrap counter & icon

### DIFF
--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -17,10 +17,10 @@
   line-height: $lh-default;
   color: $text-gray;
   text-align: center;
+  white-space: nowrap;
   border: 0;
   // stylelint-disable-next-line primer/borders
   border-bottom: 2px $border-style transparent;
-  white-space: nowrap;
 
   &:hover,
   &:focus {

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -20,6 +20,7 @@
   border: 0;
   // stylelint-disable-next-line primer/borders
   border-bottom: 2px $border-style transparent;
+  white-space: nowrap;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
I'm running into the situation where the underline nav items will wrap counter and icon items at certain screen sizes.

![image](https://user-images.githubusercontent.com/54012/75057172-4bf9b780-548d-11ea-93d4-c7db7b957602.png)

I want to add a no wrap rule to each UnderlineNav-item so that the elements don't wrap like this.