### PR TITLE
Component refresh 7

### DIFF
--- a/docs/content/components/alerts.md
+++ b/docs/content/components/alerts.md
@@ -172,9 +172,7 @@ A flash message that is full width and removes border and border radius.
 
 ```html live
 <div class="flash flash-full">
-  <div class="container">
-    Full width flash message.
-  </div>
+  Full width flash message.
 </div>
 ```
 

--- a/docs/content/components/pagination.md
+++ b/docs/content/components/pagination.md
@@ -8,16 +8,6 @@ bundle: pagination
 
 Use the pagination component to apply button styles to a connected set of links that go to related pages (for example, previous, next, or page numbers).
 
-
-```html live
-<nav class="paginate-container" aria-label="Pagination">
-  <div class="pagination">
-    <span class="previous_page" aria-disabled="true">Previous</span>
-    <a class="next_page" rel="next" href="#url" aria-label="Next Page">Next</a>
-  </div>
-</nav>
-```
-
 ## Previous/next pagination
 
 You can make a very simple pagination container with just the Previous and Next buttons. Add the `aria-disabled="true"` attribute to the `Previous` button if there isn't a preceding page, or to the `Next` button if there isn't a succeeding page.
@@ -26,7 +16,8 @@ You can make a very simple pagination container with just the Previous and Next 
 <nav class="paginate-container" aria-label="Pagination">
   <div class="pagination">
     <span class="previous_page" aria-disabled="true">Previous</span>
-    <a class="next_page" rel="next" href="#url" aria-label="Next Page">Next</div>
+    <a class="next_page" rel="next" href="#url" aria-label="Next Page">Next</a>
+  </div>
 </nav>
 ```
 

--- a/docs/content/components/pagination.md
+++ b/docs/content/components/pagination.md
@@ -8,6 +8,16 @@ bundle: pagination
 
 Use the pagination component to apply button styles to a connected set of links that go to related pages (for example, previous, next, or page numbers).
 
+
+```html live
+<nav class="paginate-container" aria-label="Pagination">
+  <div class="pagination">
+    <span class="previous_page" aria-disabled="true">Previous</span>
+    <a class="next_page" rel="next" href="#url" aria-label="Next Page">Next</a>
+  </div>
+</nav>
+```
+
 ## Previous/next pagination
 
 You can make a very simple pagination container with just the Previous and Next buttons. Add the `aria-disabled="true"` attribute to the `Previous` button if there isn't a preceding page, or to the `Next` button if there isn't a succeeding page.
@@ -15,17 +25,8 @@ You can make a very simple pagination container with just the Previous and Next 
 ```html live
 <nav class="paginate-container" aria-label="Pagination">
   <div class="pagination">
-    <span class="previous_page" aria-disabled="true">
-      <!-- <%= octicon "chevron-left mr-1" %> -->
-      <svg class="octicon octicon-chevron-left mr-1" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M9.78033 12.7803C9.48744 13.0732 9.01256 13.0732 8.71967 12.7803L4.46967 8.53033C4.17678 8.23744 4.17678 7.76256 4.46967 7.46967L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L6.06066 8L9.78033 11.7197C10.0732 12.0126 10.0732 12.4874 9.78033 12.7803Z"></path></svg>
-      Previous
-    </span>
-    <a class="next_page" rel="next" href="#url" aria-label="Next Page">
-      Next
-      <!-- <%= octicon "chevron-right ml-1" %> -->
-      <svg  class="octicon octicon-chevron-right ml-1" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M6.21967 3.21967C6.51256 2.92678 6.98744 2.92678 7.28033 3.21967L11.5303 7.46967C11.8232 7.76256 11.8232 8.23744 11.5303 8.53033L7.28033 12.7803C6.98744 13.0732 6.51256 13.0732 6.21967 12.7803C5.92678 12.4874 5.92678 12.0126 6.21967 11.7197L9.93934 8L6.21967 4.28033C5.92678 3.98744 5.92678 3.51256 6.21967 3.21967Z"></path></svg>
-    </a>
-  </div>
+    <span class="previous_page" aria-disabled="true">Previous</span>
+    <a class="next_page" rel="next" href="#url" aria-label="Next Page">Next</div>
 </nav>
 ```
 
@@ -43,11 +44,7 @@ As always, make sure to include the appropriate `aria` attributes to make the el
 ```html live
 <nav class="paginate-container" aria-label="Pagination">
   <div class="pagination">
-    <span class="previous_page" aria-disabled="true">
-      <!-- <%= octicon "chevron-left mr-1" %> -->
-      <svg class="octicon octicon-chevron-left mr-1" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M9.78033 12.7803C9.48744 13.0732 9.01256 13.0732 8.71967 12.7803L4.46967 8.53033C4.17678 8.23744 4.17678 7.76256 4.46967 7.46967L8.71967 3.21967C9.01256 2.92678 9.48744 2.92678 9.78033 3.21967C10.0732 3.51256 10.0732 3.98744 9.78033 4.28033L6.06066 8L9.78033 11.7197C10.0732 12.0126 10.0732 12.4874 9.78033 12.7803Z"></path></svg>
-      Previous
-    </span>
+    <span class="previous_page" aria-disabled="true">Previous</span>
     <em aria-current="page">1</em>
     <a href="#url" aria-label="Page 2">2</a>
     <a href="#url" aria-label="Page 3">3</a>
@@ -55,11 +52,7 @@ As always, make sure to include the appropriate `aria` attributes to make the el
     <a href="#url" aria-label="Page 8">8</a>
     <a href="#url" aria-label="Page 9">9</a>
     <a href="#url" aria-label="Page 10">10</a>
-    <a class="next_page" rel="next" href="#url" aria-label="Next Page">
-      Next
-      <!-- <%= octicon "chevron-right ml-1" %> -->
-      <svg  class="octicon octicon-chevron-right ml-1" viewBox="0 0 16 16" width="16" height="16">  <path fill-rule="evenodd" clip-rule="evenodd" d="M6.21967 3.21967C6.51256 2.92678 6.98744 2.92678 7.28033 3.21967L11.5303 7.46967C11.8232 7.76256 11.8232 8.23744 11.5303 8.53033L7.28033 12.7803C6.98744 13.0732 6.51256 13.0732 6.21967 12.7803C5.92678 12.4874 5.92678 12.0126 6.21967 11.7197L9.93934 8L6.21967 4.28033C5.92678 3.98744 5.92678 3.51256 6.21967 3.21967Z"></path></svg>
-    </a>
+    <a class="next_page" rel="next" href="#url" aria-label="Next Page">Next</a>
   </div>
 </nav>
 ```

--- a/src/alerts/flash.scss
+++ b/src/alerts/flash.scss
@@ -4,7 +4,7 @@
 .flash {
   position: relative;
   // stylelint-disable-next-line primer/spacing
-  padding: 20px $spacer-4;
+  padding: 20px $spacer-3;
   color: $text-gray-dark;
   border-style: $border-style;
   border-width: $border-width;
@@ -56,7 +56,6 @@
   float: right;
   // stylelint-disable-next-line primer/spacing
   margin-top: -3px;
-  margin-right: -$spacer-2;
   margin-left: $spacer-4;
   background-clip: padding-box;
 }

--- a/src/labels/states.scss
+++ b/src/labels/states.scss
@@ -28,8 +28,7 @@
 }
 
 .State--green {
-  // stylelint-disable-next-line primer/colors
-  background-color: #159739; // custom green
+  background-color: $bg-green;
 }
 
 .State--red {

--- a/src/pagination/pagination.scss
+++ b/src/pagination/pagination.scss
@@ -59,6 +59,33 @@
     cursor: default;
     border-color: transparent;
   }
+
+  .previous_page::before,
+  .next_page::after {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    // stylelint-disable-next-line primer/typography
+    vertical-align: 1px;
+    content: "";
+    // stylelint-disable-next-line primer/borders
+    border-color: currentColor;
+    border-style: $border-style;
+    // stylelint-disable-next-line primer/borders
+    border-width: 2px 2px 0 0;
+    // stylelint-disable-next-line primer/borders
+    border-radius: 1px;
+  }
+
+  .previous_page::before {
+    margin: 0 $spacer-2 0 $spacer-1;
+    transform: rotate(-135deg);
+  }
+
+  .next_page::after {
+    margin: 0 $spacer-1 0 $spacer-2;
+    transform: rotate(45deg);
+  }
 }
 
 // Unified centered pagination across the site

--- a/src/pagination/pagination.scss
+++ b/src/pagination/pagination.scss
@@ -60,31 +60,30 @@
     border-color: transparent;
   }
 
-  .previous_page::before,
-  .next_page::after {
-    display: inline-block;
-    width: 6px;
-    height: 6px;
-    // stylelint-disable-next-line primer/typography
-    vertical-align: 1px;
-    content: "";
-    // stylelint-disable-next-line primer/borders
-    border-color: currentColor;
-    border-style: $border-style;
-    // stylelint-disable-next-line primer/borders
-    border-width: 2px 2px 0 0;
-    // stylelint-disable-next-line primer/borders
-    border-radius: 1px;
-  }
+  // chevron icons using clip-path
+  @supports (clip-path: polygon(50% 0, 100% 50%, 50% 100%)) {
+    .previous_page::before,
+    .next_page::after {
+      display: inline-block;
+      width: 16px;
+      height: 16px;
+      vertical-align: text-bottom;
+      content: "";
+      // stylelint-disable-next-line primer/colors
+      background-color: currentColor;
+    }
 
-  .previous_page::before {
-    margin: 0 $spacer-2 0 $spacer-1;
-    transform: rotate(-135deg);
-  }
+    // chevron-left
+    .previous_page::before {
+      margin-right: $spacer-1;
+      clip-path: polygon(9.8px 12.8px, 8.7px 12.8px, 4.5px 8.5px, 4.5px 7.5px, 8.7px 3.2px, 9.8px 4.3px, 6.1px 8px, 9.8px 11.7px, 9.8px 12.8px);
+    }
 
-  .next_page::after {
-    margin: 0 $spacer-1 0 $spacer-2;
-    transform: rotate(45deg);
+    // chevron-right
+    .next_page::after {
+      margin-left: $spacer-1;
+      clip-path: polygon(6.2px 3.2px, 7.3px 3.2px, 11.5px 7.5px, 11.5px 8.5px, 7.3px 12.8px, 6.2px 11.7px, 9.9px 8px, 6.2px 4.3px, 6.2px 3.2px);
+    }
   }
 }
 


### PR DESCRIPTION
A few more "Component refresh" tweaks.

## States

`.State--green` now uses the default `$bg-green` color. 👀  [Preview](https://primer-css-git-next-7.primer.now.sh/css/components/labels#state-themes)

![image](https://user-images.githubusercontent.com/378023/81132660-2c513600-8f8a-11ea-899f-82ea33746f1a.png)

This should make it match other components like that timeline check:

![image](https://user-images.githubusercontent.com/378023/81132697-42f78d00-8f8a-11ea-90a0-1192a8cca3cf.png)


## Pagination

The "Previous" and "Next" buttons now have the chevron icons "backed in" with CSS-only. It uses `clip-path: polygon()` to draw the shape. 👀  [Preview](https://primer-css-git-next-7.primer.now.sh/css/components/pagination)

<img width="209" alt="Screen Shot 2020-05-05 at 4 52 57 PM" src="https://user-images.githubusercontent.com/378023/81045321-ebf1a980-8ef0-11ea-976b-5930e01ead90.png">

The `clip-path: polygon()` is generated by converting the [Octicon](https://octicons-git-v2.primer.now.sh/octicons/chevron-right-16) with [this tool](https://betravis.github.io/shape-tools/path-to-polygon/). It can't draw curves, so the shape is not as rounded as when using the icon as SVG, but maybe still close enough?

<img width="155" alt="Screen Shot 2020-05-05 at 4 12 25 PM" src="https://user-images.githubusercontent.com/378023/81045245-cbc1ea80-8ef0-11ea-8b87-d4eb8a77d607.png">

The benefit is no changes are needed to dotcom. But after the refresh we can refactor it and switch to the real Octicons.

## Flash alerts

In https://github.com/primer/css/pull/1071 the flash alerts have a padding of `24px`. That looked great stand-alone, but didn't align with a component like `.Box`:

![Screen Shot 2020-04-28 at 12 20 32 PM](https://user-images.githubusercontent.com/378023/81029351-7faa8200-8ebf-11ea-9e7b-d7c8c572fe8f.png)

So this PR changes the side padding back to `16px`:

![Screen Shot 2020-05-05 at 11 00 48 AM](https://user-images.githubusercontent.com/378023/81029396-b7192e80-8ebf-11ea-8ee0-86dbbed743a2.png)

👀  [Preview](https://primer-css-git-next-7.primer.now.sh/css/components/alerts)
