### PR TITLE
Component refresh tweaks 9

### DIFF
--- a/src/labels/mixins.scss
+++ b/src/labels/mixins.scss
@@ -8,7 +8,7 @@
   display: inline-block;
   padding: 0 7px;
   font-size: $font-size-small;
-  font-weight: $font-weight-normal;
+  font-weight: $font-weight-semibold;
   line-height: 18px;
   border: $border-width $border-style transparent;
   border-radius: 2em;

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -36,6 +36,7 @@
   &.selected,
   &[role=tab][aria-selected=true],
   &[aria-current]:not([aria-current=false]) {
+    font-weight: $font-weight-bold;
     // stylelint-disable-next-line primer/borders
     border-bottom-color: #f9826c; // custom coral
 

--- a/src/support/variables/misc.scss
+++ b/src/support/variables/misc.scss
@@ -22,7 +22,7 @@ $box-shadow-inset: inset 0 1px 0 rgba($border-color, 0.2) !default; // top inner
 $box-shadow-focus: 0 0 0 3px rgba($border-blue, 0.3) !default; // blue focus ring
 
 // Button variables
-$border-color-button: rgba($black, 0.12) !default;
+$border-color-button: $black-fade-15 !default;
 $btn-active-shadow: inset 0 0.15em 0.3em $black-fade-15 !default; // TODO: Deprecate?
 
 // Form variables


### PR DESCRIPTION
Here a few more tweaks to the component refresh.

1. Labels are a bit more bold. `400` -> `500`. Now matches `.Counter`:

Before | After
--- | ---
<img width="319" alt="Screen Shot 2020-06-17 at 16 14 56" src="https://user-images.githubusercontent.com/378023/84889148-5b9faa80-b0d3-11ea-8523-a98b8249437d.png"> | <img width="323" alt="Screen Shot 2020-06-17 at 16 15 04" src="https://user-images.githubusercontent.com/378023/84889152-5d696e00-b0d3-11ea-98c8-ad92689b306e.png">

2. Selected UnderlineNav items are now bold. `400` -> `600`:

Before | After
--- | ---
![Screen Shot 2020-06-17 at 19 49 35](https://user-images.githubusercontent.com/378023/84889414-c81aa980-b0d3-11ea-9f1c-c5945dc92f38.png) | ![Screen Shot 2020-06-17 at 19 50 04](https://user-images.githubusercontent.com/378023/84889420-c94bd680-b0d3-11ea-9ef3-51bfe399d048.png)

3. Buttons have a slightly darker border. `12%` -> `15%` black:

Before | After
--- | ---
![Screen Shot 2020-06-17 at 19 51 37](https://user-images.githubusercontent.com/378023/84889549-01531980-b0d4-11ea-994a-cdf9db5a30a2.png) | ![Screen Shot 2020-06-17 at 19 51 46](https://user-images.githubusercontent.com/378023/84889552-02844680-b0d4-11ea-9fd9-cf098c0275b6.png)

