### PR TITLE
Fix typo in progress docs

### DIFF
--- a/docs/content/components/progress.md
+++ b/docs/content/components/progress.md
@@ -26,7 +26,7 @@ Large progress bars are slightly taller than the default.
 
 ## Small progress
 
-Large progress bars are shorter than the default.
+Small progress bars are shorter than the default.
 
 ```html live
 <span class="Progress Progress--small">


### PR DESCRIPTION
Fix small progress bar being called large in `docs/content/components/progress.md`

**Previous:**
```markdown
## Small progress

Large progress bars are shorter than the default.
```

**Fix:**
```markdown
## Small progress

Small progress bars are shorter than the default.
```
