### PR TITLE
Use primer/publish@v2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: test deprecations
         if: startsWith(github.ref, 'refs/heads/release-')
         run: script/test-deprecations.js
-      - uses: primer/publish@v1.1.0
+      - uses: primer/publish@v2.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
This is just a test. The last few PRs e.g. https://github.com/primer/css/pull/1086 are stuck. Let's see if `primer/publish@v2.0.0` fixes it.

![image](https://user-images.githubusercontent.com/378023/82184288-5d365100-9922-11ea-9da6-477ddb9eb8b7.png)

/cc @primer/ds-core
