### PR TITLE
Component refresh 8

### DIFF
--- a/src/labels/counters.scss
+++ b/src/labels/counters.scss
@@ -11,7 +11,7 @@
   color: $text-gray-dark;
   text-align: center;
   // stylelint-disable-next-line primer/colors
-  background-color: rgba($gray-200, 0.5);
+  background-color: rgba($gray-300, 0.5);
   // stylelint-disable-next-line primer/borders
   border-radius: 2em;
 

--- a/src/labels/counters.scss
+++ b/src/labels/counters.scss
@@ -11,7 +11,7 @@
   color: $text-gray-dark;
   text-align: center;
   // stylelint-disable-next-line primer/colors
-  background-color: rgba($gray-300, 0.4);
+  background-color: rgba($gray-300, 0.5);
   // stylelint-disable-next-line primer/borders
   border-radius: 2em;
 

--- a/src/labels/counters.scss
+++ b/src/labels/counters.scss
@@ -11,7 +11,7 @@
   color: $text-gray-dark;
   text-align: center;
   // stylelint-disable-next-line primer/colors
-  background-color: rgba($gray-300, 0.5);
+  background-color: rgba($gray-300, 0.4);
   // stylelint-disable-next-line primer/borders
   border-radius: 2em;
 


### PR DESCRIPTION
A bit darker `Counter` background:

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/378023/82460375-0aac8e80-9af4-11ea-849c-585134bcf01a.png) ![image](https://user-images.githubusercontent.com/378023/82460573-4fd0c080-9af4-11ea-9cc2-a2477d4458a8.png) | ![image](https://user-images.githubusercontent.com/378023/82460260-ea7ccf80-9af3-11ea-80fb-f341cadd81a4.png) ![image](https://user-images.githubusercontent.com/378023/82460631-6119cd00-9af4-11ea-961e-33453deb25d4.png)
`rgba($gray-200, 0.5)`  | `rgba($gray-300, 0.5)` -> 2% darker

👀 [Preview](https://primer-css-git-next-8.primer.now.sh/css/components/labels#counters)

---

Ref. https://github.com/github/design-systems/issues/769#issuecomment-625987643

