### PR TITLE
Primer CSS 14.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 14.3.0
+
+### :rocket: Enhancements
+
+- [#1044](https://github.com/primer/css/1044) Accessible form validation
+- [#1028](https://github.com/primer/css/1028) Improve .form-group accessibility
+
+### :bug: Bug fixes
+- [#670](https://github.com/primer/css/670) Fix Box row top border
+- [#1042](https://github.com/primer/css/1042) Fix UnderlineNav in Safari
+- [#1035](https://github.com/primer/css/1035) Update UnderlineNav-item to not wrap counter & icon
+
+### :memo: Documentation
+- [#1018](https://github.com/primer/css/1018) Update MIGRATING.md
+
+### Committers
+- [@emplums](https://github.com/emplums)
+- [@jonrohan](https://github.com/jonrohan)
+- [@simurai](https://github.com/simurai)
+
 ## 14.2.0
 
 ### :rocket: Enhancements

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,13 +9,16 @@
 
 1. Run [`npm version <version>`](https://docs.npmjs.com/cli/version) to update the `version` field in both `package.json` and `package-lock.json`.
 
-1. Create a new PR for the `release-<version>` branch. Please use the following template for the PR description, linking to the relevant issues and/or pull requests for each change, removing irrelevant headings and checking off all of the boxes of the ship checklist:
+1. Create a new PR for the `release-<version>` branch. Please use the following template for the PR description, linking to the relevant issues and/or pull requests for each change. The changelog gets generated automatically :
 
     ```md
     # Primer CSS [Major|Minor|Patch] Release
 
-    Version: 📦 **0.0.0**
-    Approximate release date: 📆 DD/MM/YY
+    Version: 📦 **`0.0.0`**
+    Approximate release date: 📆 **DD/MM/YY**
+    Changes: 🎉 [All merged PRs](https://github.com/primer/css/pulls?q=is%3Apr+is%3Amerged+base%3Arelease-0.0.0)
+    
+    ---
 
     ### :boom: Breaking Change
     - [ ] Description #
@@ -35,11 +38,11 @@
     ### :house: Internal
     - [ ] Description #
 
-    ----
+    ---
 
     ### Ship checklist
 
-    - [ ] Update the `version` field in `package.json`
+    - [x] Update the `version` field in `package.json`
     - [ ] Update `CHANGELOG.md`
     - [ ] Test the release candidate version with `github/github`
     - [ ] Merge this PR and [create a new release](https://github.com/primer/css/releases/new)
@@ -53,11 +56,11 @@
 
 1. Start merging existing PRs into the release branch. Note: You have to change the base branch from `master` to the `release-<version>` branch before merging.
 
-1. Update `CHANGELOG.md`
+1. Update `CHANGELOG.md` and the PR description. **Tip**: You can copy&paste the changelog from `Checks > changelog > all > changelog`. It gets generated based on adding the `Tag` labels to PRs.
 
 1. Wait for your checks to pass, and take note of the version that [primer/publish] lists in your status checks.
 
-    **ProTip:** The release candidate version will always be `<version>-rc.<sha>`, where `<version>` comes from the branch name and `<sha>` is the 7-character commit SHA.
+    **Tip**: The release candidate version will always be `<version>-rc.<sha>`, where `<version>` comes from the branch name and `<sha>` is the 7-character commit SHA.
 
 
 ## Test the release candidate (in `github/github`):

--- a/docs/content/components/box.md
+++ b/docs/content/components/box.md
@@ -531,10 +531,10 @@ You can put forms in boxes. Often form submission buttons are aligned to the bot
   </div>
   <form>
     <div class="Box-body">
-      <dl class="form-group">
-        <dt><label>Example label</label></dt>
-        <dd><input class="form-control" type="text" /></dd>
-      </dl>
+      <div class="form-group">
+        <div class="form-group-header"><label>Example label</label></div>
+        <div class="form-group-body"><input class="form-control" type="text"></div>
+      </div>
       <div class="form-checkbox">
         <label>
           <input type="checkbox" checked="checked" />
@@ -563,10 +563,10 @@ When a box is all by itself centered on a page you can use [column widths](/obje
       <h3 class="f1-light">
         Example form
       </h3>
-      <dl class="form-group mb-4">
-        <dt><label>Example label</label></dt>
-        <dd><input class="form-control" type="text" /></dd>
-      </dl>
+      <div class="form-group mb-4">
+        <div class="form-group-header"><label>Example label</label></div>
+        <div class="form-group-body"><input class="form-control" type="text" /></div>
+      </div>
       <button class="btn btn-primary btn-block">
         Submit
       </button>

--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -222,40 +222,70 @@ Use the `.select-sm` class to resize both default and custom `<select>`s to matc
 
 #### Form group validation
 
-Convey errors and warnings for form groups. Add the appropriate class—either `.errored` or `.warn`—to the `<div class="form-group">` to start. Then, house your error messaging in an additional `<div>` with either `.error` or `.warning`.
+Convey success, errors and warnings for form groups. For github.com consider using the [`<auto-check>`](https://github.github.io/web-systems-documentation/#custom-elements-auto-check-md) element to perform server-side validation on an input.
+
+If the input is **valid**, add the `.successed` class to the `<div class="form-group">` element. Next add/update a success message to the `.note` element, as well as the `.success` class.
 
 ```html live
-<form class="pb-2">
+<form class="pb-6">
+  <div class="form-group successed">
+    <div class="form-group-header">
+      <label for="username-input">Username</label>
+    </div>
+    <div class="form-group-body">
+      <input
+        class="form-control"
+        type="text"
+        value="monalisa"
+        id="username-input"
+        aria-describedby="username-input-validation"
+      />
+    </div>
+    <p class="note success" id="username-input-validation">monalisa is available</p>
+  </div>
+</form>
+```
+
+If the input is **not valid**, add the `.errored` class to the `<div class="form-group">` element. Next add/update an error message to the `.note` element, as well as the `.error` class.
+
+```html live
+<form class="pb-6">
   <div class="form-group errored">
     <div class="form-group-header">
-      <label for="example-text-errored">Example Text</label>
+      <label for="username-input">Username</label>
     </div>
     <div class="form-group-body">
       <input
         class="form-control"
         type="text"
-        value="Example Value"
-        id="example-text-errored"
-        aria-describedby="form-error-text"
+        value="monalisa"
+        id="username-input"
+        aria-describedby="username-input-validation"
       />
     </div>
-    <div class="error" id="form-error-text">This example input has an error.</div>
+    <p class="note error" id="username-input-validation">monalisa is not available. monalisa-beep, monalisa-cyber, or monalisa87 are available.</p>
   </div>
-  <br />
+</form>
+  ```
+
+If the input should show a **warning**, add the `.warn` class to the `<div class="form-group">` element. Next add/update a warning message to the `.note` element, as well as the `.warning` class.
+
+  ```html live
+<form class="pb-6">
   <div class="form-group warn">
     <div class="form-group-header">
-      <label for="example-text-warn">Example Text</label>
+      <label for="username-input">Username</label>
     </div>
     <div class="form-group-body">
       <input
         class="form-control"
         type="text"
-        value="Example Value"
-        id="example-text-warn"
-        aria-describedby="form-warning-text"
+        value="monalisa-monalisa-monalisa-monalisa-"
+        id="username-input"
+        aria-describedby="username-input-validation"
       />
     </div>
-    <div class="warning" id="form-warning-text">This example input has a warning.</div>
+    <p class="note warning" id="username-input-validation">36 of maximum 39 characters entered.</p>
   </div>
 </form>
 ```

--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -183,14 +183,20 @@ Use the `.select-sm` class to resize both default and custom `<select>`s to matc
 
 ```html live
 <form>
-  <dl class="form-group">
-    <dt><label for="example-text">Example Text</label></dt>
-    <dd><input class="form-control" type="text" value="Example Value" id="example-text" /></dd>
-  </dl>
+  <div class="form-group">
+    <div class="form-group-header">
+      <label for="example-text">Example Text</label>
+    </div>
+    <div class="form-group-body">
+      <input class="form-control" type="text" value="Example Value" id="example-text" />
+    </div>
+  </div>
 
-  <dl class="form-group">
-    <dt><label for="example-select">Example Select</label></dt>
-    <dd>
+  <div class="form-group">
+    <div class="form-group-header">
+      <label for="example-select">Example Select</label>
+    </div>
+    <div class="form-group-body">
       <select class="form-select" id="example-select">
         <option>Choose an option</option>
         <option>Git</option>
@@ -200,27 +206,31 @@ Use the `.select-sm` class to resize both default and custom `<select>`s to matc
         <option>Bears</option>
         <option>Battlestar Galactica</option>
       </select>
-    </dd>
-  </dl>
+    </div>
+  </div>
 
-  <dl class="form-group">
-    <dt><label for="example-textarea">Example Textarea</label></dt>
-    <dd>
+  <div class="form-group">
+    <div class="form-group-header">
+      <label for="example-textarea">Example Textarea</label>
+    </div>
+    <div class="form-group-body">
       <textarea class="form-control" id="example-textarea"></textarea>
-    </dd>
-  </dl>
+    </div>
+  </div>
 </form>
 ```
 
 #### Form group validation
 
-Convey errors and warnings for form groups. Add the appropriate class—either `.errored` or `.warn`—to the `<dl class="form-group">` to start. Then, house your error messaging in an additional `<dd>` with either `.error` or `.warning`.
+Convey errors and warnings for form groups. Add the appropriate class—either `.errored` or `.warn`—to the `<div class="form-group">` to start. Then, house your error messaging in an additional `<div>` with either `.error` or `.warning`.
 
 ```html live
 <form class="pb-2">
-  <dl class="form-group errored">
-    <dt><label for="example-text-errored">Example Text</label></dt>
-    <dd>
+  <div class="form-group errored">
+    <div class="form-group-header">
+      <label for="example-text-errored">Example Text</label>
+    </div>
+    <div class="form-group-body">
       <input
         class="form-control"
         type="text"
@@ -228,13 +238,15 @@ Convey errors and warnings for form groups. Add the appropriate class—either `
         id="example-text-errored"
         aria-describedby="form-error-text"
       />
-    </dd>
-    <dd class="error" id="form-error-text">This example input has an error.</dd>
-  </dl>
+    </div>
+    <div class="error" id="form-error-text">This example input has an error.</div>
+  </div>
   <br />
-  <dl class="form-group warn">
-    <dt><label for="example-text-warn">Example Text</label></dt>
-    <dd>
+  <div class="form-group warn">
+    <div class="form-group-header">
+      <label for="example-text-warn">Example Text</label>
+    </div>
+    <div class="form-group-body">
       <input
         class="form-control"
         type="text"
@@ -242,9 +254,9 @@ Convey errors and warnings for form groups. Add the appropriate class—either `
         id="example-text-warn"
         aria-describedby="form-warning-text"
       />
-    </dd>
-    <dd class="warning" id="form-warning-text">This example input has a warning.</dd>
-  </dl>
+    </div>
+    <div class="warning" id="form-warning-text">This example input has a warning.</div>
+  </div>
 </form>
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/css",
-  "version": "14.2.0",
+  "version": "14.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/css",
-  "version": "14.2.0",
+  "version": "14.3.0",
   "description": "Primer is the CSS framework that powers GitHub's front-end design. primer includes 23 packages that are grouped into 3 core meta-packages for easy install. Each package and meta-package is independently versioned and distributed via npm, so it's easy to include all or part of Primer within your own project.",
   "homepage": "https://primer.style/css",
   "author": "GitHub, Inc.",

--- a/src/box/box.scss
+++ b/src/box/box.scss
@@ -111,7 +111,6 @@
   border-top: $border-width $border-style $border-gray;
 
   &:first-of-type {
-    border-top-color: transparent;
     // stylelint-disable-next-line primer/borders
     border-top-left-radius: 2px;
     // stylelint-disable-next-line primer/borders

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -188,7 +188,8 @@ label {
     // stylelint-disable-next-line primer/spacing
     margin: 0 30px 0 0;
 
-    dt {
+    dt, // TODO: Deprecate
+    .form-group-header {
       label {
         display: inline-block;
         // stylelint-disable-next-line primer/spacing

--- a/src/forms/form-group.scss
+++ b/src/forms/form-group.scss
@@ -142,8 +142,10 @@
   //
   // Our inline errors
 
+  &.successed,
   &.warn,
   &.errored {
+    .success,
     .warning,
     .error {
       position: absolute;
@@ -184,6 +186,25 @@
         margin-left: -1px;
         // stylelint-disable-next-line primer/borders
         border-width: 6px;
+      }
+    }
+  }
+
+  &.successed {
+    .success {
+      // stylelint-disable-next-line primer/colors
+      color: $green-900;
+      // stylelint-disable-next-line primer/colors
+      background-color: $green-100;
+      border-color: $border-green;
+
+      &::after {
+        // stylelint-disable-next-line primer/borders
+        border-bottom-color: $green-100;
+      }
+
+      &::before {
+        border-bottom-color: $border-green;
       }
     }
   }

--- a/src/forms/form-group.scss
+++ b/src/forms/form-group.scss
@@ -1,9 +1,15 @@
-// Form groups
-//
-// Typical form groups - `<dl.form-group>` with a `<dt>` containing the label and
-// `<dd> containing the form elements.
 // stylelint-disable selector-max-compound-selectors
 // stylelint-disable selector-max-type
+
+// Form groups
+//
+// Usage:
+//
+// <div class="form-group">
+//   <div class="form-group-header"> containing the label
+//   <div class="form-group-body"> containing the form elements
+// </div>
+
 .form-group {
   // stylelint-disable-next-line primer/spacing
   margin: 15px 0;
@@ -42,7 +48,8 @@
   // stylelint-enable selector-no-qualifying-type
 
   // The Label
-  dt {
+  dt, // TODO: Deprecate
+  .form-group-header {
     // stylelint-disable-next-line primer/spacing
     margin: 0 0 6px;
   }
@@ -51,14 +58,16 @@
     position: relative;
   }
 
-  &.flattened dt {
+  &.flattened dt, // TODO: Deprecate
+  &.flattened .form-group-header {
     float: left;
     margin: 0;
     // stylelint-disable-next-line primer/typography
     line-height: 32px;
   }
 
-  &.flattened dd {
+  &.flattened dd, // TODO: Deprecate
+  &.flattened .form-group-body {
     // stylelint-disable-next-line primer/typography
     line-height: 32px;
   }
@@ -67,7 +76,8 @@
   // Form Elements
   //
   // stylelint-disable selector-no-qualifying-type
-  dd {
+  dd, // TODO: Deprecate
+  .form-group-body {
     h4 {
       margin: $spacer-1 0 0;
 
@@ -87,7 +97,8 @@
   //
 
   &.required {
-    dt label::after {
+    dt label::after, // TODO: Deprecate
+    .form-group-header label::after {
       // stylelint-disable-next-line primer/spacing
       padding-left: 5px;
       color: $text-red;

--- a/src/forms/form-validation.scss
+++ b/src/forms/form-validation.scss
@@ -1,6 +1,7 @@
 // Needs refactoring
 // stylelint-disable selector-no-qualifying-type, selector-max-type
-dl.form-group > dd {
+dl.form-group > dd, // TODO: Deprecate
+.form-group > .form-group-body {
   .form-control {
     &.is-autocheck-loading,
     &.is-autocheck-successful,
@@ -25,7 +26,8 @@ dl.form-group > dd {
 
 // Retinization of form validation icons that aren't octicons yet
 @include retina-media-query {
-  dl.form-group > dd {
+  dl.form-group > dd, // TODO: Deprecate
+  .form-group > .form-group-body {
     .form-control {
       &.is-autocheck-loading,
       &.is-autocheck-successful,

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -17,6 +17,7 @@
   line-height: $lh-default;
   color: $text-gray;
   text-align: center;
+  white-space: nowrap;
   border: 0;
   // stylelint-disable-next-line primer/borders
   border-bottom: 2px $border-style transparent;

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -18,6 +18,7 @@
   color: $text-gray;
   text-align: center;
   white-space: nowrap;
+  background-color: transparent;
   border: 0;
   // stylelint-disable-next-line primer/borders
   border-bottom: 2px $border-style transparent;


### PR DESCRIPTION
Version: 📦 **`14.3.0`**
Approximate release date: 📆 **March 25th 2020**
Changes: 🎉 [All merged PRs](https://github.com/primer/css/pulls?q=is%3Apr+is%3Amerged+base%3Arelease-14.3.0)

---

### :rocket: Enhancements

- [#1044](https://github.com/primer/css/1044) Accessible form validation
- [#1028](https://github.com/primer/css/1028) Improve .form-group accessibility

### :bug: Bug fixes
- [#670](https://github.com/primer/css/670) Fix Box row top border
- [#1042](https://github.com/primer/css/1042) Fix UnderlineNav in Safari
- [#1035](https://github.com/primer/css/1035) Update UnderlineNav-item to not wrap counter & icon

### :memo: Documentation
- [#1018](https://github.com/primer/css/1018) Update MIGRATING.md

### Committers
- [@emplums](https://github.com/emplums)
- [@jonrohan](https://github.com/jonrohan)
- [@simurai](https://github.com/simurai)

---

### Ship checklist

- [x] Update the `version` field in `package.json`
- [x] Update `CHANGELOG.md`
- [ ] ~~Test the release candidate version with `github/github`~~
- [ ] Merge this PR and [create a new release](https://github.com/primer/css/releases/new)
- [ ] Update `github/github`
- [ ] Tell the world (Slack, Twitter, Team post)

For more details, see [RELEASING.md](https://github.com/primer/css/blob/master/RELEASING.md).

### TODO on dotcom

- Keep on eye on the Box top border fix
- Test UnderlineNav
- Consider refactoring all the `.form-group`s

/cc @primer/ds-core