### PR TITLE
Accessible Progress

### DIFF
--- a/docs/content/components/progress.md
+++ b/docs/content/components/progress.md
@@ -59,11 +59,11 @@ In cases where it's not possible to describe the progress in text, provide an `a
 
 ## Progress with multiple values
 
-To show the progress of tasks in multiple states (such as "done", "in progress", and "open"), add the `Progress-item` class and a distinct background color utility. Then give each one a percentage width proportional to the total number. Children are stacked from left to right, so if your widths add up to 100%, your bars will too.
+To show the progress of tasks in multiple states (such as "done", "in progress", and "open"), add the `Progress-item` class and a distinct background color utility. Then give each one a percentage width proportional to the total number. Children are stacked from left to right, so if your widths add up to 100%, your bars will too. Note that items with very low percentage values might not be visible if they are smaller than `1px` in width.
 
 ```html live
 <div class="tooltipped tooltipped-n" aria-label="tasks: 80 done, 14 in progress, 6 open">
-  <span class="Progress" style="width: 100px;">
+  <span class="Progress">
     <span class="Progress-item bg-green" style="width: 50%;"></span>
     <span class="Progress-item bg-purple" style="width: 25%;"></span>
     <span class="Progress-item bg-pink" style="width: 15%;"></span>
@@ -72,5 +72,3 @@ To show the progress of tasks in multiple states (such as "done", "in progress",
   </span>
 </div>
 ```
-
-Note that items with very low percentage values will still show with a minimum width of `2px`.

--- a/docs/content/components/progress.md
+++ b/docs/content/components/progress.md
@@ -59,14 +59,18 @@ In cases where it's not possible to describe the progress in text, provide an `a
 
 ## Progress with multiple values
 
-To show the progress of tasks in multiple states (such as "done", "in progress", and "open"), use distinct background color utilities and give each one a percentage width proportional to the total number. Children are stacked from left to right, so if your widths add up to 100%, your bars will too.
+To show the progress of tasks in multiple states (such as "done", "in progress", and "open"), add the `Progress-item` class and a distinct background color utility. Then give each one a percentage width proportional to the total number. Children are stacked from left to right, so if your widths add up to 100%, your bars will too.
 
 ```html live
 <div class="tooltipped tooltipped-n" aria-label="tasks: 80 done, 14 in progress, 6 open">
-  <span class="Progress">
-    <span class="bg-green" style="width: 80%;"></span>
-    <span class="bg-purple" style="width: 14%;"></span>
-    <span class="bg-red" style="width: 6%;"></span>
+  <span class="Progress" style="width: 100px;">
+    <span class="Progress-item bg-green" style="width: 50%;"></span>
+    <span class="Progress-item bg-purple" style="width: 25%;"></span>
+    <span class="Progress-item bg-pink" style="width: 15%;"></span>
+    <span class="Progress-item bg-red" style="width: 8%;"></span>
+    <span class="Progress-item bg-blue" style="width: 2%;"></span>
   </span>
 </div>
 ```
+
+Note that items with very low percentage values will still show with a minimum width of `2px`.

--- a/src/progress/progress.scss
+++ b/src/progress/progress.scss
@@ -18,7 +18,6 @@
 }
 
 .Progress-item + .Progress-item {
-  min-width: 2px;
   // stylelint-disable-next-line primer/spacing
   margin-left: 2px;
 }

--- a/src/progress/progress.scss
+++ b/src/progress/progress.scss
@@ -16,3 +16,9 @@
 .Progress--small {
   height: 5px;
 }
+
+.Progress-item + .Progress-item {
+  min-width: 2px;
+  // stylelint-disable-next-line primer/spacing
+  margin-left: 2px;
+}


### PR DESCRIPTION
This PR improves accessibility of the `Progress` component by adding a `2px` gap between multiple values.

Before | After
--- | ---
<img width="110" alt="img-2020-05-19-14 47 01@2x" src="https://user-images.githubusercontent.com/378023/82289382-a7313c80-99df-11ea-8bf6-bb1b2832ca4f.png"> | <img width="115" alt="img-2020-05-19-13 41 02@2x" src="https://user-images.githubusercontent.com/378023/82287700-c9c15680-99db-11ea-880f-660866d3e0a8.png">

## Why

This makes it easier to see different values that have similar colors.

## Alternatives

If there are a lot of very small values, like `0.1%`, they might not be visible and it just shows some empty space towards the end:

<img width="115" alt="img-2020-05-19-14 28 18@2x" src="https://user-images.githubusercontent.com/378023/82288326-34bf5d00-99dd-11ea-83f1-a421e84de96e.png">

An option would be to show every value with a `min-width` of `2px`. So that they all show up. Downside it that it makes the values look different than they actually are, so for now this is not included in this PR.

<img width="118" alt="img-2020-05-19-13 30 03@2x" src="https://user-images.githubusercontent.com/378023/82288534-a4cde300-99dd-11ea-9e69-0896482f52cd.png">


## API changes

- `.Progress-item` class needs to be added for Progress with multiple values

---

Closes #1079