### PR TITLE
Component refresh tweaks III

### DIFF
--- a/docs/content/components/labels.md
+++ b/docs/content/components/labels.md
@@ -190,22 +190,6 @@ You can also have icons and emoji in counters. Or use utilities for counters wit
 <span class="Counter mr-1 bg-purple text-white">22</span>
 ```
 
-## Small counters
-
-Use the `Counter--small` modifier class to reduce the size of a counter.
-
-```html live
-<span class="Counter mr-1 Counter--gray-light">1</span>
-<span class="Counter mr-1">23</span>
-<span class="Counter mr-1 Counter--gray">456</span>
-<span class="Counter mr-1">1.5K</span>
-<div class="my-2"></div>
-<span class="Counter Counter--small mr-1 Counter--gray-light">1</span>
-<span class="Counter Counter--small mr-1">23</span>
-<span class="Counter Counter--small mr-1 Counter--gray">456</span>
-<span class="Counter Counter--small mr-1">1.5K</span>
-```
-
 ## Diffstat
 
 Diffstats show how many deletions or additions a diff has. It's typically a row of 5 blocks that get colored with green or red.

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -4,11 +4,11 @@
 .btn {
   position: relative;
   display: inline-block;
-  padding: 0 $spacer-3;
+  padding: 5px $spacer-3;
   font-size: $body-font-size;
   font-weight: $font-weight-semibold;
   // stylelint-disable-next-line primer/typography
-  line-height: height-without-border($size-5);
+  line-height: 20px; // Specifically not inherit our `<body>` default
   white-space: nowrap;
   vertical-align: middle;
   cursor: pointer;
@@ -56,6 +56,7 @@
     margin-left: 2px;
     color: inherit;
     text-shadow: none;
+    vertical-align: top;
     // stylelint-disable-next-line primer/colors
     background-color: rgba($black, 0.08); // Darken for just a tad more contrast against the button background
   }
@@ -263,12 +264,14 @@
 // Tweak `line-height` to make them smaller.
 .btn-sm {
   // stylelint-disable-next-line primer/spacing
-  padding-right: 12px;
-  // stylelint-disable-next-line primer/spacing
-  padding-left: 12px;
+  padding: 3px 12px;
   font-size: $font-size-small;
   // stylelint-disable-next-line primer/typography
-  line-height: height-without-border($size-4);
+  line-height: 20px;
+
+  .octicon {
+    vertical-align: text-top;
+  }
 }
 
 // Large button adds more padding around text. Use font-size utils to increase font-size.. e.g, <p class="text-gamma"><button class="btn btn-large btn-primary" type="button">Big green button</button></p>

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -4,6 +4,7 @@
 .btn {
   position: relative;
   display: inline-block;
+  // stylelint-disable-next-line primer/spacing
   padding: 5px $spacer-3;
   font-size: $body-font-size;
   font-weight: $font-weight-semibold;

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -166,6 +166,7 @@
   }
 
   .octicon {
+    // stylelint-disable-next-line primer/colors
     color: rgba($text-white, 0.8);
   }
 }

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -119,22 +119,19 @@
   $bg-active: darken($bg-hover, 2%);
   $bg-disabled: #94d3a2; // custom green
 
-  $border-default: $green-600;
-  $border-hover: $green-700;
-
   $shadow: $green-900;
   $box-shadow: 0 1px 0 rgba($black, 0.1), inset 0 1px 0 rgba($white, 0.03);
 
   color: $text-white;
   background-color: $bg-default;
-  border-color: $border-default;
+  // stylelint-disable-next-line primer/borders
+  border-color: rgba($black, 0.15);
   box-shadow: $box-shadow;
 
   &:hover,
   &.hover,
   [open] > & {
     background-color: $bg-hover;
-    border-color: $border-hover;
   }
 
   &:active,
@@ -152,7 +149,7 @@
     color: rgba($text-white, 0.8);
     background-color: $bg-disabled;
     // stylelint-disable-next-line primer/borders
-    border-color: rgba($border-default, 0.1);
+    border-color: rgba($black, 0.1);
     box-shadow: $box-shadow;
   }
 
@@ -175,7 +172,7 @@
 
 // Mixin: btn-inverse-on-hover
 
-@mixin btn-inverse-on-hover( $color, $bg-hover, $bg-active, $border-hover, $border-active, $shadow ) {
+@mixin btn-inverse-on-hover( $color, $bg-hover, $bg-active, $shadow ) {
   color: $color;
   transition: none;
 
@@ -183,7 +180,7 @@
   [open] > & {
     color: $text-white;
     background-color: $bg-hover;
-    border-color: $border-hover;
+    border-color: rgba($black, 0.15);
     box-shadow: 0 1px 0 rgba($shadow, 0.1), inset 0 1px 0 rgba($white, 0.03);
 
     .Counter {
@@ -200,7 +197,7 @@
   &[aria-selected=true] {
     color: $text-white;
     background-color: $bg-active;
-    border-color: $border-active;
+    border-color: rgba($black, 0.15);
     box-shadow: inset 0 1px 0 rgba($shadow, 0.2);
   }
 
@@ -234,8 +231,6 @@
     $color: $text-red,
     $bg-hover: $red-600,
     $bg-active: darken($red-600, 3%),
-    $border-hover: $red-700,
-    $border-active: $red-800,
     $shadow: $red-900
   );
 }
@@ -247,8 +242,6 @@
     $color: $blue-500,
     $bg-hover: $blue-500,
     $bg-active: darken($blue-500, 3%),
-    $border-hover: $blue-600,
-    $border-active: rgba($blue-700, 0.5),
     $shadow: $blue-900
   );
 }

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -182,7 +182,7 @@
     color: $text-white;
     background-color: $bg-hover;
     border-color: rgba($black, 0.15);
-    box-shadow: 0 1px 0 rgba($shadow, 0.1), inset 0 1px 0 rgba($white, 0.03);
+    box-shadow: 0 1px 0 rgba($black, 0.1), inset 0 1px 0 rgba($white, 0.03);
 
     .Counter {
       background-color: rgba($bg-white, 0.2);

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -62,7 +62,7 @@
 
   .dropdown-caret {
     margin-left: $spacer-1;
-    opacity: 0.6;
+    opacity: 0.8;
   }
 }
 
@@ -169,7 +169,7 @@
   }
 
   .octicon {
-    color: inherit;
+    color: rgba($text-white, 0.8);
   }
 }
 

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -123,7 +123,7 @@
   $border-hover: $green-700;
 
   $shadow: $green-900;
-  $box-shadow: $box-shadow, inset 0 1px 0 rgba($white, 0.03);
+  $box-shadow: 0 1px 0 rgba($black, 0.1), inset 0 1px 0 rgba($white, 0.03);
 
   color: $text-white;
   background-color: $bg-default;

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -114,8 +114,8 @@
 // Primary button
 
 .btn-primary {
-  $bg-default: #159739; // custom green
-  $bg-hover: #138934; // custom green
+  $bg-default: #2ea44f; // custom green
+  $bg-hover: #2c974b; // custom green
   $bg-active: darken($bg-hover, 2%);
   $bg-disabled: #94d3a2; // custom green
 

--- a/src/buttons/misc.scss
+++ b/src/buttons/misc.scss
@@ -169,11 +169,11 @@
   position: relative;
   float: left;
   // stylelint-disable-next-line primer/spacing
-  padding: 0 12px;
+  padding: 3px 12px;
   font-size: $font-size-small;
   font-weight: $font-weight-bold;
   // stylelint-disable-next-line primer/typography
-  line-height: height-without-border($size-4);
+  line-height: 20px;
   color: $text-gray-dark;
   vertical-align: middle;
   background-color: $bg-white;

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -18,10 +18,10 @@ label {
 .form-control,
 .form-select {
   // stylelint-disable-next-line primer/spacing
-  padding: 0 12px;
+  padding: 5px 12px;
   font-size: $body-font-size;
   // stylelint-disable-next-line primer/typography
-  line-height: height-without-border($size-5);
+  line-height: 20px;
   color: $text-gray-dark;
   vertical-align: middle;
   background-color: $bg-white;
@@ -72,6 +72,7 @@ textarea.form-control {
   // stylelint-disable-next-line primer/colors
   background-color: $white-fade-15;
   border-color: transparent;
+  box-shadow: none;
 
   &::placeholder {
     color: inherit;
@@ -94,15 +95,17 @@ textarea.form-control {
 
 // Mini inputs, to match .minibutton
 .input-sm {
+  // stylelint-disable-next-line primer/spacing
+  padding-top: 3px;
+  // stylelint-disable-next-line primer/spacing
+  padding-bottom: 3px;
   font-size: $font-size-small;
   // stylelint-disable-next-line primer/typography
-  line-height: height-without-border($size-4);
+  line-height: 20px;
 }
 
 // Large inputs
 .input-lg {
-  padding-right: $spacer-3;
-  padding-left: $spacer-3;
   font-size: $h4-size;
 }
 

--- a/src/forms/form-select.scss
+++ b/src/forms/form-select.scss
@@ -25,10 +25,11 @@
 
 .select-sm {
   height: $size-4;
-  min-height: $size-4;
+  // stylelint-disable-next-line primer/spacing
+  padding-top: 3px;
+  // stylelint-disable-next-line primer/spacing
+  padding-bottom: 3px;
   font-size: $font-size-small;
-  // stylelint-disable-next-line primer/typography
-  line-height: height-without-border($size-4);
 
   &[multiple] {
     height: auto;

--- a/src/labels/counters.scss
+++ b/src/labels/counters.scss
@@ -20,8 +20,8 @@
   }
 
   .octicon {
-    opacity: 0.8;
     vertical-align: text-top;
+    opacity: 0.8;
   }
 }
 

--- a/src/labels/counters.scss
+++ b/src/labels/counters.scss
@@ -20,7 +20,8 @@
   }
 
   .octicon {
-    opacity: 0.5;
+    opacity: 0.8;
+    vertical-align: text-top;
   }
 }
 

--- a/src/labels/states.scss
+++ b/src/labels/states.scss
@@ -13,11 +13,11 @@
 .State {
   display: inline-block;
   // stylelint-disable-next-line primer/spacing
-  padding: 0 12px;
+  padding: 6px 12px;
   font-size: $body-font-size;
   font-weight: $font-weight-semibold;
   // stylelint-disable-next-line primer/typography
-  line-height: $size-5;
+  line-height: 20px;
   color: $text-white;
   text-align: center;
   white-space: nowrap;
@@ -43,8 +43,8 @@
 // Small
 
 .State--small {
-  padding-right: $spacer-2;
-  padding-left: $spacer-2;
+  // stylelint-disable-next-line primer/spacing
+  padding: 0 10px;
   font-size: $font-size-small;
   // stylelint-disable-next-line primer/typography
   line-height: $size-3;

--- a/src/navigation/subnav.scss
+++ b/src/navigation/subnav.scss
@@ -20,10 +20,11 @@
 .subnav-item {
   position: relative;
   float: left;
-  padding: 0 $spacer-3;
+  // stylelint-disable-next-line primer/spacing
+  padding: 5px $spacer-3;
   font-weight: $font-weight-semibold;
   // stylelint-disable-next-line primer/typography
-  line-height: height-without-border($size-5);
+  line-height: 20px;
   color: $text-gray-dark;
   border: $border;
 

--- a/src/support/mixins/typography.scss
+++ b/src/support/mixins/typography.scss
@@ -1,10 +1,3 @@
-// height-without-border
-//
-// Removes top/bottom border from the total height
-@function height-without-border($height) {
-  @return $height - ($border-width * 2);
-}
-
 // Text hiding for image based text replacement.
 // Higher performance than -9999px because it only renders
 // the size of the actual text, not a full 9999px box.

--- a/src/support/variables/misc.scss
+++ b/src/support/variables/misc.scss
@@ -12,7 +12,7 @@ $border-radius-2:  6px !default;
 $border-radius: $border-radius-2 !default;
 
 // Box shadow
-$box-shadow: 0 1px 0 rgba($gray-400, 0.1) !default;
+$box-shadow: 0 1px 0 rgba($black, 0.04) !default;
 $box-shadow-medium: 0 3px 6px rgba($gray-400, 0.15) !default;
 $box-shadow-large: 0 8px 24px rgba($gray-400, 0.2) !default;
 $box-shadow-extra-large: 0 12px 48px rgba($gray-400, 0.3) !default;

--- a/src/support/variables/misc.scss
+++ b/src/support/variables/misc.scss
@@ -22,7 +22,7 @@ $box-shadow-inset: inset 0 1px 0 rgba($border-color, 0.2) !default; // top inner
 $box-shadow-focus: 0 0 0 3px rgba($border-blue, 0.3) !default; // blue focus ring
 
 // Button variables
-$border-color-button: $border-color !default;
+$border-color-button: rgba($black, 0.12) !default;
 $btn-active-shadow: inset 0 0.15em 0.3em $black-fade-15 !default; // TODO: Deprecate?
 
 // Form variables


### PR DESCRIPTION
Here a few more "Component refresh" tweaks

## Buttons

There are some [changes](https://github.com/github/design-systems/issues/770#issuecomment-605783773) to the primary and outline buttons:

#### Before

<img width="572" alt="before" src="https://user-images.githubusercontent.com/378023/78019388-9a527e00-738a-11ea-9dea-d5eeaf9c66c9.png">

#### After

<img width="570" alt="after" src="https://user-images.githubusercontent.com/378023/78019383-9888ba80-738a-11ea-8ded-0c09e398354d.png">

## Sizes

This PR also reverts using only line-height for setting a component's height and instead uses again a mix of line-height and padding (and border). There are [some places](https://github.com/github/design-systems/issues/769#issuecomment-602458706) on dotcom that use custom padding and would blow them up too much with a large line-height.

The buttons are still only `32px` in height (instead of `34px`) so it matches our sizing scale. It leaves the line-height unchanged to `20px` but uses `5px` y-padding instead of `6px`.

![Screen Shot 2020-04-02 at 9 29 23 AM](https://user-images.githubusercontent.com/378023/78198954-38e2fa00-74c5-11ea-9183-71ace9236d65.png)

👀  [Preview](https://primer-css-git-next-3.primer.now.sh/css/stickersheet)