### PR TITLE
chore: add missing link to color utilities

### DIFF
--- a/docs/content/components/timeline.md
+++ b/docs/content/components/timeline.md
@@ -44,7 +44,7 @@ The default TimelineItem-badge color is dark text on a light grey background.
 
 ### Adding color to TimelineItem-badge
 
-To have color variants, use the [color utilities]() on the badge. Be cautious with color choices. We typically use them in the timeline to give meaning to the event in context of the timeline.
+To have color variants, use the [color utilities](/css/utilities/colors) on the badge. Be cautious with color choices. We typically use them in the timeline to give meaning to the event in context of the timeline.
 
 ```html live
 <!-- Colorful TimelineItem Badge -->

--- a/docs/content/components/timeline.md
+++ b/docs/content/components/timeline.md
@@ -44,7 +44,7 @@ The default TimelineItem-badge color is dark text on a light grey background.
 
 ### Adding color to TimelineItem-badge
 
-To have color variants, use the [color utilities](/css/utilities/colors) on the badge. Be cautious with color choices. We typically use them in the timeline to give meaning to the event in context of the timeline.
+To have color variants, use the [color utilities](/utilities/colors) on the badge. Be cautious with color choices. We typically use them in the timeline to give meaning to the event in context of the timeline.
 
 ```html live
 <!-- Colorful TimelineItem Badge -->


### PR DESCRIPTION
This change fixes a typo in the documentation for the "Timeline" component.

This patch adds a link to [Color utilities](https://primer.style/css/utilities/colors).

/cc @primer/ds-core
