### PR TITLE
Make sure autocomplete resets button styles

### DIFF
--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -22,11 +22,11 @@
   padding: $spacer-1 $spacer-2;
   overflow: hidden;
   font-weight: $font-weight-bold;
+  color: $text-gray-dark;
   text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
-  color: $text-gray-dark;
   background-color: $bg-white;
   border: 0;
 

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -19,10 +19,12 @@
 
 .autocomplete-item {
   display: block;
+  width: 100%;
   padding: $spacer-1 $spacer-2;
   overflow: hidden;
   font-weight: $font-weight-bold;
   color: $text-gray-dark;
+  text-align: left;
   text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -26,6 +26,9 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
+  color: $text-gray-dark;
+  background-color: $bg-white;
+  border: 0;
 
   &:hover,
   &.selected,


### PR DESCRIPTION
This adds some additional styles to `.autocomplete-item`.

Currently `autocomplete-item` assumes that the item doesn't come with any UA styles, but in fact they can be blue links or buttons with background colors and borders.

- `.autocomplete-results` sets a white background, so it should explicitly set the item text to be something that is dark enough.
- `.autocomplete-item:hover` sets a blue background with white text, so it should ensure that the non-hover state is styled with non-inverted colors. So we know the hover state is different to the default state. 

Resetting these items with utility classes wouldn't work as they have higher specificity than `.autocomplete-item`/`:hover`.

/cc @primer/ds-core

/cc @dinahshi