### PR TITLE
Add source link to color-system

### DIFF
--- a/docs/content/support/color-system.mdx
+++ b/docs/content/support/color-system.mdx
@@ -2,7 +2,8 @@
 title: Color system
 description: 'Sass variables, mixins, and functions for use in our components.'
 status: Stable
-status_issue: 'https://github.com/github/design-systems/issues/301'
+source: 'https://github.com/primer/css/blob/master/src/support/variables/color-system.scss'
+bundle: support
 ---
 
 import colors from 'primer-colors'


### PR DESCRIPTION
Part of https://github.com/primer/css/issues/1016. This adds the "View source" in the top right corner.

👀 [Preview](https://primer-css-git-fix-color-system-links.primer.now.sh/css/support/color-system)

Also:

- Removes `status_issue`. Don't think we use it for anything.
- Adds `bundle: support`. Not sure if this is needed. Others do have it.

