### PR TITLE
Primer CSS 14.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,36 @@
+## 14.4.0
+
+### :rocket: Enhancements
+- [#1089](https://github.com/primer/css/pull/1089) Accessible Progress
+
+### :bug: Bug fixes
+- [#1060](https://github.com/primer/css/pull/1060) Add support for aria-current=false
+
+### :memo: Documentation
+- [#1059](https://github.com/primer/css/pull/1059) Typo in scss.md
+- [#1065](https://github.com/primer/css/pull/1065) Convert markdown page to one big example
+- [#1075](https://github.com/primer/css/pull/1075) chore: add missing link to color utilities
+- [#1067](https://github.com/primer/css/pull/1067) Add .text-gray-light to docs
+
+### Committers
+- [@daniseguraf](https://github.com/daniseguraf)
+- [@metonym](https://github.com/metonym)
+- [@simurai](https://github.com/simurai)
+
 ## 14.3.0
 
 ### :rocket: Enhancements
 
-- [#1044](https://github.com/primer/css/1044) Accessible form validation
-- [#1028](https://github.com/primer/css/1028) Improve .form-group accessibility
+- [#1044](https://github.com/primer/css/pull/1044) Accessible form validation
+- [#1028](https://github.com/primer/css/pull/1028) Improve .form-group accessibility
 
 ### :bug: Bug fixes
-- [#670](https://github.com/primer/css/670) Fix Box row top border
-- [#1042](https://github.com/primer/css/1042) Fix UnderlineNav in Safari
-- [#1035](https://github.com/primer/css/1035) Update UnderlineNav-item to not wrap counter & icon
+- [#670](https://github.com/primer/css/pull/670) Fix Box row top border
+- [#1042](https://github.com/primer/css/pull/1042) Fix UnderlineNav in Safari
+- [#1035](https://github.com/primer/css/pull/1035) Update UnderlineNav-item to not wrap counter & icon
 
 ### :memo: Documentation
-- [#1018](https://github.com/primer/css/1018) Update MIGRATING.md
+- [#1018](https://github.com/primer/css/pull/1018) Update MIGRATING.md
 
 ### Committers
 - [@emplums](https://github.com/emplums)

--- a/deprecations.js
+++ b/deprecations.js
@@ -7,10 +7,6 @@ const versionDeprecations = {
   '14.4.0': [
     {
       selectors: [
-        '.subnav-item.selected:hover',
-        '.subnav-item.selected:focus',
-        '.autocomplete-item[aria-selected="true"]',
-        '.autocomplete-item[aria-selected="true"] *',
         '.breadcrumb-item[aria-current]',
         '.breadcrumb-item[aria-current]::after',
         '.menu-item[aria-current]',

--- a/deprecations.js
+++ b/deprecations.js
@@ -4,13 +4,27 @@
  * array and a "message" string.
  */
 const versionDeprecations = {
-  '14.2.0': [
+  '14.4.0': [
     {
       selectors: [
         '.subnav-item.selected:hover',
         '.subnav-item.selected:focus',
         '.autocomplete-item[aria-selected="true"]',
-        '.autocomplete-item[aria-selected="true"] *'
+        '.autocomplete-item[aria-selected="true"] *',
+        '.breadcrumb-item[aria-current]',
+        '.breadcrumb-item[aria-current]::after',
+        '.menu-item[aria-current]',
+        '.menu-item[aria-current]::before',
+        '.tabnav-tab[aria-current]',
+        '.filter-item[aria-current]',
+        '.SideNav-item[aria-current="page"]',
+        '.SideNav-item[aria-current="page"]::before',
+        '.SideNav-subItem[aria-current="page"]',
+        '.subnav-item[aria-current]',
+        '.UnderlineNav-item[aria-current]',
+        '.UnderlineNav-item[aria-current] .UnderlineNav-octicon',
+        '.pagination [aria-current]',
+        '.pagination [aria-current]:hover'
       ],
       message: `These selectors are not needed anymore.`
     }

--- a/docs/content/components/markdown.md
+++ b/docs/content/components/markdown.md
@@ -7,6 +7,284 @@ bundle: markdown
 ---
 
 
+```html live
+<div class="markdown-body">
+  <p>Text can be <b>bold</b>, <i>italic</i>, or <s>strikethrough</s>. <a href="https://github.com">Links </a> should be blue with no underlines (unless hovered over).</p>
+
+  <p>There should be whitespace between paragraphs. There should be whitespace between paragraphs. There should be whitespace between paragraphs. There should be whitespace between paragraphs.</p>
+
+  <p>There should be whitespace between paragraphs. There should be whitespace between paragraphs. There should be whitespace between paragraphs. There should be whitespace between paragraphs.</p>
+
+  <blockquote>
+    <p>There should be no margin above this first sentence.</p>
+    <p>Blockquotes should be a lighter gray with a gray border along the left side.</p>
+    <p>There should be no margin below this final sentence.</p>
+  </blockquote>
+
+  <h1>Header 1</h1>
+
+  <p>This is a normal paragraph following a header. Bacon ipsum dolor sit amet t-bone doner shank drumstick, pork belly porchetta chuck sausage brisket ham hock rump pig. Chuck kielbasa leberkas, pork bresaola ham hock filet mignon cow shoulder short ribs biltong.</p>
+
+  <h2>Header 2</h2>
+
+  <blockquote>This is a blockquote following a header. Bacon ipsum dolor sit amet t-bone doner shank drumstick, pork belly porchetta chuck sausage brisket ham hock rump pig. Chuck kielbasa leberkas, pork bresaola ham hock filet mignon cow shoulder short ribs biltong.</blockquote>
+
+  <h3>Header 3</h3>
+
+  <pre><code>This is a code block following a header.</code></pre>
+
+  <h4>Header 4</h4>
+
+  <ul>
+    <li>This is an unordered list following a header.</li>
+    <li>This is an unordered list following a header.</li>
+    <li>This is an unordered list following a header.</li>
+  </ul>
+
+  <h5>Header 5</h5>
+
+  <ol>
+    <li>This is an ordered list following a header.</li>
+    <li>This is an ordered list following a header.</li>
+    <li>This is an ordered list following a header.</li>
+  </ol>
+
+  <h6>Header 6</h6>
+
+  <table>
+    <thead>
+      <tr>
+        <th>What</th>
+        <th>Follows</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>A table</td>
+        <td>A header</td>
+      </tr>
+      <tr>
+        <td>A table</td>
+        <td>A header</td>
+      </tr>
+      <tr>
+        <td>A table</td>
+        <td>A header</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <hr />
+
+  <p>There's a horizontal rule above and below this.</p>
+
+  <hr />
+
+  <p>Here is an unordered list:</p>
+
+  <ul>
+    <li>Salt-n-Pepa</li>
+    <li>Bel Biv DeVoe</li>
+    <li>Kid 'N Play</li>
+  </ul>
+
+  <p>And an ordered list:</p>
+
+  <ol>
+    <li>Michael Jackson</li>
+    <li>Michael Bolton</li>
+    <li>Michael Bublé</li>
+  </ol>
+
+  <p>And an unordered task list:</p>
+
+  <ul>
+    <li><input type="checkbox" checked> Create a sample markdown document</li>
+    <li><input type="checkbox"> Add task lists to it</li>
+    <li><input type="checkbox"> Take a vacation</li>
+  </ul>
+
+  <p>And a "mixed" task list:</p>
+
+  <ul>
+    <li><input type="checkbox"> Steal underpants</li>
+    <li>?</li>
+    <li><input type="checkbox"> Profit!</li>
+  </ul>
+
+  And a nested list:
+
+  <ul>
+    <li>Jackson 5
+      <ul>
+        <li>Michael</li>
+        <li>Tito</li>
+        <li>Jackie</li>
+        <li>Marlon</li>
+        <li>Jermaine</li>
+      </ul>
+    </li>
+    <li>TMNT
+      <ul>
+        <li>Leonardo</li>
+        <li>Michelangelo</li>
+        <li>Donatello</li>
+        <li>Raphael</li>
+      </ul>
+    </li>
+  </ul>
+
+  <p>Definition lists can be used with HTML syntax. Definition terms are bold and italic.</p>
+
+  <dl>
+      <dt>Name</dt>
+      <dd>Godzilla</dd>
+      <dt>Born</dt>
+      <dd>1952</dd>
+      <dt>Birthplace</dt>
+      <dd>Japan</dd>
+      <dt>Color</dt>
+      <dd>Green</dd>
+  </dl>
+
+  <hr />
+
+  <p>Tables should have bold headings and alternating shaded rows.</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Artist</th>
+        <th>Album</th>
+        <th>Year</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>David Bowie</td>
+        <td>Scary Monsters</td>
+        <td>1980</td>
+      </tr>
+      <tr>
+        <td>Prince</td>
+        <td>Purple Rain</td>
+        <td>1982</td>
+      </tr>
+      <tr>
+        <td>Beastie Boys</td>
+        <td>License to Ill</td>
+        <td>1986</td>
+      </tr>
+      <tr>
+        <td>Janet Jackson</td>
+        <td>Rhythm Nation 1814</td>
+        <td>1989</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>If a table is too wide, it should condense down and/or scroll horizontally.</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Artist</th>
+        <th>Album</th>
+        <th>Year</th>
+        <th>Label</th>
+        <th>Songs</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>David Bowie</td>
+        <td>Scary Monsters</td>
+        <td>1980</td>
+        <td>RCA Records</td>
+        <td>It's No Game (No. 1), Up the Hill Backwards, Scary Monsters (And Super Creeps), Ashes to Ashes, Fashion, Teenage Wildlife, Scream Like a Baby, Kingdom Come, Because You're Young, It's No Game (No. 2)</td>
+      </tr>
+      <tr>
+        <td>Prince</td>
+        <td>Purple Rain</td>
+        <td>1982</td>
+        <td>Warner Brothers Records</td>
+        <td>Let's Go Crazy, Take Me With U, The Beautiful Ones, Computer Blue, Darling Nikki, When Doves Cry, I Would Die 4 U, Baby I'm a Star, Purple Rain</td>
+      </tr>
+      <tr>
+        <td>Beastie Boys</td>
+        <td>License to Ill</td>
+        <td>1986</td>
+        <td>Def Jam</td>
+        <td>Rhymin &amp; Stealin, The New Style, She's Crafty, Posse in Effect, Slow Ride, Girls, Fight for Your Right, No Sleep till Brooklyn, Paul Revere, "Hold It Now, Hit It", Brass Monkey, Slow and Low, Time to Get Ill</td>
+      </tr>
+      <tr>
+        <td>Janet Jackson</td>
+        <td>Rhythm Nation 1814</td>
+        <td>1989</td>
+        <td>A&amp;M</td>
+        <td>Interlude: Pledge, Rhythm Nation, Interlude: T.V., State of the World, Interlude: Race, The Knowledge, Interlude: Let's Dance, Miss You Much, Interlude: Come Back, Love Will Never Do (Without You), Livin' in a World (They Didn't Make), Alright, Interlude: Hey Baby, Escapade, Interlude: No Acid, Black Cat, Lonely, Come Back to Me, Someday Is Tonight, Interlude: Livin'...In Complete Darkness</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <hr />
+
+  <p>Code snippets like <code>var foo = "bar";</code> can be shown inline.</p>
+
+  <p>Also, <code>this should vertically align</code> <s><code>with this</code></s> <s>and this</s>.</p>
+
+  <p>Code can also be shown in a block element.</p>
+
+  <pre><code>var foo = "bar";</code></pre>
+
+  <p>Code can also use syntax highlighting.</p>
+
+  <pre><code class="prism-code language-javascript">var foo = "bar";</code></pre>
+
+  <pre><code>Long, single-line code blocks should not wrap. They should horizontally scroll if they are too long. This line should be long enough to demonstrate this.</code></pre>
+
+  <pre><code class="prism-code language-javascript">var foo = "The same thing is true for code with syntax highlighting. A single line of code should horizontally scroll if it is really long.";</code></pre>
+
+  <p>Inline code inside table cells should still be distinguishable.</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Language</th>
+        <th>Code</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>JavasScript</td>
+        <td><code>var foo = "bar";</code></td>
+      </tr>
+      <tr>
+        <td>Ruby</td>
+        <td><code>foo = "bar"</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <hr />
+
+  <p>Small images should be shown at their actual size.</p>
+
+  <p><img src="http://placekitten.com/g/300/200/"></p>
+
+  <p>Large images should always scale down and fit in the content container.</p>
+
+  <p><img src="http://placekitten.com/g/1200/800/"></p>
+
+  <pre><code>This is the final element on the page and there should be no margin below this.</code></pre>
+</div>
+```
+
+
+<!-- Source MD (update when making changes to the HTML) -->
+
+<!--
+
 Text can be **bold**, _italic_, or ~~strikethrough~~. [Links](https://github.com) should be blue with no underlines (unless hovered over).
 
 There should be whitespace between paragraphs. There should be whitespace between paragraphs. There should be whitespace between paragraphs. There should be whitespace between paragraphs.
@@ -172,3 +450,5 @@ Large images should always scale down and fit in the content container.
 ```
 This is the final element on the page and there should be no margin below this.
 ```
+
+-->

--- a/docs/content/components/progress.md
+++ b/docs/content/components/progress.md
@@ -59,14 +59,16 @@ In cases where it's not possible to describe the progress in text, provide an `a
 
 ## Progress with multiple values
 
-To show the progress of tasks in multiple states (such as "done", "in progress", and "open"), use distinct background color utilities and give each one a percentage width proportional to the total number. Children are stacked from left to right, so if your widths add up to 100%, your bars will too.
+To show the progress of tasks in multiple states (such as "done", "in progress", and "open"), add the `Progress-item` class and a distinct background color utility. Then give each one a percentage width proportional to the total number. Children are stacked from left to right, so if your widths add up to 100%, your bars will too. Note that items with very low percentage values might not be visible if they are smaller than `1px` in width.
 
 ```html live
 <div class="tooltipped tooltipped-n" aria-label="tasks: 80 done, 14 in progress, 6 open">
   <span class="Progress">
-    <span class="bg-green" style="width: 80%;"></span>
-    <span class="bg-purple" style="width: 14%;"></span>
-    <span class="bg-red" style="width: 6%;"></span>
+    <span class="Progress-item bg-green" style="width: 50%;"></span>
+    <span class="Progress-item bg-purple" style="width: 25%;"></span>
+    <span class="Progress-item bg-pink" style="width: 15%;"></span>
+    <span class="Progress-item bg-red" style="width: 8%;"></span>
+    <span class="Progress-item bg-blue" style="width: 2%;"></span>
   </span>
 </div>
 ```

--- a/docs/content/components/timeline.md
+++ b/docs/content/components/timeline.md
@@ -44,7 +44,7 @@ The default TimelineItem-badge color is dark text on a light grey background.
 
 ### Adding color to TimelineItem-badge
 
-To have color variants, use the [color utilities]() on the badge. Be cautious with color choices. We typically use them in the timeline to give meaning to the event in context of the timeline.
+To have color variants, use the [color utilities](/utilities/colors) on the badge. Be cautious with color choices. We typically use them in the timeline to give meaning to the event in context of the timeline.
 
 ```html live
 <!-- Colorful TimelineItem Badge -->

--- a/docs/content/principles/scss.md
+++ b/docs/content/principles/scss.md
@@ -22,7 +22,7 @@ path: priniciples/scss
 * Avoid specifying units for zero values, e.g., `margin: 0;` instead of `margin: 0px;`.
 * Strive to limit use of shorthand declarations to instances where you must explicitly set all the available values.
 
-## Guidelines for using Sass feaures (WIP)
+## Guidelines for using Sass features (WIP)
 _When and when not to create:_
 
 * Variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/css",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/css",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "description": "Primer is the CSS framework that powers GitHub's front-end design. primer includes 23 packages that are grouped into 3 core meta-packages for easy install. Each package and meta-package is independently versioned and distributed via npm, so it's easy to include all or part of Primer within your own project.",
   "homepage": "https://primer.style/css",
   "author": "GitHub, Inc.",

--- a/src/breadcrumb/breadcrumb.scss
+++ b/src/breadcrumb/breadcrumb.scss
@@ -19,7 +19,7 @@
 }
 
 .breadcrumb-item-selected,
-.breadcrumb-item[aria-current] {
+.breadcrumb-item[aria-current]:not([aria-current=false]) {
   color: $text-gray;
 
   &::after {

--- a/src/navigation/filter-list.scss
+++ b/src/navigation/filter-list.scss
@@ -45,7 +45,7 @@
 
   &.selected,
   &[aria-selected=true],
-  &[aria-current] {
+  &[aria-current]:not([aria-current=false]) {
     color: $text-white;
     background-color: $bg-blue;
   }

--- a/src/navigation/menu.scss
+++ b/src/navigation/menu.scss
@@ -46,7 +46,7 @@
 
   &.selected,
   &[aria-selected=true],
-  &[aria-current] {
+  &[aria-current]:not([aria-current=false]) {
     font-weight: $font-weight-bold;
     color: $text-gray-dark;
     cursor: default;

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -60,7 +60,7 @@
   background-color: $bg-white;
 }
 
-.SideNav-item[aria-current="page"],
+.SideNav-item[aria-current]:not([aria-current=false]),
 .SideNav-item[aria-selected="true"] {
   font-weight: $font-weight-semibold;
   color: $text-gray-dark;
@@ -104,7 +104,7 @@
   outline: none;
 }
 
-.SideNav-subItem[aria-current="page"],
+.SideNav-subItem[aria-current]:not([aria-current=false]),
 .SideNav-subItem[aria-selected="true"] {
   font-weight: $font-weight-semibold;
   color: $text-gray-dark;

--- a/src/navigation/subnav.scss
+++ b/src/navigation/subnav.scss
@@ -41,7 +41,7 @@
 
   &.selected,
   &[aria-selected=true],
-  &[aria-current] {
+  &[aria-current]:not([aria-current=false]) {
     z-index: 2;
     color: $text-white;
     background-color: $bg-blue;

--- a/src/navigation/tabnav.scss
+++ b/src/navigation/tabnav.scss
@@ -31,7 +31,7 @@
 
   &.selected,
   &[aria-selected=true],
-  &[aria-current] {
+  &[aria-current]:not([aria-current=false]) {
     color: $text-gray-dark;
     background-color: $bg-white;
     border-color: $border-gray-dark;

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -37,7 +37,7 @@
 
   &.selected,
   &[role=tab][aria-selected=true],
-  &[aria-current] {
+  &[aria-current]:not([aria-current=false]) {
     font-weight: $font-weight-bold;
     color: $text-gray-dark;
     // stylelint-disable-next-line primer/borders

--- a/src/pagination/pagination.scss
+++ b/src/pagination/pagination.scss
@@ -50,8 +50,7 @@
 
   .current,
   .current:hover,
-  [aria-current],
-  [aria-current]:hover {
+  [aria-current]:not([aria-current=false]) {
     z-index: 3;
     color: $text-white;
     background-color: $bg-blue;

--- a/src/progress/progress.scss
+++ b/src/progress/progress.scss
@@ -16,3 +16,8 @@
 .Progress--small {
   height: 5px;
 }
+
+.Progress-item + .Progress-item {
+  // stylelint-disable-next-line primer/spacing
+  margin-left: 2px;
+}


### PR DESCRIPTION
Version: 📦 **`14.4.0`**
Approximate release date: 📆 **May 22th 2020**
Changes: 🎉 [All merged PRs](https://github.com/primer/css/pulls?q=is%3Apr+is%3Amerged+base%3Arelease-14.4.0)

---

### :rocket: Enhancements
- [#1089](https://github.com/primer/css/pull/1089) Accessible Progress

### :bug: Bug fixes
- [#1060](https://github.com/primer/css/pull/1060) Add support for aria-current=false

### :memo: Documentation
- [#1059](https://github.com/primer/css/pull/1059) Typo in scss.md
- [#1065](https://github.com/primer/css/pull/1065) Convert markdown page to one big example
- [#1075](https://github.com/primer/css/pull/1075) chore: add missing link to color utilities
- [#1067](https://github.com/primer/css/pull/1067) Add .text-gray-light to docs

---

### Ship checklist

- [x] Update the `version` field in `package.json`
- [x] Update `CHANGELOG.md`
- [ ] ~Test the release candidate version with `github/github`~
- [ ] Merge this PR and [create a new release](https://github.com/primer/css/releases/new)
- [ ] Update `github/github`

For more details, see [RELEASING.md](https://github.com/primer/css/blob/master/RELEASING.md).

### TODO on dotcom

- TBD

/cc @primer/ds-core