### PR TITLE
Add .text-gray-light to docs

### DIFF
--- a/docs/content/utilities/colors.mdx
+++ b/docs/content/utilities/colors.mdx
@@ -55,37 +55,37 @@ You can set the color inheritance on an element by using the `text-inherit` clas
 
 ```html live
 <div class="text-blue mb-2">
-  .text-blue on white
+  .text-blue
 </div>
 <div class="text-gray-dark mb-2">
-  .text-gray-dark on white
+  .text-gray-dark
 </div>
 <div class="text-gray mb-2">
-  .text-gray on white
+  .text-gray
 </div>
 <div class="text-gray-light mb-2">
-  .text-gray-light on white
+  .text-gray-light
 </div>
 <div class="text-red mb-2">
-  .text-red on white
+  .text-red
 </div>
 <div class="text-orange mb-2">
-  .text-orange on white
+  .text-orange
 </div>
 <div class="text-orange-light mb-2">
-  .text-orange-light on white
+  .text-orange-light
   <span class="tooltipped tooltipped-n" aria-label="Does not meet accessibility standards">⚠️</span>
 </div>
 <div class="text-yellow mb-2">
-  .text-yellow on white
+  .text-yellow
   <span class="tooltipped tooltipped-n" aria-label="Does not meet accessibility standards">⚠️</span>
 </div>
 <div class="text-green mb-2">
-  .text-green on white
+  .text-green
   <span class="tooltipped tooltipped-n" aria-label="Does not meet accessibility standards">⚠️</span>
 </div>
 <div class="text-purple mb-2">
-  .text-purple on white
+  .text-purple
 </div>
 ```
 

--- a/docs/content/utilities/colors.mdx
+++ b/docs/content/utilities/colors.mdx
@@ -63,6 +63,9 @@ You can set the color inheritance on an element by using the `text-inherit` clas
 <div class="text-gray mb-2">
   .text-gray on white
 </div>
+<div class="text-gray-light mb-2">
+  .text-gray-light on white
+</div>
 <div class="text-red mb-2">
   .text-red on white
 </div>


### PR DESCRIPTION
This adds the `.text-gray-light` utility that is missing in the [Text on white background](https://primer.style/css/utilities/colors#text-on-white-background) list.

Also, removed the "on white" since it's just a repetition from the title and should make it easier to read the colors.

[Before](https://primer.style/css/utilities/colors#text-on-white-background) | [After](https://primer-css-git-add-text-gray-light.primer.now.sh/css/utilities/colors#text-on-white-background)
--- | ---
![Screen Shot 2020-04-15 at 10 51 16 AM](https://user-images.githubusercontent.com/378023/79290444-18746000-7f07-11ea-93ed-06f77b403799.png) | ![Screen Shot 2020-04-15 at 10 51 28 AM](https://user-images.githubusercontent.com/378023/79290448-1a3e2380-7f07-11ea-8ec8-a2b5b8807609.png)
