### PR TITLE
Refresh SelectMenu

### DIFF
--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -512,6 +512,31 @@ When fetching large lists, consider showing a `.SelectMenu-loading` animation.
 <div class="d-none d-sm-block" style="height: 220px"><!-- min height for > sm --></div>
 ```
 
+## Disabled
+
+To disable a list item, use the `disabled` attribute for `<button>`s. For `<a>`s replace the `href` with an `aria-disabled="true"` attribute. Note: If not obvious, try to communicate to the user why an item is disabled.
+
+```html live
+<details class="details-reset details-overlay" open>
+  <summary class="btn" aria-haspopup="true">
+    Choose an item
+  </summary>
+  <div class="SelectMenu">
+    <div class="SelectMenu-modal">
+      <div class="SelectMenu-list">
+        <button class="SelectMenu-item" role="menuitem">Item 1</button>
+        <button class="SelectMenu-item" role="menuitem" disabled>Item 2 (disabled)</button>
+        <a class="SelectMenu-item" role="menuitem" href="#">Item 3</a>
+        <a class="SelectMenu-item" role="menuitem" aria-disabled="true">Item 4 (disabled)</a>
+      </div>
+    </div>
+  </div>
+</details>
+
+<div class="d-sm-none" style="height: 600px"><!-- min height for < sm --></div>
+<div class="d-none d-sm-block" style="height: 160px"><!-- min height for > sm --></div>
+```
+
 ## Blankslate
 
 Sometimes a Select Menu needs to communicate a "blank slate" where there's no content in the menu's list. Usually these include a clear call to action to add said content to the list. Swap out the contents of a `.SelectMenu-list` with a `.SelectMenu-blankslate` and customize its contents as needed.

--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -102,70 +102,10 @@ If the `SelectMenu` should show a check icon for selected items, use the `Select
 </details>
 
 <div class="d-sm-none" style="height: 600px"><!-- min height for < sm --></div>
-<div class="d-none d-sm-block" style="height: 250px"><!-- min height for > sm --></div>
+<div class="d-none d-sm-block" style="height: 200px"><!-- min height for > sm --></div>
 ```
 
-## List items
-
-The list of items is arguably the most important subcomponent within the menu. Build them out of anchors, buttons, or just about any [interactive content](http://w3c.github.io/html/dom.html#interactive-content). List items are also customizable with options for avatars, additional icons, and multiple lines of text. Use utility classes in case more custom styling is needed.
-
-```html live
-<details class="details-reset details-overlay" open>
-  <summary class="btn" aria-haspopup="true">
-    Choose an item
-  </summary>
-  <div class="SelectMenu">
-    <div class="SelectMenu-modal">
-      <div class="SelectMenu-list">
-        <button class="SelectMenu-item" role="menuitem">
-          Text only
-        </button>
-        <button class="SelectMenu-item" role="menuitem">
-          <!-- <%= octicon "pin", class: "SelectMenu-icon" %> -->
-          <svg class="SelectMenu-icon octicon octicon-pin" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 1.2V2l.5 1L6 6H2.2c-.44 0-.67.53-.34.86L5 10l-4 5 5-4 3.14 3.14a.5.5 0 00.86-.34V10l3-4.5 1 .5h.8c.44 0 .67-.53.34-.86L10.86.86a.5.5 0 00-.86.34z"></path></svg>
-          With an icon
-        </button>
-        <button class="SelectMenu-item" role="menuitem">
-          <img
-            class="avatar avatar-small mr-2"
-            src="https://avatars.githubusercontent.com/hubot?s=40"
-            alt="hubot"
-            height="20"
-            width="20"
-          />
-          With an avatar
-        </button>
-        <button class="SelectMenu-item flex-justify-between" role="menuitem">
-          With a status icon
-          <!-- <%= octicon "primitive-dot", class: "color-green-5 ml-2" %> -->
-          <svg
-            width="8"
-            height="16"
-            viewBox="0 0 8 16"
-            class="octicon octicon-primitive-dot color-green-5 ml-2"
-            aria-hidden="true"
-          >
-            <path fill-rule="evenodd" d="M0 8c0-2.2 1.8-4 4-4s4 1.8 4 4-1.8 4-4 4-4-1.8-4-4z" />
-          </svg>
-        </button>
-        <button class="SelectMenu-item d-block" role="menuitem">
-          With a <span class="Label bg-blue" title="Label: label">label</span>
-        </button>
-        <button class="SelectMenu-item" role="menuitem">
-          With a counter <span class="Counter bg-gray-2 ml-1">16</span>
-        </button>
-        <button class="SelectMenu-item d-block" role="menuitem">
-          <h5>With a heading</h5>
-          <span>and some longer description</span>
-        </button>
-      </div>
-    </div>
-  </div>
-</details>
-
-<div class="d-sm-none" style="height: 600px"><!-- min height for < sm --></div>
-<div class="d-none d-sm-block" style="height: 320px"><!-- min height for > sm --></div>
-```
+## Borderless
 
 Use the `.SelectMenu-list--withoutBorders` modifier to remove the borders between list items. Note: It's better to keep the borders if a list contains items with multiple lines of text. It will make it easier to see where the items start and end.
 
@@ -220,9 +160,78 @@ Add a `.SelectMenu-header` at the top to house a clear title and a close button.
 <div class="d-none d-sm-block" style="height: 180px"><!-- min height for > sm --></div>
 ```
 
+## List items
+
+The list of items is arguably the most important subcomponent within the menu. Build them out of anchors, buttons, or just about any [interactive content](http://w3c.github.io/html/dom.html#interactive-content). List items are also customizable with options for avatars, additional icons, and multiple lines of text. Use utility classes in case more custom styling is needed.
+
+```html live
+<details class="details-reset details-overlay" open>
+  <summary class="btn" aria-haspopup="true">
+    Choose an item
+  </summary>
+  <div class="SelectMenu">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <h3 class="SelectMenu-title">Title</h3>
+        <button class="SelectMenu-closeButton" type="button">
+          <!-- <%= octicon "x" %> -->
+          <svg class="octicon octicon-x" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.72 3.72C3.86062 3.57955 4.05125 3.50066 4.25 3.50066C4.44875 3.50066 4.63937 3.57955 4.78 3.72L8 6.94L11.22 3.72C11.2887 3.64631 11.3715 3.58721 11.4635 3.54622C11.5555 3.50523 11.6548 3.48319 11.7555 3.48141C11.8562 3.47963 11.9562 3.49816 12.0496 3.53588C12.143 3.5736 12.2278 3.62974 12.299 3.70096C12.3703 3.77218 12.4264 3.85702 12.4641 3.9504C12.5018 4.04379 12.5204 4.14382 12.5186 4.24452C12.5168 4.34523 12.4948 4.44454 12.4538 4.53654C12.4128 4.62854 12.3537 4.71134 12.28 4.78L9.06 8L12.28 11.22C12.3537 11.2887 12.4128 11.3715 12.4538 11.4635C12.4948 11.5555 12.5168 11.6548 12.5186 11.7555C12.5204 11.8562 12.5018 11.9562 12.4641 12.0496C12.4264 12.143 12.3703 12.2278 12.299 12.299C12.2278 12.3703 12.143 12.4264 12.0496 12.4641C11.9562 12.5018 11.8562 12.5204 11.7555 12.5186C11.6548 12.5168 11.5555 12.4948 11.4635 12.4538C11.3715 12.4128 11.2887 12.3537 11.22 12.28L8 9.06L4.78 12.28C4.63782 12.4125 4.44977 12.4846 4.25547 12.4812C4.06117 12.4777 3.87579 12.399 3.73837 12.2616C3.60096 12.1242 3.52225 11.9388 3.51882 11.7445C3.51539 11.5502 3.58752 11.3622 3.72 11.22L6.94 8L3.72 4.78C3.57955 4.63938 3.50066 4.44875 3.50066 4.25C3.50066 4.05125 3.57955 3.86063 3.72 3.72Z"></path></svg>
+        </button>
+      </header>
+      <div class="SelectMenu-list">
+        <button class="SelectMenu-item" role="menuitem">
+          Text only
+        </button>
+        <button class="SelectMenu-item" role="menuitem">
+          <!-- <%= octicon "pin", class: "SelectMenu-icon" %> -->
+          <svg class="SelectMenu-icon octicon octicon-pin" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 1.2V2l.5 1L6 6H2.2c-.44 0-.67.53-.34.86L5 10l-4 5 5-4 3.14 3.14a.5.5 0 00.86-.34V10l3-4.5 1 .5h.8c.44 0 .67-.53.34-.86L10.86.86a.5.5 0 00-.86.34z"></path></svg>
+          With an icon
+        </button>
+        <button class="SelectMenu-item" role="menuitem">
+          <img
+            class="avatar avatar-small mr-2"
+            src="https://avatars.githubusercontent.com/hubot?s=40"
+            alt="hubot"
+            height="20"
+            width="20"
+          />
+          With an avatar
+        </button>
+        <button class="SelectMenu-item flex-justify-between" role="menuitem">
+          With a status icon
+          <!-- <%= octicon "primitive-dot", class: "color-green-5 ml-2" %> -->
+          <svg
+            width="8"
+            height="16"
+            viewBox="0 0 8 16"
+            class="octicon octicon-primitive-dot color-green-5 ml-2"
+            aria-hidden="true"
+          >
+            <path fill-rule="evenodd" d="M0 8c0-2.2 1.8-4 4-4s4 1.8 4 4-1.8 4-4 4-4-1.8-4-4z" />
+          </svg>
+        </button>
+        <button class="SelectMenu-item d-block" role="menuitem">
+          With a <span class="Label bg-blue" title="Label: label">label</span>
+        </button>
+        <button class="SelectMenu-item" role="menuitem">
+          With a counter <span class="Counter bg-gray-2 ml-1">16</span>
+        </button>
+        <button class="SelectMenu-item d-block" role="menuitem">
+          <h5>With a heading</h5>
+          <span>and some longer description</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</details>
+
+<div class="d-sm-none" style="height: 600px"><!-- min height for < sm --></div>
+<div class="d-none d-sm-block" style="height: 320px"><!-- min height for > sm --></div>
+```
+
 ## Divider
 
-The Select Menu's list can be divided into multiple parts by adding a `.SelectMenu-divider`.
+The Select Menu's list can be divided into multiple parts by adding a `.SelectMenu-divider`. It can be a `<div>` with text/content. Or just an `<hr>` to add a visual separator.
 
 ```html live
 <details class="details-reset details-overlay" open>
@@ -244,14 +253,50 @@ The Select Menu's list can be divided into multiple parts by adding a `.SelectMe
         <div class="SelectMenu-divider">More options</div>
         <button class="SelectMenu-item" role="menuitem">Item 3</button>
         <button class="SelectMenu-item" role="menuitem">Item 4</button>
+        <hr class="SelectMenu-divider">
         <button class="SelectMenu-item" role="menuitem">Item 5</button>
+        <button class="SelectMenu-item" role="menuitem">Item 6</button>
       </div>
     </div>
   </div>
 </details>
 
 <div class="d-sm-none" style="height: 600px"><!-- min height for < sm --></div>
-<div class="d-none d-sm-block" style="height: 260px"><!-- min height for > sm --></div>
+<div class="d-none d-sm-block" style="height: 300px"><!-- min height for > sm --></div>
+```
+
+Dividers are also supported when using the `.SelectMenu-list--withoutBorders` modifier.
+
+```html live
+<details class="details-reset details-overlay" open>
+  <summary class="btn" aria-haspopup="true">
+    Choose an item
+  </summary>
+  <div class="SelectMenu">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <h3 class="SelectMenu-title">Title</h3>
+        <button class="SelectMenu-closeButton" type="button">
+          <!-- <%= octicon "x" %> -->
+          <svg class="octicon octicon-x" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.72 3.72C3.86062 3.57955 4.05125 3.50066 4.25 3.50066C4.44875 3.50066 4.63937 3.57955 4.78 3.72L8 6.94L11.22 3.72C11.2887 3.64631 11.3715 3.58721 11.4635 3.54622C11.5555 3.50523 11.6548 3.48319 11.7555 3.48141C11.8562 3.47963 11.9562 3.49816 12.0496 3.53588C12.143 3.5736 12.2278 3.62974 12.299 3.70096C12.3703 3.77218 12.4264 3.85702 12.4641 3.9504C12.5018 4.04379 12.5204 4.14382 12.5186 4.24452C12.5168 4.34523 12.4948 4.44454 12.4538 4.53654C12.4128 4.62854 12.3537 4.71134 12.28 4.78L9.06 8L12.28 11.22C12.3537 11.2887 12.4128 11.3715 12.4538 11.4635C12.4948 11.5555 12.5168 11.6548 12.5186 11.7555C12.5204 11.8562 12.5018 11.9562 12.4641 12.0496C12.4264 12.143 12.3703 12.2278 12.299 12.299C12.2278 12.3703 12.143 12.4264 12.0496 12.4641C11.9562 12.5018 11.8562 12.5204 11.7555 12.5186C11.6548 12.5168 11.5555 12.4948 11.4635 12.4538C11.3715 12.4128 11.2887 12.3537 11.22 12.28L8 9.06L4.78 12.28C4.63782 12.4125 4.44977 12.4846 4.25547 12.4812C4.06117 12.4777 3.87579 12.399 3.73837 12.2616C3.60096 12.1242 3.52225 11.9388 3.51882 11.7445C3.51539 11.5502 3.58752 11.3622 3.72 11.22L6.94 8L3.72 4.78C3.57955 4.63938 3.50066 4.44875 3.50066 4.25C3.50066 4.05125 3.57955 3.86063 3.72 3.72Z"></path></svg>
+        </button>
+      </header>
+      <div class="SelectMenu-list SelectMenu-list--withoutBorders">
+        <button class="SelectMenu-item" role="menuitem">Item 1</button>
+        <button class="SelectMenu-item" role="menuitem">Item 2</button>
+        <div class="SelectMenu-divider">More options</div>
+        <button class="SelectMenu-item" role="menuitem">Item 3</button>
+        <button class="SelectMenu-item" role="menuitem">Item 4</button>
+        <hr class="SelectMenu-divider">
+        <button class="SelectMenu-item" role="menuitem">Item 5</button>
+        <button class="SelectMenu-item" role="menuitem">Item 6</button>
+      </div>
+    </div>
+  </div>
+</details>
+
+<div class="d-sm-none" style="height: 600px"><!-- min height for < sm --></div>
+<div class="d-none d-sm-block" style="height: 300px"><!-- min height for > sm --></div>
 ```
 
 ## Footer

--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -18,18 +18,6 @@ Use a `<details>` element to toggle the Select Menu. The `<summary>` element can
   </summary>
   <div class="SelectMenu">
     <div class="SelectMenu-modal">
-      <header class="SelectMenu-header">
-        <h3 class="SelectMenu-title">Title</h3>
-        <button class="SelectMenu-closeButton" type="button">
-          <!-- <%= octicon "x" %> -->
-          <svg width="12" height="16" viewBox="0 0 12 16" class="octicon octicon-x" aria-hidden="true">
-            <path
-              fill-rule="evenodd"
-              d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
-            />
-          </svg>
-        </button>
-      </header>
       <div class="SelectMenu-list">
         <button class="SelectMenu-item" role="menuitem">Item 1</button>
         <button class="SelectMenu-item" role="menuitem">Item 2</button>
@@ -40,7 +28,7 @@ Use a `<details>` element to toggle the Select Menu. The `<summary>` element can
 </details>
 
 <div class="d-sm-none" style="height: 600px"><!-- min height for < sm --></div>
-<div class="d-none d-sm-block" style="height: 180px"><!-- min height for > sm --></div>
+<div class="d-none d-sm-block" style="height: 120px"><!-- min height for > sm --></div>
 ```
 
 Add a `.SelectMenu-header` to house a clear title and a close button. Note that the close button is only shown on narrow screens (mobile).
@@ -57,18 +45,6 @@ In case the Select Menu should be aligned to the right, use `SelectMenu right-0`
     </summary>
     <div class="SelectMenu right-0">
       <div class="SelectMenu-modal">
-        <header class="SelectMenu-header">
-          <h3 class="SelectMenu-title">Title</h3>
-          <button class="SelectMenu-closeButton" type="button">
-            <!-- <%= octicon "x" %> -->
-            <svg width="12" height="16" viewBox="0 0 12 16" class="octicon octicon-x" aria-hidden="true">
-              <path
-                fill-rule="evenodd"
-                d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
-              />
-            </svg>
-          </button>
-        </header>
         <div class="SelectMenu-list">
           <button class="SelectMenu-item" role="menuitem">Item 1</button>
           <button class="SelectMenu-item" role="menuitem">Item 2</button>
@@ -94,42 +70,30 @@ If the `SelectMenu` should show a check icon for selected items, use the `Select
   </summary>
   <div class="SelectMenu">
     <div class="SelectMenu-modal">
-      <header class="SelectMenu-header">
-        <h3 class="SelectMenu-title">Title</h3>
-        <button class="SelectMenu-closeButton" type="button">
-          <!-- <%= octicon "x" %> -->
-          <svg width="12" height="16" viewBox="0 0 12 16" class="octicon octicon-x" aria-hidden="true">
-            <path
-              fill-rule="evenodd"
-              d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
-            />
-          </svg>
-        </button>
-      </header>
       <div class="SelectMenu-list">
         <button class="SelectMenu-item" role="menuitemcheckbox" aria-checked="true">
           <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
-          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M13.78 4.22C13.9204 4.36062 13.9993 4.55125 13.9993 4.75C13.9993 4.94875 13.9204 5.13937 13.78 5.28L6.53 12.53C6.38937 12.6704 6.19875 12.7493 6 12.7493C5.80125 12.7493 5.61062 12.6704 5.47 12.53L2.22 9.28C2.08752 9.13782 2.0154 8.94978 2.01882 8.75547C2.02225 8.56117 2.10096 8.37579 2.23838 8.23837C2.37579 8.10096 2.56118 8.02225 2.75548 8.01882C2.94978 8.01539 3.13782 8.08752 3.28 8.22L6 10.94L12.72 4.22C12.8606 4.07955 13.0512 4.00066 13.25 4.00066C13.4487 4.00066 13.6394 4.07955 13.78 4.22Z"></path></svg>
           Selected state
         </button>
         <button class="SelectMenu-item" role="menuitemcheckbox">
           <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
-          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M13.78 4.22C13.9204 4.36062 13.9993 4.55125 13.9993 4.75C13.9993 4.94875 13.9204 5.13937 13.78 5.28L6.53 12.53C6.38937 12.6704 6.19875 12.7493 6 12.7493C5.80125 12.7493 5.61062 12.6704 5.47 12.53L2.22 9.28C2.08752 9.13782 2.0154 8.94978 2.01882 8.75547C2.02225 8.56117 2.10096 8.37579 2.23838 8.23837C2.37579 8.10096 2.56118 8.02225 2.75548 8.01882C2.94978 8.01539 3.13782 8.08752 3.28 8.22L6 10.94L12.72 4.22C12.8606 4.07955 13.0512 4.00066 13.25 4.00066C13.4487 4.00066 13.6394 4.07955 13.78 4.22Z"></path></svg>
           Default state
         </button>
         <button class="SelectMenu-item" role="menuitemcheckbox" aria-checked="true">
           <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
-          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M13.78 4.22C13.9204 4.36062 13.9993 4.55125 13.9993 4.75C13.9993 4.94875 13.9204 5.13937 13.78 5.28L6.53 12.53C6.38937 12.6704 6.19875 12.7493 6 12.7493C5.80125 12.7493 5.61062 12.6704 5.47 12.53L2.22 9.28C2.08752 9.13782 2.0154 8.94978 2.01882 8.75547C2.02225 8.56117 2.10096 8.37579 2.23838 8.23837C2.37579 8.10096 2.56118 8.02225 2.75548 8.01882C2.94978 8.01539 3.13782 8.08752 3.28 8.22L6 10.94L12.72 4.22C12.8606 4.07955 13.0512 4.00066 13.25 4.00066C13.4487 4.00066 13.6394 4.07955 13.78 4.22Z"></path></svg>
           Selected state
         </button>
         <button class="SelectMenu-item" role="menuitemcheckbox">
           <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
-          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M13.78 4.22C13.9204 4.36062 13.9993 4.55125 13.9993 4.75C13.9993 4.94875 13.9204 5.13937 13.78 5.28L6.53 12.53C6.38937 12.6704 6.19875 12.7493 6 12.7493C5.80125 12.7493 5.61062 12.6704 5.47 12.53L2.22 9.28C2.08752 9.13782 2.0154 8.94978 2.01882 8.75547C2.02225 8.56117 2.10096 8.37579 2.23838 8.23837C2.37579 8.10096 2.56118 8.02225 2.75548 8.01882C2.94978 8.01539 3.13782 8.08752 3.28 8.22L6 10.94L12.72 4.22C12.8606 4.07955 13.0512 4.00066 13.25 4.00066C13.4487 4.00066 13.6394 4.07955 13.78 4.22Z"></path></svg>
           Default state
         </button>
         <button class="SelectMenu-item" role="menuitemcheckbox">
           <!-- <%= octicon "check", class: "SelectMenu-icon SelectMenu-icon--check" %> -->
-          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true" ><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z" /></svg>
+          <svg class="SelectMenu-icon SelectMenu-icon--check octicon octicon-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M13.78 4.22C13.9204 4.36062 13.9993 4.55125 13.9993 4.75C13.9993 4.94875 13.9204 5.13937 13.78 5.28L6.53 12.53C6.38937 12.6704 6.19875 12.7493 6 12.7493C5.80125 12.7493 5.61062 12.6704 5.47 12.53L2.22 9.28C2.08752 9.13782 2.0154 8.94978 2.01882 8.75547C2.02225 8.56117 2.10096 8.37579 2.23838 8.23837C2.37579 8.10096 2.56118 8.02225 2.75548 8.01882C2.94978 8.01539 3.13782 8.08752 3.28 8.22L6 10.94L12.72 4.22C12.8606 4.07955 13.0512 4.00066 13.25 4.00066C13.4487 4.00066 13.6394 4.07955 13.78 4.22Z"></path></svg>
           Default state
         </button>
       </div>
@@ -152,18 +116,6 @@ The list of items is arguably the most important subcomponent within the menu. B
   </summary>
   <div class="SelectMenu">
     <div class="SelectMenu-modal">
-      <header class="SelectMenu-header">
-        <h3 class="SelectMenu-title">Title</h3>
-        <button class="SelectMenu-closeButton" type="button">
-          <!--%= octicon "x" %-->
-          <svg version="1.1" width="12" height="16" viewBox="0 0 12 16" class="octicon octicon-x" aria-hidden="true">
-            <path
-              fill-rule="evenodd"
-              d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
-            />
-          </svg>
-        </button>
-      </header>
       <div class="SelectMenu-list">
         <button class="SelectMenu-item" role="menuitem">
           Text only
@@ -215,6 +167,37 @@ The list of items is arguably the most important subcomponent within the menu. B
 <div class="d-none d-sm-block" style="height: 320px"><!-- min height for > sm --></div>
 ```
 
+## Header
+
+Add a `.SelectMenu-header` at the top to house a clear title and a close button.
+
+```html live
+<details class="details-reset details-overlay" open>
+  <summary class="btn" aria-haspopup="true">
+    Choose an item
+  </summary>
+  <div class="SelectMenu">
+    <div class="SelectMenu-modal">
+      <header class="SelectMenu-header">
+        <h3 class="SelectMenu-title">Title</h3>
+        <button class="SelectMenu-closeButton" type="button">
+          <!-- <%= octicon "x" %> -->
+          <svg class="octicon octicon-x" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.72 3.72C3.86062 3.57955 4.05125 3.50066 4.25 3.50066C4.44875 3.50066 4.63937 3.57955 4.78 3.72L8 6.94L11.22 3.72C11.2887 3.64631 11.3715 3.58721 11.4635 3.54622C11.5555 3.50523 11.6548 3.48319 11.7555 3.48141C11.8562 3.47963 11.9562 3.49816 12.0496 3.53588C12.143 3.5736 12.2278 3.62974 12.299 3.70096C12.3703 3.77218 12.4264 3.85702 12.4641 3.9504C12.5018 4.04379 12.5204 4.14382 12.5186 4.24452C12.5168 4.34523 12.4948 4.44454 12.4538 4.53654C12.4128 4.62854 12.3537 4.71134 12.28 4.78L9.06 8L12.28 11.22C12.3537 11.2887 12.4128 11.3715 12.4538 11.4635C12.4948 11.5555 12.5168 11.6548 12.5186 11.7555C12.5204 11.8562 12.5018 11.9562 12.4641 12.0496C12.4264 12.143 12.3703 12.2278 12.299 12.299C12.2278 12.3703 12.143 12.4264 12.0496 12.4641C11.9562 12.5018 11.8562 12.5204 11.7555 12.5186C11.6548 12.5168 11.5555 12.4948 11.4635 12.4538C11.3715 12.4128 11.2887 12.3537 11.22 12.28L8 9.06L4.78 12.28C4.63782 12.4125 4.44977 12.4846 4.25547 12.4812C4.06117 12.4777 3.87579 12.399 3.73837 12.2616C3.60096 12.1242 3.52225 11.9388 3.51882 11.7445C3.51539 11.5502 3.58752 11.3622 3.72 11.22L6.94 8L3.72 4.78C3.57955 4.63938 3.50066 4.44875 3.50066 4.25C3.50066 4.05125 3.57955 3.86063 3.72 3.72Z"></path></svg>
+        </button>
+      </header>
+      <div class="SelectMenu-list">
+        <button class="SelectMenu-item" role="menuitem">Item 1</button>
+        <button class="SelectMenu-item" role="menuitem">Item 2</button>
+        <button class="SelectMenu-item" role="menuitem">Item 3</button>
+      </div>
+    </div>
+  </div>
+</details>
+
+<div class="d-sm-none" style="height: 600px"><!-- min height for < sm --></div>
+<div class="d-none d-sm-block" style="height: 180px"><!-- min height for > sm --></div>
+```
+
 ## Divider
 
 The Select Menu's list can be divided into multiple parts by adding a `.SelectMenu-divider`.
@@ -230,12 +213,7 @@ The Select Menu's list can be divided into multiple parts by adding a `.SelectMe
         <h3 class="SelectMenu-title">Title</h3>
         <button class="SelectMenu-closeButton" type="button">
           <!-- <%= octicon "x" %> -->
-          <svg width="12" height="16" viewBox="0 0 12 16" class="octicon octicon-x" aria-hidden="true">
-            <path
-              fill-rule="evenodd"
-              d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
-            />
-          </svg>
+          <svg class="octicon octicon-x" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.72 3.72C3.86062 3.57955 4.05125 3.50066 4.25 3.50066C4.44875 3.50066 4.63937 3.57955 4.78 3.72L8 6.94L11.22 3.72C11.2887 3.64631 11.3715 3.58721 11.4635 3.54622C11.5555 3.50523 11.6548 3.48319 11.7555 3.48141C11.8562 3.47963 11.9562 3.49816 12.0496 3.53588C12.143 3.5736 12.2278 3.62974 12.299 3.70096C12.3703 3.77218 12.4264 3.85702 12.4641 3.9504C12.5018 4.04379 12.5204 4.14382 12.5186 4.24452C12.5168 4.34523 12.4948 4.44454 12.4538 4.53654C12.4128 4.62854 12.3537 4.71134 12.28 4.78L9.06 8L12.28 11.22C12.3537 11.2887 12.4128 11.3715 12.4538 11.4635C12.4948 11.5555 12.5168 11.6548 12.5186 11.7555C12.5204 11.8562 12.5018 11.9562 12.4641 12.0496C12.4264 12.143 12.3703 12.2278 12.299 12.299C12.2278 12.3703 12.143 12.4264 12.0496 12.4641C11.9562 12.5018 11.8562 12.5204 11.7555 12.5186C11.6548 12.5168 11.5555 12.4948 11.4635 12.4538C11.3715 12.4128 11.2887 12.3537 11.22 12.28L8 9.06L4.78 12.28C4.63782 12.4125 4.44977 12.4846 4.25547 12.4812C4.06117 12.4777 3.87579 12.399 3.73837 12.2616C3.60096 12.1242 3.52225 11.9388 3.51882 11.7445C3.51539 11.5502 3.58752 11.3622 3.72 11.22L6.94 8L3.72 4.78C3.57955 4.63938 3.50066 4.44875 3.50066 4.25C3.50066 4.05125 3.57955 3.86063 3.72 3.72Z"></path></svg>
         </button>
       </header>
       <div class="SelectMenu-list">
@@ -269,11 +247,7 @@ Use a `.SelectMenu-footer` at the bottom for additional information. As a side e
         <h3 class="SelectMenu-title">Title</h3>
         <button class="SelectMenu-closeButton" type="button">
           <!-- <%= octicon "x" %> -->
-          <svg width="12" height="16" viewBox="0 0 12 16" class="octicon octicon-x" aria-hidden="true">
-            <path fill-rule="evenodd"
-              d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
-            />
-          </svg>
+          <svg class="octicon octicon-x" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.72 3.72C3.86062 3.57955 4.05125 3.50066 4.25 3.50066C4.44875 3.50066 4.63937 3.57955 4.78 3.72L8 6.94L11.22 3.72C11.2887 3.64631 11.3715 3.58721 11.4635 3.54622C11.5555 3.50523 11.6548 3.48319 11.7555 3.48141C11.8562 3.47963 11.9562 3.49816 12.0496 3.53588C12.143 3.5736 12.2278 3.62974 12.299 3.70096C12.3703 3.77218 12.4264 3.85702 12.4641 3.9504C12.5018 4.04379 12.5204 4.14382 12.5186 4.24452C12.5168 4.34523 12.4948 4.44454 12.4538 4.53654C12.4128 4.62854 12.3537 4.71134 12.28 4.78L9.06 8L12.28 11.22C12.3537 11.2887 12.4128 11.3715 12.4538 11.4635C12.4948 11.5555 12.5168 11.6548 12.5186 11.7555C12.5204 11.8562 12.5018 11.9562 12.4641 12.0496C12.4264 12.143 12.3703 12.2278 12.299 12.299C12.2278 12.3703 12.143 12.4264 12.0496 12.4641C11.9562 12.5018 11.8562 12.5204 11.7555 12.5186C11.6548 12.5168 11.5555 12.4948 11.4635 12.4538C11.3715 12.4128 11.2887 12.3537 11.22 12.28L8 9.06L4.78 12.28C4.63782 12.4125 4.44977 12.4846 4.25547 12.4812C4.06117 12.4777 3.87579 12.399 3.73837 12.2616C3.60096 12.1242 3.52225 11.9388 3.51882 11.7445C3.51539 11.5502 3.58752 11.3622 3.72 11.22L6.94 8L3.72 4.78C3.57955 4.63938 3.50066 4.44875 3.50066 4.25C3.50066 4.05125 3.57955 3.86063 3.72 3.72Z"></path></svg>
         </button>
       </header>
       <div class="SelectMenu-list">
@@ -306,8 +280,8 @@ If the list is expected to get long, consider adding a `.SelectMenu-filter` inpu
       <header class="SelectMenu-header">
         <h3 class="SelectMenu-title">Title</h3>
         <button class="SelectMenu-closeButton" type="button">
-           <!-- <%= octicon "x" %> -->
-          <svg width="12" height="16" viewBox="0 0 12 16" class="octicon octicon-x" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z" /></svg>
+          <!-- <%= octicon "x" %> -->
+          <svg class="octicon octicon-x" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.72 3.72C3.86062 3.57955 4.05125 3.50066 4.25 3.50066C4.44875 3.50066 4.63937 3.57955 4.78 3.72L8 6.94L11.22 3.72C11.2887 3.64631 11.3715 3.58721 11.4635 3.54622C11.5555 3.50523 11.6548 3.48319 11.7555 3.48141C11.8562 3.47963 11.9562 3.49816 12.0496 3.53588C12.143 3.5736 12.2278 3.62974 12.299 3.70096C12.3703 3.77218 12.4264 3.85702 12.4641 3.9504C12.5018 4.04379 12.5204 4.14382 12.5186 4.24452C12.5168 4.34523 12.4948 4.44454 12.4538 4.53654C12.4128 4.62854 12.3537 4.71134 12.28 4.78L9.06 8L12.28 11.22C12.3537 11.2887 12.4128 11.3715 12.4538 11.4635C12.4948 11.5555 12.5168 11.6548 12.5186 11.7555C12.5204 11.8562 12.5018 11.9562 12.4641 12.0496C12.4264 12.143 12.3703 12.2278 12.299 12.299C12.2278 12.3703 12.143 12.4264 12.0496 12.4641C11.9562 12.5018 11.8562 12.5204 11.7555 12.5186C11.6548 12.5168 11.5555 12.4948 11.4635 12.4538C11.3715 12.4128 11.2887 12.3537 11.22 12.28L8 9.06L4.78 12.28C4.63782 12.4125 4.44977 12.4846 4.25547 12.4812C4.06117 12.4777 3.87579 12.399 3.73837 12.2616C3.60096 12.1242 3.52225 11.9388 3.51882 11.7445C3.51539 11.5502 3.58752 11.3622 3.72 11.22L6.94 8L3.72 4.78C3.57955 4.63938 3.50066 4.44875 3.50066 4.25C3.50066 4.05125 3.57955 3.86063 3.72 3.72Z"></path></svg>
         </button>
       </header>
       <form class="SelectMenu-filter">
@@ -364,12 +338,7 @@ Sometimes you need two or more lists of items in your Select Menu, e.g. branches
         <h3 class="SelectMenu-title">Title</h3>
         <button class="SelectMenu-closeButton" type="button">
           <!-- <%= octicon "x" %> -->
-          <svg width="12" height="16" viewBox="0 0 12 16" class="octicon octicon-x" aria-hidden="true">
-            <path
-              fill-rule="evenodd"
-              d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
-            />
-          </svg>
+          <svg class="octicon octicon-x" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.72 3.72C3.86062 3.57955 4.05125 3.50066 4.25 3.50066C4.44875 3.50066 4.63937 3.57955 4.78 3.72L8 6.94L11.22 3.72C11.2887 3.64631 11.3715 3.58721 11.4635 3.54622C11.5555 3.50523 11.6548 3.48319 11.7555 3.48141C11.8562 3.47963 11.9562 3.49816 12.0496 3.53588C12.143 3.5736 12.2278 3.62974 12.299 3.70096C12.3703 3.77218 12.4264 3.85702 12.4641 3.9504C12.5018 4.04379 12.5204 4.14382 12.5186 4.24452C12.5168 4.34523 12.4948 4.44454 12.4538 4.53654C12.4128 4.62854 12.3537 4.71134 12.28 4.78L9.06 8L12.28 11.22C12.3537 11.2887 12.4128 11.3715 12.4538 11.4635C12.4948 11.5555 12.5168 11.6548 12.5186 11.7555C12.5204 11.8562 12.5018 11.9562 12.4641 12.0496C12.4264 12.143 12.3703 12.2278 12.299 12.299C12.2278 12.3703 12.143 12.4264 12.0496 12.4641C11.9562 12.5018 11.8562 12.5204 11.7555 12.5186C11.6548 12.5168 11.5555 12.4948 11.4635 12.4538C11.3715 12.4128 11.2887 12.3537 11.22 12.28L8 9.06L4.78 12.28C4.63782 12.4125 4.44977 12.4846 4.25547 12.4812C4.06117 12.4777 3.87579 12.399 3.73837 12.2616C3.60096 12.1242 3.52225 11.9388 3.51882 11.7445C3.51539 11.5502 3.58752 11.3622 3.72 11.22L6.94 8L3.72 4.78C3.57955 4.63938 3.50066 4.44875 3.50066 4.25C3.50066 4.05125 3.57955 3.86063 3.72 3.72Z"></path></svg>
         </button>
       </header>
       <form class="SelectMenu-filter">
@@ -415,18 +384,13 @@ A `SelectMenu-message` can be used to show different kind of messages to a user.
         <h3 class="SelectMenu-title">Title</h3>
         <button class="SelectMenu-closeButton" type="button">
           <!-- <%= octicon "x" %> -->
-          <svg width="12" height="16" viewBox="0 0 12 16" class="octicon octicon-x" aria-hidden="true">
-            <path
-              fill-rule="evenodd"
-              d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
-            />
-          </svg>
+          <svg class="octicon octicon-x" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.72 3.72C3.86062 3.57955 4.05125 3.50066 4.25 3.50066C4.44875 3.50066 4.63937 3.57955 4.78 3.72L8 6.94L11.22 3.72C11.2887 3.64631 11.3715 3.58721 11.4635 3.54622C11.5555 3.50523 11.6548 3.48319 11.7555 3.48141C11.8562 3.47963 11.9562 3.49816 12.0496 3.53588C12.143 3.5736 12.2278 3.62974 12.299 3.70096C12.3703 3.77218 12.4264 3.85702 12.4641 3.9504C12.5018 4.04379 12.5204 4.14382 12.5186 4.24452C12.5168 4.34523 12.4948 4.44454 12.4538 4.53654C12.4128 4.62854 12.3537 4.71134 12.28 4.78L9.06 8L12.28 11.22C12.3537 11.2887 12.4128 11.3715 12.4538 11.4635C12.4948 11.5555 12.5168 11.6548 12.5186 11.7555C12.5204 11.8562 12.5018 11.9562 12.4641 12.0496C12.4264 12.143 12.3703 12.2278 12.299 12.299C12.2278 12.3703 12.143 12.4264 12.0496 12.4641C11.9562 12.5018 11.8562 12.5204 11.7555 12.5186C11.6548 12.5168 11.5555 12.4948 11.4635 12.4538C11.3715 12.4128 11.2887 12.3537 11.22 12.28L8 9.06L4.78 12.28C4.63782 12.4125 4.44977 12.4846 4.25547 12.4812C4.06117 12.4777 3.87579 12.399 3.73837 12.2616C3.60096 12.1242 3.52225 11.9388 3.51882 11.7445C3.51539 11.5502 3.58752 11.3622 3.72 11.22L6.94 8L3.72 4.78C3.57955 4.63938 3.50066 4.44875 3.50066 4.25C3.50066 4.05125 3.57955 3.86063 3.72 3.72Z"></path></svg>
         </button>
       </header>
       <div class="SelectMenu-list">
+        <div class="SelectMenu-message bg-red-0 text-red">Message goes here</div>
         <button class="SelectMenu-item" role="menuitem">Item 1</button>
         <button class="SelectMenu-item" role="menuitem">Item 2</button>
-        <div class="SelectMenu-message bg-red-0 text-red p-2">Message goes here</div>
         <button class="SelectMenu-item" role="menuitem">Item 3</button>
       </div>
     </div>
@@ -446,23 +410,15 @@ When fetching large lists, consider showing a `.SelectMenu-loading` animation.
   <summary class="btn" aria-haspopup="true">
     Choose an item
   </summary>
-  <div class="SelectMenu SelectMenu--hasFilter">
+  <div class="SelectMenu">
     <div class="SelectMenu-modal">
       <header class="SelectMenu-header">
         <h3 class="SelectMenu-title">Title</h3>
         <button class="SelectMenu-closeButton" type="button">
           <!-- <%= octicon "x" %> -->
-          <svg width="12" height="16" viewBox="0 0 12 16" class="octicon octicon-x" aria-hidden="true">
-            <path
-              fill-rule="evenodd"
-              d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
-            />
-          </svg>
+          <svg class="octicon octicon-x" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.72 3.72C3.86062 3.57955 4.05125 3.50066 4.25 3.50066C4.44875 3.50066 4.63937 3.57955 4.78 3.72L8 6.94L11.22 3.72C11.2887 3.64631 11.3715 3.58721 11.4635 3.54622C11.5555 3.50523 11.6548 3.48319 11.7555 3.48141C11.8562 3.47963 11.9562 3.49816 12.0496 3.53588C12.143 3.5736 12.2278 3.62974 12.299 3.70096C12.3703 3.77218 12.4264 3.85702 12.4641 3.9504C12.5018 4.04379 12.5204 4.14382 12.5186 4.24452C12.5168 4.34523 12.4948 4.44454 12.4538 4.53654C12.4128 4.62854 12.3537 4.71134 12.28 4.78L9.06 8L12.28 11.22C12.3537 11.2887 12.4128 11.3715 12.4538 11.4635C12.4948 11.5555 12.5168 11.6548 12.5186 11.7555C12.5204 11.8562 12.5018 11.9562 12.4641 12.0496C12.4264 12.143 12.3703 12.2278 12.299 12.299C12.2278 12.3703 12.143 12.4264 12.0496 12.4641C11.9562 12.5018 11.8562 12.5204 11.7555 12.5186C11.6548 12.5168 11.5555 12.4948 11.4635 12.4538C11.3715 12.4128 11.2887 12.3537 11.22 12.28L8 9.06L4.78 12.28C4.63782 12.4125 4.44977 12.4846 4.25547 12.4812C4.06117 12.4777 3.87579 12.399 3.73837 12.2616C3.60096 12.1242 3.52225 11.9388 3.51882 11.7445C3.51539 11.5502 3.58752 11.3622 3.72 11.22L6.94 8L3.72 4.78C3.57955 4.63938 3.50066 4.44875 3.50066 4.25C3.50066 4.05125 3.57955 3.86063 3.72 3.72Z"></path></svg>
         </button>
       </header>
-      <form class="SelectMenu-filter">
-        <input class="SelectMenu-input form-control" type="text" placeholder="Filter" aria-label="Filter" />
-      </form>
       <div class="SelectMenu-list">
         <div class="SelectMenu-loading">
           <!-- <%= octicon "octoface", class: "anim-pulse", width: 32 %> -->
@@ -504,12 +460,7 @@ Sometimes a Select Menu needs to communicate a "blank slate" where there's no co
         <h3 class="SelectMenu-title">Title</h3>
         <button class="SelectMenu-closeButton" type="button">
           <!-- <%= octicon "x" %> -->
-          <svg width="12" height="16" viewBox="0 0 12 16" class="octicon octicon-x" aria-hidden="true">
-            <path
-              fill-rule="evenodd"
-              d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
-            />
-          </svg>
+          <svg class="octicon octicon-x" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.72 3.72C3.86062 3.57955 4.05125 3.50066 4.25 3.50066C4.44875 3.50066 4.63937 3.57955 4.78 3.72L8 6.94L11.22 3.72C11.2887 3.64631 11.3715 3.58721 11.4635 3.54622C11.5555 3.50523 11.6548 3.48319 11.7555 3.48141C11.8562 3.47963 11.9562 3.49816 12.0496 3.53588C12.143 3.5736 12.2278 3.62974 12.299 3.70096C12.3703 3.77218 12.4264 3.85702 12.4641 3.9504C12.5018 4.04379 12.5204 4.14382 12.5186 4.24452C12.5168 4.34523 12.4948 4.44454 12.4538 4.53654C12.4128 4.62854 12.3537 4.71134 12.28 4.78L9.06 8L12.28 11.22C12.3537 11.2887 12.4128 11.3715 12.4538 11.4635C12.4948 11.5555 12.5168 11.6548 12.5186 11.7555C12.5204 11.8562 12.5018 11.9562 12.4641 12.0496C12.4264 12.143 12.3703 12.2278 12.299 12.299C12.2278 12.3703 12.143 12.4264 12.0496 12.4641C11.9562 12.5018 11.8562 12.5204 11.7555 12.5186C11.6548 12.5168 11.5555 12.4948 11.4635 12.4538C11.3715 12.4128 11.2887 12.3537 11.22 12.28L8 9.06L4.78 12.28C4.63782 12.4125 4.44977 12.4846 4.25547 12.4812C4.06117 12.4777 3.87579 12.399 3.73837 12.2616C3.60096 12.1242 3.52225 11.9388 3.51882 11.7445C3.51539 11.5502 3.58752 11.3622 3.72 11.22L6.94 8L3.72 4.78C3.57955 4.63938 3.50066 4.44875 3.50066 4.25C3.50066 4.05125 3.57955 3.86063 3.72 3.72Z"></path></svg>
         </button>
       </header>
       <div class="SelectMenu-list">

--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -107,7 +107,7 @@ If the `SelectMenu` should show a check icon for selected items, use the `Select
 
 ## Borderless
 
-Use the `.SelectMenu-list--withoutBorders` modifier to remove the borders between list items. Note: It's better to keep the borders if a list contains items with multiple lines of text. It will make it easier to see where the items start and end.
+Use the `.SelectMenu-list--borderless` modifier to remove the borders between list items. Note: It's better to keep the borders if a list contains items with multiple lines of text. It will make it easier to see where the items start and end.
 
 ```html live
 <details class="details-reset details-overlay" open>
@@ -116,7 +116,7 @@ Use the `.SelectMenu-list--withoutBorders` modifier to remove the borders betwee
   </summary>
   <div class="SelectMenu">
     <div class="SelectMenu-modal">
-      <div class="SelectMenu-list SelectMenu-list--withoutBorders">
+      <div class="SelectMenu-list SelectMenu-list--borderless">
         <button class="SelectMenu-item" role="menuitem">Item 1</button>
         <button class="SelectMenu-item" role="menuitem">Item 2</button>
         <button class="SelectMenu-item" role="menuitem">Item 3</button>
@@ -265,7 +265,7 @@ The Select Menu's list can be divided into multiple parts by adding a `.SelectMe
 <div class="d-none d-sm-block" style="height: 300px"><!-- min height for > sm --></div>
 ```
 
-Dividers are also supported when using the `.SelectMenu-list--withoutBorders` modifier.
+Dividers are also supported when using the `.SelectMenu-list--borderless` modifier.
 
 ```html live
 <details class="details-reset details-overlay" open>
@@ -281,7 +281,7 @@ Dividers are also supported when using the `.SelectMenu-list--withoutBorders` mo
           <svg class="octicon octicon-x" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M3.72 3.72C3.86062 3.57955 4.05125 3.50066 4.25 3.50066C4.44875 3.50066 4.63937 3.57955 4.78 3.72L8 6.94L11.22 3.72C11.2887 3.64631 11.3715 3.58721 11.4635 3.54622C11.5555 3.50523 11.6548 3.48319 11.7555 3.48141C11.8562 3.47963 11.9562 3.49816 12.0496 3.53588C12.143 3.5736 12.2278 3.62974 12.299 3.70096C12.3703 3.77218 12.4264 3.85702 12.4641 3.9504C12.5018 4.04379 12.5204 4.14382 12.5186 4.24452C12.5168 4.34523 12.4948 4.44454 12.4538 4.53654C12.4128 4.62854 12.3537 4.71134 12.28 4.78L9.06 8L12.28 11.22C12.3537 11.2887 12.4128 11.3715 12.4538 11.4635C12.4948 11.5555 12.5168 11.6548 12.5186 11.7555C12.5204 11.8562 12.5018 11.9562 12.4641 12.0496C12.4264 12.143 12.3703 12.2278 12.299 12.299C12.2278 12.3703 12.143 12.4264 12.0496 12.4641C11.9562 12.5018 11.8562 12.5204 11.7555 12.5186C11.6548 12.5168 11.5555 12.4948 11.4635 12.4538C11.3715 12.4128 11.2887 12.3537 11.22 12.28L8 9.06L4.78 12.28C4.63782 12.4125 4.44977 12.4846 4.25547 12.4812C4.06117 12.4777 3.87579 12.399 3.73837 12.2616C3.60096 12.1242 3.52225 11.9388 3.51882 11.7445C3.51539 11.5502 3.58752 11.3622 3.72 11.22L6.94 8L3.72 4.78C3.57955 4.63938 3.50066 4.44875 3.50066 4.25C3.50066 4.05125 3.57955 3.86063 3.72 3.72Z"></path></svg>
         </button>
       </header>
-      <div class="SelectMenu-list SelectMenu-list--withoutBorders">
+      <div class="SelectMenu-list SelectMenu-list--borderless">
         <button class="SelectMenu-item" role="menuitem">Item 1</button>
         <button class="SelectMenu-item" role="menuitem">Item 2</button>
         <div class="SelectMenu-divider">More options</div>

--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -167,6 +167,28 @@ The list of items is arguably the most important subcomponent within the menu. B
 <div class="d-none d-sm-block" style="height: 320px"><!-- min height for > sm --></div>
 ```
 
+Use the `.SelectMenu-list--withoutBorders` modifier to remove the borders between list items. Note: It's better to keep the borders if a list contains items with multiple lines of text. It will make it easier to see where the items start and end.
+
+```html live
+<details class="details-reset details-overlay" open>
+  <summary class="btn" aria-haspopup="true">
+    Choose an item
+  </summary>
+  <div class="SelectMenu">
+    <div class="SelectMenu-modal">
+      <div class="SelectMenu-list SelectMenu-list--withoutBorders">
+        <button class="SelectMenu-item" role="menuitem">Item 1</button>
+        <button class="SelectMenu-item" role="menuitem">Item 2</button>
+        <button class="SelectMenu-item" role="menuitem">Item 3</button>
+      </div>
+    </div>
+  </div>
+</details>
+
+<div class="d-sm-none" style="height: 600px"><!-- min height for < sm --></div>
+<div class="d-none d-sm-block" style="height: 120px"><!-- min height for > sm --></div>
+```
+
 ## Header
 
 Add a `.SelectMenu-header` at the top to house a clear title and a close button.

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -203,7 +203,7 @@ $SelectMenu-max-height: 480px !default;
   }
 
   // Borderless
-  .SelectMenu-list--withoutBorders & {
+  .SelectMenu-list--borderless & {
     border-bottom: 0;
   }
 }
@@ -321,7 +321,7 @@ $SelectMenu-max-height: 480px !default;
   border-bottom: $border-width $border-style $border-gray-light;
 
   // Borderless
-  .SelectMenu-list--withoutBorders & {
+  .SelectMenu-list--borderless & {
     border-top: $border-width $border-style $border-gray-light;
 
     &:empty {

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -1,14 +1,6 @@
 // stylelint-disable selector-max-type
 // selector-max-type is needed for body:not(.intent-mouse) to target keyboard only styles.
 
-// TODO@15.0.0: remove styles below
-@media (hover: hover) {
-  .SelectMenu-tab:not([aria-checked="true"]):hover,
-  .SelectMenu-tab:not([aria-checked="true"]):active {
-    background-color: $bg-white;
-  }
-}
-
 $SelectMenu-max-height: 480px !default;
 
 // Select Menu
@@ -141,7 +133,8 @@ $SelectMenu-max-height: 480px !default;
 
   @include breakpoint(sm) {
     padding: $spacer-2;
-    margin: -$spacer-2;
+    // stylelint-disable-next-line primer/spacing
+    margin: (-$spacer-2) (-7px); // Using -7px fixes a :focus glitch
   }
 }
 
@@ -260,7 +253,7 @@ $SelectMenu-max-height: 480px !default;
   background-color: transparent;
   border: 0;
   // stylelint-disable-next-line primer/box-shadow
-  box-shadow: inset 0 -1px 0 $border-color;
+  box-shadow: inset 0 -1px 0 $border-gray-light;
 
   @include breakpoint(sm) {
     flex: none;
@@ -277,10 +270,10 @@ $SelectMenu-max-height: 480px !default;
     cursor: default;
     background-color: $bg-white;
     // stylelint-disable-next-line primer/box-shadow
-    box-shadow: 0 0 0 1px $border-color;
+    box-shadow: 0 0 0 1px $border-gray-light;
 
     @include breakpoint(sm) {
-      border-color: $border-color;
+      border-color: $border-gray-light;
       box-shadow: none;
     }
   }
@@ -364,9 +357,10 @@ $SelectMenu-max-height: 480px !default;
 // Different states
 
 // Reset outlines
+.SelectMenu-closeButton:focus,
 .SelectMenu-tab:focus,
 .SelectMenu-item:focus {
-  outline: none;
+  outline: 0;
 }
 
 // Reset <a> elements
@@ -378,7 +372,7 @@ $SelectMenu-max-height: 480px !default;
 //
 // Visible when a used clicks/taps on a list item
 
-.SelectMenu-item[aria-checked="true"] {
+.SelectMenu-item[aria-checked=true] {
   font-weight: $font-weight-semibold;
   color: $text-gray-dark;
 
@@ -394,6 +388,15 @@ $SelectMenu-max-height: 480px !default;
 // For mouse/keyboard input
 
 @media (hover: hover) {
+  body:not(.intent-mouse) .SelectMenu-closeButton:focus,
+  .SelectMenu-closeButton:hover {
+    color: $text-gray-dark;
+  }
+
+  .SelectMenu-closeButton:active {
+    color: $text-gray;
+  }
+
   body:not(.intent-mouse) .SelectMenu-item:focus,
   .SelectMenu-item:hover {
     background-color: $bg-gray;
@@ -408,10 +411,8 @@ $SelectMenu-max-height: 480px !default;
     background-color: $blue-100;
   }
 
-  .SelectMenu-tab:not([aria-selected="true"]):hover {
+  .SelectMenu-tab:hover {
     color: $text-gray-dark;
-    // stylelint-disable-next-line primer/colors
-    background-color: $gray-200;
   }
 
   .SelectMenu-tab:not([aria-selected="true"]):active {

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -69,7 +69,7 @@ $SelectMenu-max-height: 480px !default;
   overflow: hidden; // Enables border radius on scrollable child elements
   pointer-events: auto;
   flex-direction: column;
-  background-color: $bg-gray;
+  background-color: $bg-white;
   // stylelint-disable-next-line primer/borders
   border-radius: $border-radius * 2;
   // stylelint-disable-next-line primer/box-shadow

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -94,7 +94,7 @@ $SelectMenu-max-height: 480px !default;
     width: 300px;
     height: auto;
     max-height: $SelectMenu-max-height;
-    margin: $spacer-1 0 $spacer-3 0;
+    margin: $spacer-2 0 $spacer-3 0;
     font-size: $font-size-small;
     border: $border;
     border-radius: $border-radius;
@@ -109,17 +109,19 @@ $SelectMenu-max-height: 480px !default;
 
 .SelectMenu-header {
   display: flex;
-  flex: none; // fixes header from getting squeezed in Safari iOS
   padding: $spacer-3;
+  flex: none; // fixes header from getting squeezed in Safari iOS
+  align-items: center;
+  border-bottom: $border-width $border-style $border-gray-light;
 
   @include breakpoint(sm) {
-    padding-top: $spacer-2;
-    padding-bottom: $spacer-2;
+    // stylelint-disable-next-line primer/spacing
+    padding: 7px 7px 7px $spacer-3;
   }
 }
 
 .SelectMenu-title {
-  flex: auto;
+  flex: 1;
   font-size: $body-font-size;
   font-weight: $font-weight-bold;
 
@@ -131,12 +133,15 @@ $SelectMenu-max-height: 480px !default;
 .SelectMenu-closeButton {
   padding: $spacer-3;
   margin: -$spacer-3;
-  color: $text-gray-light;
+  line-height: 1;
+  // stylelint-disable-next-line primer/colors
+  color: $gray-light;
   background-color: transparent;
   border: 0;
 
   @include breakpoint(sm) {
-    display: none;
+    padding: $spacer-2;
+    margin: -$spacer-2;
   }
 }
 
@@ -147,7 +152,7 @@ $SelectMenu-max-height: 480px !default;
 .SelectMenu-filter {
   padding: $spacer-3;
   margin: 0;
-  border-top: $border;
+  border-bottom: $border-width $border-style $border-gray-light;
 
   @include breakpoint(sm) {
     padding: $spacer-2;
@@ -177,7 +182,6 @@ $SelectMenu-max-height: 480px !default;
   overflow-x: hidden;
   overflow-y: auto;
   background-color: $bg-white;
-  border-top: $border;
   -webkit-overflow-scrolling: touch; // Adds momentum + bouncy scrolling
 }
 
@@ -199,8 +203,10 @@ $SelectMenu-max-height: 480px !default;
   border-bottom: $border-width $border-style $border-gray-light;
 
   @include breakpoint(sm) {
-    padding-top: $spacer-2;
-    padding-bottom: $spacer-2;
+    // stylelint-disable-next-line primer/spacing
+    padding-top: 7px;
+    // stylelint-disable-next-line primer/spacing
+    padding-bottom: 7px;
   }
 }
 
@@ -228,11 +234,10 @@ $SelectMenu-max-height: 480px !default;
 .SelectMenu-tabs {
   display: flex;
   flex-shrink: 0;
-  // stylelint-disable-next-line primer/spacing
-  margin-bottom: -$border-width; // hide border of element below
   overflow-x: auto;
   overflow-y: hidden;
-  border-top: $border;
+  // stylelint-disable-next-line primer/box-shadow
+  box-shadow: inset 0 -1px 0 $border-gray-light;
   -webkit-overflow-scrolling: touch;
 
   // Hide scrollbar so it doesn't cover the text
@@ -241,8 +246,7 @@ $SelectMenu-max-height: 480px !default;
   }
 
   @include breakpoint(sm) {
-    padding: 0 $spacer-2;
-    border-top: 0;
+    padding: $spacer-2 $spacer-2 0 $spacer-2;
   }
 }
 
@@ -282,15 +286,22 @@ $SelectMenu-max-height: 480px !default;
   }
 }
 
-// Message, Blankslate and Loading
+// Message
 //
-// A container used to show different kinds of content. Like a message, a blankslate or the loading animation.
+// A container used to show different kinds of text messages.
 
 .SelectMenu-message {
+  // stylelint-disable-next-line primer/spacing
+  padding: 7px $spacer-3;
+  text-align: center;
+  background-color: $bg-white;
   border-bottom: $border-width $border-style $border-gray-light;
 }
 
-.SelectMenu-message,
+// Blankslate and Loading
+//
+// A container used to show a blankslate or the loading animation.
+
 .SelectMenu-blankslate,
 .SelectMenu-loading {
   padding: $spacer-4 $spacer-3;
@@ -306,7 +317,7 @@ $SelectMenu-max-height: 480px !default;
   padding: $spacer-1 $spacer-3;
   margin: 0;
   font-size: $font-size-small;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
   color: $text-gray-light;
   background-color: $bg-gray;
   border-bottom: $border-width $border-style $border-gray-light;
@@ -322,10 +333,11 @@ $SelectMenu-max-height: 480px !default;
   font-size: $font-size-small;
   color: $text-gray-light;
   text-align: center;
-  border-top: $border;
+  border-top: $border-width $border-style $border-gray-light;
 
   @include breakpoint(sm) {
-    padding: $spacer-1 $spacer-2;
+    // stylelint-disable-next-line primer/spacing
+    padding: 7px $spacer-3;
   }
 }
 
@@ -342,7 +354,7 @@ $SelectMenu-max-height: 480px !default;
     @include breakpoint(sm) {
       height: auto;
       max-height: $SelectMenu-max-height;
-      margin-top: $spacer-1;
+      margin-top: $spacer-2;
     }
   }
 }

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -323,6 +323,11 @@ $SelectMenu-max-height: 480px !default;
   // Borderless
   .SelectMenu-list--withoutBorders & {
     border-top: $border-width $border-style $border-gray-light;
+
+    &:empty {
+      padding: 0;
+      border-top: 0;
+    }
   }
 }
 

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -201,6 +201,11 @@ $SelectMenu-max-height: 480px !default;
     // stylelint-disable-next-line primer/spacing
     padding-bottom: 7px;
   }
+
+  // Borderless
+  .SelectMenu-list--withoutBorders & {
+    border-bottom: 0;
+  }
 }
 
 // Icon
@@ -314,6 +319,11 @@ $SelectMenu-max-height: 480px !default;
   color: $text-gray-light;
   background-color: $bg-gray;
   border-bottom: $border-width $border-style $border-gray-light;
+
+  // Borderless
+  .SelectMenu-list--withoutBorders & {
+    border-top: $border-width $border-style $border-gray-light;
+  }
 }
 
 // Footer

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -188,7 +188,7 @@ $SelectMenu-max-height: 480px !default;
   width: 100%;
   padding: $spacer-3;
   overflow: hidden;
-  color: $text-gray;
+  color: $text-gray-dark;
   text-align: left;
   cursor: pointer;
   background-color: $bg-white;
@@ -385,7 +385,7 @@ $SelectMenu-max-height: 480px !default;
 
 // Selected
 //
-// Visible when a used clicks/taps on a list item
+// Visible when a user clicks/taps on a list item
 
 .SelectMenu-item[aria-checked=true] {
   font-weight: $font-weight-semibold;
@@ -396,6 +396,16 @@ $SelectMenu-max-height: 480px !default;
     transition: transform 0.12s cubic-bezier(0, 0, 0.2, 1), visibility 0s linear;
     transform: scale(1);
   }
+}
+
+// Disabled
+//
+// Prevent list items to be selected
+
+.SelectMenu-item:disabled,
+.SelectMenu-item[aria-disabled=true] {
+  color: $text-gray-light;
+  pointer-events: none;
 }
 
 // Can hover states


### PR DESCRIPTION
This refreshes the SelectMenu 👀 [Preview](https://primer-css-git-next-select-menu.primer.now.sh/css/components/select-menu). Changes include:

- [x] The header is now optional. But show the close button also on desktop.
- [x] Everything has now a white background.
- [x] The filter and tabs can be switched in order.
- [x] The height is mostly kept at `32px` (excluding the border) to match other components.
- [x] Add option to remove the borders in the list
- [x] Add option to disable a list item

Current | Next | Refreshed (this PR)
--- | --- | ---
![image](https://user-images.githubusercontent.com/378023/79189922-ef4bc500-7e5d-11ea-815c-78f2dc7b9196.png) | ![Screen Shot 2020-04-09 at 3 51 50 PM](https://user-images.githubusercontent.com/378023/78866275-0ebbaa00-7a7a-11ea-878b-7808d8c26333.png) | ![Screen Shot 2020-04-09 at 3 51 13 PM](https://user-images.githubusercontent.com/378023/78866273-0d8a7d00-7a7a-11ea-99af-47d85ae86a6d.png)

## API changes

- Add `.SelectMenu-list--borderless` modifier
- Add support for `disabled` + `aria-disabled="true"` list items

/cc @primer/ds-core 