### PR TITLE
Accessible form validation

### DIFF
--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -222,7 +222,7 @@ Use the `.select-sm` class to resize both default and custom `<select>`s to matc
 
 #### Form group validation
 
-Convey success, errors and warnings for form groups.
+Convey success, errors and warnings for form groups. For github.com consider using the [`<auto-check>`](https://github.github.io/web-systems-documentation/demo/custom_elements/auto_check/) element to perform server-side validation on an input.
 
 If the input is **valid**, add the `.successed` class to the `<div class="form-group">` element. Next add/update a success message to the `<div>` under the input, as well as the `.success` class.
 

--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -222,7 +222,7 @@ Use the `.select-sm` class to resize both default and custom `<select>`s to matc
 
 #### Form group validation
 
-Convey success, errors and warnings for form groups. For github.com consider using the `<auto-check>` element to perform server-side validation on an input.
+Convey success, errors and warnings for form groups. For github.com consider using the [`<auto-check>`](https://github.github.io/web-systems-documentation/#custom-elements-auto-check-md) element to perform server-side validation on an input.
 
 If the input is **valid**, add the `.successed` class to the `<div class="form-group">` element. Next add/update a success message to the `.note` element, as well as the `.success` class.
 

--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -224,11 +224,11 @@ Use the `.select-sm` class to resize both default and custom `<select>`s to matc
 
 Convey success, errors and warnings for form groups.
 
-If the input is **valid**, add the `.successful` class to the `<div class="form-group">` element. Next add/update a success message to the `<div>` under the input, as well as the `.success` class.
+If the input is **valid**, add the `.successed` class to the `<div class="form-group">` element. Next add/update a success message to the `<div>` under the input, as well as the `.success` class.
 
 ```html live
 <form class="pb-6">
-  <div class="form-group valid">
+  <div class="form-group successed">
     <div class="form-group-header">
       <label for="username-input">Username</label>
     </div>

--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -224,7 +224,7 @@ Use the `.select-sm` class to resize both default and custom `<select>`s to matc
 
 Convey success, errors and warnings for form groups. For github.com consider using the [`<auto-check>`](https://github.github.io/web-systems-documentation/demo/custom_elements/auto_check/) element to perform server-side validation on an input.
 
-If the input is **valid**, add the `.successed` class to the `<div class="form-group">` element. Next add/update a success message to the `<div>` under the input, as well as the `.success` class.
+If the input is **valid**, add the `.successed` class to the `<div class="form-group">` element. Next add/update a success message to the `.note` element, as well as the `.success` class.
 
 ```html live
 <form class="pb-6">
@@ -241,12 +241,12 @@ If the input is **valid**, add the `.successed` class to the `<div class="form-g
         aria-describedby="username-input-validation"
       />
     </div>
-    <div class="success" id="username-input-validation">monalisa is available</div>
+    <p class="note success" id="username-input-validation">monalisa is available</p>
   </div>
 </form>
 ```
 
-If the input is **not valid**, add the `.errored` class to the `<div class="form-group">` element. Next add/update an error message to the `<div>` under the input, as well as the `.error` class.
+If the input is **not valid**, add the `.errored` class to the `<div class="form-group">` element. Next add/update an error message to the `.note` element, as well as the `.error` class.
 
 ```html live
 <form class="pb-6">
@@ -263,12 +263,12 @@ If the input is **not valid**, add the `.errored` class to the `<div class="form
         aria-describedby="username-input-validation"
       />
     </div>
-    <div class="error" id="username-input-validation">monalisa is not available. monalisa-beep, monalisa-cyber, or monalisa87 are available.</div>
+    <p class="note error" id="username-input-validation">monalisa is not available. monalisa-beep, monalisa-cyber, or monalisa87 are available.</p>
   </div>
 </form>
   ```
 
-If the input should show a **warning**, add the `.warn` class to the `<div class="form-group">` element. Next add/update a warning message to the `<div>` under the input, as well as the `.warning` class.
+If the input should show a **warning**, add the `.warn` class to the `<div class="form-group">` element. Next add/update a warning message to the `.note` element, as well as the `.warning` class.
 
   ```html live
 <form class="pb-6">
@@ -285,7 +285,7 @@ If the input should show a **warning**, add the `.warn` class to the `<div class
         aria-describedby="username-input-validation"
       />
     </div>
-    <div class="warning" id="username-input-validation">36 of maximum 39 characters entered.</div>
+    <p class="note warning" id="username-input-validation">36 of maximum 39 characters entered.</p>
   </div>
 </form>
 ```

--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -227,8 +227,8 @@ Convey success, errors and warnings for form groups.
 If the input is **valid**, add the `.successful` class to the `<div class="form-group">` element. Next add/update a success message to the `<div>` under the input, as well as the `.success` class.
 
 ```html live
-<form>
-  <div class="form-group successful">
+<form class="pb-6">
+  <div class="form-group valid">
     <div class="form-group-header">
       <label for="unsername-input">Username</label>
     </div>

--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -230,18 +230,18 @@ If the input is **valid**, add the `.successful` class to the `<div class="form-
 <form class="pb-6">
   <div class="form-group valid">
     <div class="form-group-header">
-      <label for="unsername-input">Username</label>
+      <label for="username-input">Username</label>
     </div>
     <div class="form-group-body">
       <input
         class="form-control"
         type="text"
         value="monalisa"
-        id="unsername-input"
-        aria-describedby="unsername-input-validation"
+        id="username-input"
+        aria-describedby="username-input-validation"
       />
     </div>
-    <div class="success" id="unsername-input-validation">monalisa is available</div>
+    <div class="success" id="username-input-validation">monalisa is available</div>
   </div>
 </form>
 ```
@@ -252,18 +252,18 @@ If the input is **not valid**, add the `.errored` class to the `<div class="form
 <form class="pb-6">
   <div class="form-group errored">
     <div class="form-group-header">
-      <label for="unsername-input">Username</label>
+      <label for="username-input">Username</label>
     </div>
     <div class="form-group-body">
       <input
         class="form-control"
         type="text"
         value="monalisa"
-        id="unsername-input"
-        aria-describedby="unsername-input-validation"
+        id="username-input"
+        aria-describedby="username-input-validation"
       />
     </div>
-    <div class="error" id="unsername-input-validation">monalisa is not available. monalisa-beep, monalisa-cyber, or monalisa87 are available.</div>
+    <div class="error" id="username-input-validation">monalisa is not available. monalisa-beep, monalisa-cyber, or monalisa87 are available.</div>
   </div>
 </form>
   ```
@@ -274,18 +274,18 @@ If the input should show a **warning**, add the `.warn` class to the `<div class
 <form class="pb-6">
   <div class="form-group warn">
     <div class="form-group-header">
-      <label for="unsername-input">Username</label>
+      <label for="username-input">Username</label>
     </div>
     <div class="form-group-body">
       <input
         class="form-control"
         type="text"
         value="monalisa-monalisa-monalisa-monalisa-"
-        id="unsername-input"
-        aria-describedby="unsername-input-validation"
+        id="username-input"
+        aria-describedby="username-input-validation"
       />
     </div>
-    <div class="warning" id="unsername-input-validation">36 of maximum 39 characters entered.</div>
+    <div class="warning" id="username-input-validation">36 of maximum 39 characters entered.</div>
   </div>
 </form>
 ```

--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -222,7 +222,7 @@ Use the `.select-sm` class to resize both default and custom `<select>`s to matc
 
 #### Form group validation
 
-Convey success, errors and warnings for form groups. For github.com consider using the [`<auto-check>`](https://github.github.io/web-systems-documentation/demo/custom_elements/auto_check/) element to perform server-side validation on an input.
+Convey success, errors and warnings for form groups. For github.com consider using the `<auto-check>` element to perform server-side validation on an input.
 
 If the input is **valid**, add the `.successed` class to the `<div class="form-group">` element. Next add/update a success message to the `.note` element, as well as the `.success` class.
 

--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -222,40 +222,70 @@ Use the `.select-sm` class to resize both default and custom `<select>`s to matc
 
 #### Form group validation
 
-Convey errors and warnings for form groups. Add the appropriate class—either `.errored` or `.warn`—to the `<div class="form-group">` to start. Then, house your error messaging in an additional `<div>` with either `.error` or `.warning`.
+Convey success, errors and warnings for form groups.
+
+If the input is **valid**, add the `.successful` class to the `<div class="form-group">` element. Next add/update a success message to the `<div>` under the input, as well as the `.success` class.
 
 ```html live
-<form class="pb-2">
+<form>
+  <div class="form-group successful">
+    <div class="form-group-header">
+      <label for="unsername-input">Username</label>
+    </div>
+    <div class="form-group-body">
+      <input
+        class="form-control"
+        type="text"
+        value="monalisa"
+        id="unsername-input"
+        aria-describedby="unsername-input-validation"
+      />
+    </div>
+    <div class="success" id="unsername-input-validation">monalisa is available</div>
+  </div>
+</form>
+```
+
+If the input is **not valid**, add the `.errored` class to the `<div class="form-group">` element. Next add/update an error message to the `<div>` under the input, as well as the `.error` class.
+
+```html live
+<form class="pb-6">
   <div class="form-group errored">
     <div class="form-group-header">
-      <label for="example-text-errored">Example Text</label>
+      <label for="unsername-input">Username</label>
     </div>
     <div class="form-group-body">
       <input
         class="form-control"
         type="text"
-        value="Example Value"
-        id="example-text-errored"
-        aria-describedby="form-error-text"
+        value="monalisa"
+        id="unsername-input"
+        aria-describedby="unsername-input-validation"
       />
     </div>
-    <div class="error" id="form-error-text">This example input has an error.</div>
+    <div class="error" id="unsername-input-validation">monalisa is not available. monalisa-beep, monalisa-cyber, or monalisa87 are available.</div>
   </div>
-  <br />
+</form>
+  ```
+
+If the input should show a **warning**, add the `.warn` class to the `<div class="form-group">` element. Next add/update a warning message to the `<div>` under the input, as well as the `.warning` class.
+
+  ```html live
+<form class="pb-6">
   <div class="form-group warn">
     <div class="form-group-header">
-      <label for="example-text-warn">Example Text</label>
+      <label for="unsername-input">Username</label>
     </div>
     <div class="form-group-body">
       <input
         class="form-control"
         type="text"
-        value="Example Value"
-        id="example-text-warn"
-        aria-describedby="form-warning-text"
+        value="monalisa-monalisa-monalisa-monalisa-"
+        id="unsername-input"
+        aria-describedby="unsername-input-validation"
       />
     </div>
-    <div class="warning" id="form-warning-text">This example input has a warning.</div>
+    <div class="warning" id="unsername-input-validation">36 of maximum 39 characters entered.</div>
   </div>
 </form>
 ```

--- a/src/forms/form-group.scss
+++ b/src/forms/form-group.scss
@@ -142,7 +142,7 @@
   //
   // Our inline errors
 
-  &.valid,
+  &.successed,
   &.warn,
   &.errored {
     .success,
@@ -190,7 +190,7 @@
     }
   }
 
-  &.valid {
+  &.successed {
     .success {
       // stylelint-disable-next-line primer/colors
       color: $green-900;

--- a/src/forms/form-group.scss
+++ b/src/forms/form-group.scss
@@ -142,8 +142,10 @@
   //
   // Our inline errors
 
+  &.valid,
   &.warn,
   &.errored {
+    .success,
     .warning,
     .error {
       position: absolute;
@@ -184,6 +186,25 @@
         margin-left: -1px;
         // stylelint-disable-next-line primer/borders
         border-width: 6px;
+      }
+    }
+  }
+
+  &.valid {
+    .success {
+      // stylelint-disable-next-line primer/colors
+      color: $green-900;
+      // stylelint-disable-next-line primer/colors
+      background-color: $green-100;
+      border-color: $border-green;
+
+      &::after {
+        // stylelint-disable-next-line primer/borders
+        border-bottom-color: $green-100;
+      }
+
+      &::before {
+        border-bottom-color: $border-green;
       }
     }
   }


### PR DESCRIPTION
This is on top of https://github.com/primer/css/pull/1028. It adds a "success" tooltip when a form input is valid. :eyes: [Docs preview](https://primer-css-git-accessible-form-validation.primer.now.sh/css/components/forms#form-group-validation)

![image](https://user-images.githubusercontent.com/378023/76302308-136a3280-6303-11ea-96ac-b8b67dc26233.png)

```html
<form>
  <div class="form-group successed">
    <div class="form-group-header">
      <label for="username-input">Username</label>
    </div>
    <div class="form-group-body">
      <input
        class="form-control"
        type="text"
        value="monalisa"
        id="unsername-input"
        aria-describedby="username-input-validation"
      />
    </div>
    <p class="note success" id="username-input-validation">monalisa is available</p>
  </div>
</form>
```

The docs example also got split into 3 seperate examples so that the same `id`s can be used.

Before | After
--- | ---
![screenshot before](https://user-images.githubusercontent.com/378023/76294540-5c67ba00-62f6-11ea-8c07-b56c156a6eb3.png) | ![screenshot after](https://user-images.githubusercontent.com/378023/76294546-5ffb4100-62f6-11ea-9050-f8b46341e9f5.png)

## Why?

When an input is valid we typically show a checkmark icon. But screen reader users don't get notified. Adding a success message adds confidence that everything is fine. :ok_hand::relieved:

See https://github.com/github/github/issues/132199

## Concerns + alternatives

We could consider removing the `.success `, `.error` and `.warning` classes since we already set the state on the `.form-group` element. Maybe once we start refactoring all the form-groups on dotcom? 🤔 And also get rid of the `.form-group-header` and `.form-group-body` that are not really needed.

---

/cc @primer/ds-core
