### PR TITLE
More "component refresh" tweaks

### DIFF
--- a/src/labels/mixins.scss
+++ b/src/labels/mixins.scss
@@ -8,7 +8,7 @@
   display: inline-block;
   padding: 0 7px;
   font-size: $font-size-small;
-  font-weight: $font-weight-semibold;
+  font-weight: $font-weight-normal;
   line-height: 18px;
   border: $border-width $border-style transparent;
   border-radius: 2em;

--- a/src/navigation/menu.scss
+++ b/src/navigation/menu.scss
@@ -50,7 +50,7 @@
   &[aria-current] {
     cursor: default;
     // stylelint-disable-next-line primer/colors
-    background-color: $orange-000;
+    background-color: #fff2f0; // custom coral
 
     &::before {
       position: absolute;
@@ -60,7 +60,7 @@
       width: 2px;
       content: "";
       // stylelint-disable-next-line primer/colors
-      background-color: $orange-500;
+      background-color: #f9826c; // custom coral
     }
   }
 

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -62,7 +62,7 @@
   // Bar on the left
   &::before {
     // stylelint-disable-next-line primer/colors
-    background-color: $orange-500;
+    background-color: #f9826c; // custom coral
   }
 }
 

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -35,7 +35,7 @@
   &[role=tab][aria-selected=true],
   &[aria-current] {
     // stylelint-disable-next-line primer/borders
-    border-bottom-color: $orange-500;
+    border-bottom-color: #f9826c; // custom coral
   }
 }
 

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -28,8 +28,8 @@
   &:focus {
     text-decoration: none;
     border-bottom-color: $border-gray-dark;
-    transition-duration: 0.12s;
     transition-timing-function: ease-out;
+    transition-duration: 0.12s;
   }
 
   &.selected,

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -21,14 +21,15 @@
   background-color: transparent;
   border: 0;
   // stylelint-disable-next-line primer/borders
-  border-bottom: 2px $border-style transparent;
+  border-bottom: 2px $border-style rgba($border-gray-dark, 0);
   transition: border-bottom-color 0.36s ease-in;
 
   &:hover,
   &:focus {
     text-decoration: none;
     border-bottom-color: $border-gray-dark;
-    transition: border-bottom-color 0.12s ease-out;
+    transition-duration: 0.12s;
+    transition-timing-function: ease-out;
   }
 
   &.selected,


### PR DESCRIPTION
This makes a few more changes to the "component refresh".

## Navigation

The orange of the `menu`, `UnderlineNav` and `SideNav` slightly changed:

Description | Before | After
--- | --- | ---
2px border | `orange-500` | `#f9826c`
background | `$orange-000` | `#fff2f0`

![image](https://user-images.githubusercontent.com/378023/76368110-76df7900-6372-11ea-82b8-455da06052bb.png)

## UnderlineNav

It should also fix the dark border on page load.

![76385520-3f3df480-63a5-11ea-8880-7a90b52b7559](https://user-images.githubusercontent.com/378023/76394602-22132100-63b9-11ea-90b4-7fefe6137c44.png)

Might be caused because there is a transparent border with a transition. Which initially transitions from `initial` (black) to `transparent`. The fix is to use a `rgba()` instead of `transparent`.

## Labels

The `.Label`s now use `$font-weight-normal`.

Before | After
--- | ---
`font-weight: 500;` | `font-weight: 400;`

![image](https://user-images.githubusercontent.com/378023/76384716-0ef55680-63a3-11ea-9b18-42c212c204bc.png)

/cc @primer/ds-core
