### PR TITLE
Add support for aria-current=false

### DIFF
--- a/src/breadcrumb/breadcrumb.scss
+++ b/src/breadcrumb/breadcrumb.scss
@@ -19,7 +19,7 @@
 }
 
 .breadcrumb-item-selected,
-.breadcrumb-item[aria-current] {
+.breadcrumb-item[aria-current]:not([aria-current=false]) {
   color: $text-gray;
 
   &::after {

--- a/src/navigation/filter-list.scss
+++ b/src/navigation/filter-list.scss
@@ -45,7 +45,7 @@
 
   &.selected,
   &[aria-selected=true],
-  &[aria-current] {
+  &[aria-current]:not([aria-current=false]) {
     color: $text-white;
     background-color: $bg-blue;
   }

--- a/src/navigation/menu.scss
+++ b/src/navigation/menu.scss
@@ -46,7 +46,7 @@
 
   &.selected,
   &[aria-selected=true],
-  &[aria-current] {
+  &[aria-current]:not([aria-current=false]) {
     font-weight: $font-weight-bold;
     color: $text-gray-dark;
     cursor: default;

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -60,7 +60,7 @@
   background-color: $bg-white;
 }
 
-.SideNav-item[aria-current="page"],
+.SideNav-item[aria-current]:not([aria-current=false]),
 .SideNav-item[aria-selected="true"] {
   font-weight: $font-weight-semibold;
   color: $text-gray-dark;
@@ -104,7 +104,7 @@
   outline: none;
 }
 
-.SideNav-subItem[aria-current="page"],
+.SideNav-subItem[aria-current]:not([aria-current=false]),
 .SideNav-subItem[aria-selected="true"] {
   font-weight: $font-weight-semibold;
   color: $text-gray-dark;

--- a/src/navigation/subnav.scss
+++ b/src/navigation/subnav.scss
@@ -41,7 +41,7 @@
 
   &.selected,
   &[aria-selected=true],
-  &[aria-current] {
+  &[aria-current]:not([aria-current=false]) {
     z-index: 2;
     color: $text-white;
     background-color: $bg-blue;

--- a/src/navigation/tabnav.scss
+++ b/src/navigation/tabnav.scss
@@ -31,7 +31,7 @@
 
   &.selected,
   &[aria-selected=true],
-  &[aria-current] {
+  &[aria-current]:not([aria-current=false]) {
     color: $text-gray-dark;
     background-color: $bg-white;
     border-color: $border-gray-dark;

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -37,7 +37,7 @@
 
   &.selected,
   &[role=tab][aria-selected=true],
-  &[aria-current] {
+  &[aria-current]:not([aria-current=false]) {
     font-weight: $font-weight-bold;
     color: $text-gray-dark;
     // stylelint-disable-next-line primer/borders

--- a/src/pagination/pagination.scss
+++ b/src/pagination/pagination.scss
@@ -50,8 +50,7 @@
 
   .current,
   .current:hover,
-  [aria-current],
-  [aria-current]:hover {
+  [aria-current]:not([aria-current=false]) {
     z-index: 3;
     color: $text-white;
     background-color: $bg-blue;


### PR DESCRIPTION
This PR adds support for using `aria-current=false`.

## Problem

In https://github.com/primer/css/pull/1006 we added support for using `aria-current` to add a "selected" state. But on dotcom there were cases where instead of removing the `aria-current` attribute, it was set to `aria-current=false`. The CSS selector of `[aria-current]` was still valid, thus making all items look selected. See https://github.com/github/github/issues/140091.

## Fix

By using a `[aria-current]:not([aria-current=false])` selector, an item looks selected with any of the options like `page`, `step`, `true` etc., except when using `aria-current=false`:

![aria-current](https://user-images.githubusercontent.com/378023/78642668-0fbfd080-78ee-11ea-9c14-2316f5d72f0c.gif)

👀  [Preview](https://primer-css-git-fix-aria-current.primer.now.sh/css/components/navigation#sub-navigation)

## Concerns

- Higher specificity. Although a nice side effect is that we don't need [this](https://github.com/primer/css/pull/1060/files#diff-c0b47638ca33e04f13378ccebaf554b9L54) `:hover` selector anymore.
- In the past, using `:not()` was bad for performance. But I think most browser found a way to optimize that by now.

## TODO on dotcom

- Revert https://github.com/github/github/pull/140114 once this PR is in `github/github`.

---

Fixes https://github.com/primer/css/issues/1019
