### PR TITLE
Refresh pagination

### DIFF
--- a/src/pagination/pagination.scss
+++ b/src/pagination/pagination.scss
@@ -5,34 +5,46 @@
   span,
   em {
     display: inline-block;
-    padding: $spacer-1 12px;
+    min-width: 32px;
+    // stylelint-disable-next-line primer/spacing
+    padding: 5px 10px;
     font-style: normal;
-    color: $text-black;
+    // stylelint-disable-next-line primer/typography
+    line-height: 20px;
+    color: $text-gray-dark;
+    text-align: center;
     white-space: nowrap;
     vertical-align: middle;
     cursor: pointer;
     user-select: none;
     // stylelint-disable-next-line primer/borders
-    border-bottom: 2px $border-style transparent;
+    border: $border-width $border-style transparent;
+    border-radius: $border-radius;
 
     &:hover,
     &:focus {
-      color: $text-gray-dark;
       text-decoration: none;
+      border-color: $border-color;
       outline: 0;
     }
 
     &:active {
-      color: $text-gray-light;
+      border-color: $border-gray-light;
     }
+  }
+
+  .previous_page,
+  .next_page {
+    color: $text-blue;
   }
 
   .current,
   .current:hover,
   [aria-current],
   [aria-current]:hover {
-    // stylelint-disable-next-line primer/borders
-    border-color: #f9826c; // custom coral
+    color: $text-white;
+    background-color: $bg-blue;
+    border-color: transparent;
   }
 
   .gap,

--- a/src/pagination/pagination.scss
+++ b/src/pagination/pagination.scss
@@ -17,7 +17,6 @@
     vertical-align: middle;
     cursor: pointer;
     user-select: none;
-    // stylelint-disable-next-line primer/borders
     border: $border-width $border-style transparent;
     border-radius: $border-radius;
     transition: border-color 0.2s cubic-bezier(0.3, 0, 0.5, 1);

--- a/src/pagination/pagination.scss
+++ b/src/pagination/pagination.scss
@@ -20,16 +20,19 @@
     // stylelint-disable-next-line primer/borders
     border: $border-width $border-style transparent;
     border-radius: $border-radius;
+    transition: border-color 0.2s cubic-bezier(0.3, 0, 0.5, 1);
 
     &:hover,
     &:focus {
       text-decoration: none;
       border-color: $border-color;
       outline: 0;
+      transition-duration: 0.1s;
     }
 
     &:active {
       border-color: $border-gray-light;
+      transition: none;
     }
   }
 


### PR DESCRIPTION
This updates the `.pagination` component. Changes include:

- [x] Replace underline with blue background
- [x] Blue prev/next links
- [x] Border on hover
- [x] Border transitions

Current | `primer_next` | This PR
--- | --- | ---
![image](https://user-images.githubusercontent.com/378023/79757703-65b55f00-8357-11ea-9d63-f240a8431bc1.png) | ![image](https://user-images.githubusercontent.com/378023/79757625-5209f880-8357-11ea-8682-0aa04755b2ed.png) | ![image](https://user-images.githubusercontent.com/378023/79757807-88477800-8357-11ea-9c96-97eda0e8a56a.png)
[Docs](https://primer.style/css/components/pagination) | [Docs preview](https://primer-css-git-next.primer.now.sh/css/components/pagination) | [Docs preview](https://primer-css-git-next-5.primer.now.sh/css/components/pagination)

## Gif

![pagination](https://user-images.githubusercontent.com/378023/79758332-3d7a3000-8358-11ea-88e9-8ac2f1809ade.gif)

## API changes

- None

/cc @primer/ds-core 

