### PR TITLE
Fix UnderlineNav in Safari

### DIFF
--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -17,6 +17,7 @@
   line-height: $lh-default;
   color: $text-gray;
   text-align: center;
+  background-color: transparent;
   border: 0;
   // stylelint-disable-next-line primer/borders
   border-bottom: 2px $border-style transparent;


### PR DESCRIPTION
This fixes the gray background in [`UnderlineNav`](https://primer.style/css/components/navigation#underline-nav) items when used as `<button>` elements in Safari.

![Screen Shot 2020-03-09 at 7 02 30 PM](https://user-images.githubusercontent.com/378023/76202682-94102c80-6238-11ea-9c1b-e5d94150224c.png)

---

Reported in [Slack](https://github.slack.com/archives/C0ZCGGGJ2/p1583744172124800) by @tobiasahlin 🙇 ❤️ 