### PR TITLE
Add .bg-orange utility

### DIFF
--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -12,6 +12,7 @@
 .bg-green-light   { background-color: $bg-green-light !important; }
 .bg-red           { background-color: $bg-red !important; }
 .bg-red-light     { background-color: $bg-red-light !important; }
+.bg-orange        { background-color: $bg-orange !important; }
 .bg-yellow        { background-color: $bg-yellow !important; }
 .bg-yellow-light  { background-color: $bg-yellow-light !important; }
 .bg-yellow-dark   { background-color: $bg-yellow-dark !important; }

--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -2,38 +2,22 @@
 // stylelint-disable block-opening-brace-space-before, comment-empty-line-before
 
 // background colors
-/* Set the background to $bg-white */
-.bg-white      { background-color: $bg-white !important; }
-/* Set the background to $bg-blue */
-.bg-blue       { background-color: $bg-blue !important; }
-/* Set the background to $bg-blue-light */
-.bg-blue-light { background-color: $bg-blue-light !important; }
-/* Set the background to $bg-gray-dark */
-.bg-gray-dark  { background-color: $bg-gray-dark !important; }
-/* Set the background to $bg-gray */
-.bg-gray       { background-color: $bg-gray !important; }
-/* Set the background to $bg-gray-light */
-.bg-gray-light { background-color: $bg-gray-light !important; }
-/* Set the background to $bg-green */
-.bg-green      { background-color: $bg-green !important; }
-/* Set the background to $bg-green-light */
-.bg-green-light     { background-color: $bg-green-light !important; }
-/* Set the background to $bg-red */
-.bg-red        { background-color: $bg-red !important; }
-/* Set the background to $bg-red-light */
-.bg-red-light  { background-color: $bg-red-light !important; }
-/* Set the background to $bg-yellow */
-.bg-yellow     { background-color: $bg-yellow !important; }
-/* Set the background to $bg-yellow-light */
-.bg-yellow-light     { background-color: $bg-yellow-light !important; }
-/* Set the background to $bg-yellow-dark */
-.bg-yellow-dark      { background-color: $bg-yellow-dark !important; }
-/* Set the background to $bg-purple */
-.bg-purple     { background-color: $bg-purple !important; }
-/* Set the background to $bg-pink */
-.bg-pink { background-color: $bg-pink !important; }
-/* Set the background to $bg-purple-light */
-.bg-purple-light     { background-color: $bg-purple-light !important; }
+.bg-white         { background-color: $bg-white !important; }
+.bg-blue          { background-color: $bg-blue !important; }
+.bg-blue-light    { background-color: $bg-blue-light !important; }
+.bg-gray-dark     { background-color: $bg-gray-dark !important; }
+.bg-gray          { background-color: $bg-gray !important; }
+.bg-gray-light    { background-color: $bg-gray-light !important; }
+.bg-green         { background-color: $bg-green !important; }
+.bg-green-light   { background-color: $bg-green-light !important; }
+.bg-red           { background-color: $bg-red !important; }
+.bg-red-light     { background-color: $bg-red-light !important; }
+.bg-yellow        { background-color: $bg-yellow !important; }
+.bg-yellow-light  { background-color: $bg-yellow-light !important; }
+.bg-yellow-dark   { background-color: $bg-yellow-dark !important; }
+.bg-purple        { background-color: $bg-purple !important; }
+.bg-pink          { background-color: $bg-pink !important; }
+.bg-purple-light  { background-color: $bg-purple-light !important; }
 
 // Generate a foreground and background utility for every shade of every hue
 @each $hue, $shades in $hue-maps {
@@ -50,31 +34,18 @@
 }
 
 // text colors
-/* Set the text color to $text-blue */
 .text-blue          { color: $text-blue !important; }
-/* Set the text color to $text-red */
 .text-red           { color: $text-red !important; }
-/* Set the text color to $text-gray-light */
 .text-gray-light    { color: $text-gray-light !important; }
-/* Set the text color to $text-gray */
 .text-gray          { color: $text-gray !important; }
-/* Set the text color to $text-gray-dark */
 .text-gray-dark     { color: $text-gray-dark !important; }
-/* Set the text color to $text-green */
 .text-green         { color: $text-green !important; }
-/* Set the text color to $text-yellow */
 .text-yellow        { color: $text-yellow !important; }
-/* Set the text color to $text-orange */
 .text-orange        { color: $text-orange !important; }
-/* Set the text color to $text-orange-light */
-.text-orange-light        { color: $text-orange-light !important; }
-/* Set the text color to $text-purple */
+.text-orange-light  { color: $text-orange-light !important; }
 .text-purple        { color: $text-purple !important; }
-/* Set the text color to $text-pink */
-.text-pink { color: $text-pink !important; }
-/* Set the text color to $text-white */
+.text-pink          { color: $text-pink !important; }
 .text-white         { color: $text-white !important; }
-/* Set the text color to inherit */
 .text-inherit       { color: inherit !important; }
 
 // Link colors

--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -1,5 +1,5 @@
 // Color utilities
-// stylelint-disable block-opening-brace-space-before, comment-empty-line-before
+// stylelint-disable block-opening-brace-space-before
 
 // background colors
 .bg-white         { background-color: $bg-white !important; }


### PR DESCRIPTION
This adds the `.bg-orange` utility. 👉 https://github.com/primer/css/pull/1070/commits/f950f7a5c28149755121f7e0de7fb436b0c448e1

It's shown in the [docs](https://primer.style/css/utilities/colors#background-utilities), but the actual `.bg-orange` utility class is missing. 😬 

![image](https://user-images.githubusercontent.com/378023/79351444-a5ed9980-7f73-11ea-8d02-da5f0aa05f82.png)

**Bonus**: Also formated the class names and 🔥 removed the `/* Set the background to ... */` comments. They just make it look messy and don't add much value. 👉 https://github.com/primer/css/pull/1070/commits/965d89a70cd31ea22c816d14de352db08872d8d8?diff=split&w=1

---

Closes #1068 