### PR TITLE
Component refresh tweaks 10

### DIFF
--- a/docs/content/components/progress.md
+++ b/docs/content/components/progress.md
@@ -6,11 +6,11 @@ source: 'https://github.com/primer/css/tree/master/src/progress'
 bundle: progress
 ---
 
-Use progress components to visualize task completion. The `Progress` class adds a background color and aligns its children horizontally with flexbox. The children should be individually colored with [background utilities](/utilities/colors#background-colors) and sized with inline `width` styles in percentages. Overflow is hidden, so children that overflow will be clipped.
+Use progress components to visualize task completion. The `Progress` class adds a background color and aligns its children horizontally with flexbox. The children (`Progress-item`) should be individually colored with [background utilities](/utilities/colors#background-colors) and sized with inline `width` styles in percentages. Overflow is hidden, so children that overflow will be clipped.
 
 ```html live
 <span class="Progress">
-  <span class="bg-green" style="width: 50%;"></span>
+  <span class="Progress-item bg-green" style="width: 50%;"></span>
 </span>
 ```
 
@@ -20,7 +20,7 @@ Large progress bars are slightly taller than the default.
 
 ```html live
 <span class="Progress Progress--large">
-  <span class="bg-green" style="width: 50%;"></span>
+  <span class="Progress-item bg-green" style="width: 50%;"></span>
 </span>
 ```
 
@@ -30,7 +30,7 @@ Large progress bars are shorter than the default.
 
 ```html live
 <span class="Progress Progress--small">
-  <span class="bg-green" style="width: 50%;"></span>
+  <span class="Progress-item bg-green" style="width: 50%;"></span>
 </span>
 ```
 
@@ -41,7 +41,7 @@ For inline progress indicators, use the `Progress` and `d-inline-flex` with an i
 ```html live
 <span class="text-small text-gray mr-2">4 of 16</span>
 <span class="Progress d-inline-flex" style="width: 160px">
-  <div class="bg-green" style="width: 25%"></div>
+  <div class="Progress-item bg-green" style="width: 25%"></div>
 </span>
 ```
 
@@ -52,7 +52,7 @@ In cases where it's not possible to describe the progress in text, provide an `a
 ```html live
 <div aria-label="tasks: 8 of 10 complete">
   <span class="Progress">
-    <span class="bg-green" style="width: 80%;"></span>
+    <span class="Progress-item bg-green" style="width: 80%;"></span>
   </span>
 </div>
 ```

--- a/docs/content/utilities/colors.mdx
+++ b/docs/content/utilities/colors.mdx
@@ -82,7 +82,6 @@ You can set the color inheritance on an element by using the `text-inherit` clas
 </div>
 <div class="text-green mb-2">
   .text-green
-  <span class="tooltipped tooltipped-n" aria-label="Does not meet accessibility standards">⚠️</span>
 </div>
 <div class="text-purple mb-2">
   .text-purple

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -22,10 +22,6 @@
     text-decoration: none;
   }
 
-  &:focus {
-    outline: 0;
-  }
-
   &:disabled,
   &.disabled,
   &[aria-disabled=true] {

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -109,6 +109,8 @@
   // Keep :focus after :disabled. Allows to see the focus ring even on disabled buttons
   &:focus,
   &.focus {
+    outline: 1px dotted transparent; // Support Firfox custom colors
+    outline-offset: 2px;
     box-shadow: $box-shadow-focus;
   }
 }

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -91,6 +91,7 @@ textarea.form-control {
 // Custom styling for HTML5 validation bubbles (WebKit only)
 ::placeholder {
   color: $text-gray-light;
+  opacity: 1; // override opacity in normalize.css
 }
 
 // Mini inputs, to match .minibutton

--- a/src/labels/counters.scss
+++ b/src/labels/counters.scss
@@ -7,11 +7,12 @@
   font-size: $font-size-small;
   font-weight: $font-weight-semibold;
   // stylelint-disable-next-line primer/typography
-  line-height: $size-2;
+  line-height: $size-2 - 2px; // remove borders
   color: $text-gray-dark;
   text-align: center;
   // stylelint-disable-next-line primer/colors
   background-color: rgba($gray-300, 0.5);
+  border: $border-width $border-style transparent; // Support Firfox custom colors
   // stylelint-disable-next-line primer/borders
   border-radius: 2em;
 

--- a/src/labels/diffstat.scss
+++ b/src/labels/diffstat.scss
@@ -18,16 +18,20 @@
   height: $spacer-2;
   // stylelint-disable-next-line primer/spacing
   margin-left: 1px;
+  outline-offset: -1px; // Support Firfox custom colors
 }
 
 .diffstat-block-deleted {
   background-color: $bg-diffstat-deleted;
+  outline: 1px dashed transparent; // Support Firfox custom colors
 }
 
 .diffstat-block-added {
   background-color: $bg-diffstat-added;
+  outline: 1px solid transparent; // Support Firfox custom colors
 }
 
 .diffstat-block-neutral {
   background-color: $bg-diffstat-neutral;
+  outline: 1px dotted transparent; // Support Firfox custom colors
 }

--- a/src/labels/states.scss
+++ b/src/labels/states.scss
@@ -13,7 +13,7 @@
 .State {
   display: inline-block;
   // stylelint-disable-next-line primer/spacing
-  padding: 6px 12px;
+  padding: 5px 12px;
   font-size: $body-font-size;
   font-weight: $font-weight-semibold;
   // stylelint-disable-next-line primer/typography
@@ -23,6 +23,7 @@
   white-space: nowrap;
   // stylelint-disable-next-line primer/colors
   background-color: $gray-500;
+  border: $border-width $border-style transparent; // Support Firfox custom colors
   // stylelint-disable-next-line primer/borders
   border-radius: 2em;
 }

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -29,6 +29,8 @@
   &:focus {
     text-decoration: none;
     border-bottom-color: $border-gray-dark;
+    outline: 1px dotted transparent; // Support Firfox custom colors
+    outline-offset: -1px;
     transition-timing-function: ease-out;
     transition-duration: 0.12s;
   }
@@ -39,6 +41,8 @@
     font-weight: $font-weight-bold;
     // stylelint-disable-next-line primer/borders
     border-bottom-color: #f9826c; // custom coral
+    outline: 1px dotted transparent; // Support Firfox custom colors
+    outline-offset: -1px;
 
     .UnderlineNav-octicon {
       color: $text-gray;

--- a/src/progress/progress.scss
+++ b/src/progress/progress.scss
@@ -7,6 +7,7 @@
   // stylelint-disable-next-line primer/colors
   background-color: $gray-200;
   border-radius: $border-radius;
+  outline: 1px solid transparent; // Support Firfox custom colors
 }
 
 .Progress--large {
@@ -15,6 +16,10 @@
 
 .Progress--small {
   height: 5px;
+}
+
+.Progress-item {
+  outline: 2px solid transparent; // Support Firfox custom colors
 }
 
 .Progress-item + .Progress-item {

--- a/src/support/variables/colors.scss
+++ b/src/support/variables/colors.scss
@@ -46,7 +46,7 @@ $text-blue:         $blue-500 !default;
 $text-gray-dark:    $gray-900 !default;
 $text-gray-light:   $gray-500 !default;
 $text-gray:         $gray-600 !default;
-$text-green:        $green-500 !default;
+$text-green:        $green-600 !default;
 $text-orange:       $orange-900 !default;
 $text-orange-light: $orange-600 !default;
 $text-purple:       $purple !default;


### PR DESCRIPTION
A few more accessibility improvements to the component refresh before releasing it as Primer CSS `15.0.0`.

## 1. Increase contrast for `$text-green`

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/378023/86011070-37d74f80-ba57-11ea-863d-03cb28184eb5.png) | ![after](https://user-images.githubusercontent.com/378023/86011141-4cb3e300-ba57-11ea-8f74-0230f168b152.png)
`green-500` | `green-600`
`#28a745` | `#22863a`
Contrast ratio: `3.13` ❌  | Contrast ratio: `4.63` ✅ 


## 2. Increase contrast for placeholders

Overriding the `opacity: 0.54` to `opacity: 1` will make sure the `$text-gray-light` is opaque and the contrast ratio should now be `4.82` (recommendation is `4.5`). Improves https://github.com/github/github/issues/131894

Before | After
--- | ---
![Screenshot before](https://user-images.githubusercontent.com/378023/85984030-80751580-ba23-11ea-9226-c22ca856f08a.png) | ![Screenshot after](https://user-images.githubusercontent.com/378023/85983779-0f356280-ba23-11ea-8546-776c7ad258c5.png)
Contrast ratio: `2.06` ❌  | Contrast ratio: `4.82` ✅ 



## 3. More accessible `.Progress` component

This makes sure the `.Progress` bar is visible when enabling [custom colors](https://user-images.githubusercontent.com/378023/86003809-4f113f80-ba4d-11ea-9324-275ebe7af6a1.png) in Firefox. Improves https://github.com/github/github/issues/131895. The transparent outline/border won't be visible by default. But when custom colors are enabled in Firefox, it will make the outline/border the same color as the text color. And they magically appear. ✨ 

Description | Screenshot
--- | ---
Default | ![Screenshot default](https://user-images.githubusercontent.com/378023/86003928-7cf68400-ba4d-11ea-8e64-26d561cd08d9.png)
Before (invisible) | ![Screenshot before](https://user-images.githubusercontent.com/378023/86003922-7a942a00-ba4d-11ea-81c5-b62bead28afb.png)
After | ![Screenshot after](https://user-images.githubusercontent.com/378023/86003927-7c5ded80-ba4d-11ea-83b2-71c85365f780.png)



## 4. More accessible `.State` component

Same as above ☝️ .

Description | Screenshot
--- | ---
Default | ![Screenshot default](https://user-images.githubusercontent.com/378023/86017284-d1562f80-ba5e-11ea-8ca1-19e53cc34bb6.png)
Before (invisible borders) | ![Screenshot before](https://user-images.githubusercontent.com/378023/86017282-d0bd9900-ba5e-11ea-91a6-e6ceb94275ed.png)
After | ![Screenshot after](https://user-images.githubusercontent.com/378023/86017275-cf8c6c00-ba5e-11ea-81b1-5c907effdbaa.png)

## 5. More accessible `.Counter` component

Same as above ☝️ .

Description | Screenshot
--- | ---
Default | ![Screenshot default](https://user-images.githubusercontent.com/378023/86198717-3612a680-bb93-11ea-85b2-85b00f252da0.png)
Before (invisible borders) | ![Screenshot before](https://user-images.githubusercontent.com/378023/86198718-36ab3d00-bb93-11ea-8d78-01df57910b74.png)
After | ![Screenshot after](https://user-images.githubusercontent.com/378023/86198720-3743d380-bb93-11ea-8ea3-43398ff6ddab.png)

## 6. More accessible `.diffstat` component

Same as above ☝️ .

Description | Screenshot
--- | ---
Default | ![Screenshot default](https://user-images.githubusercontent.com/378023/86199595-7b37d800-bb95-11ea-8d1c-62bbba249cb8.png)
Before (invisible) | ![Screenshot before](https://user-images.githubusercontent.com/378023/86199596-7c690500-bb95-11ea-926b-7287902fcc52.png)
After | ![Screenshot after](https://user-images.githubusercontent.com/378023/86199597-7d019b80-bb95-11ea-90be-7b8ad0793ae7.png)

## 7. More accessible `.btn` component when focused

Same as above ☝️ . Improves https://github.com/github/github/issues/131885

Description | Screenshot
--- | ---
Default | ![Screenshot default](https://user-images.githubusercontent.com/378023/86203441-fef6c200-bb9f-11ea-851f-f011aac97cc7.png)
Before (invisible focus state) | ![Screenshot before](https://user-images.githubusercontent.com/378023/86203442-00c08580-bba0-11ea-89e4-49cc2e1143be.png)
After | ![Screenshot after](https://user-images.githubusercontent.com/378023/86203444-01591c00-bba0-11ea-932c-268eb763c7bc.png)

## 8. More accessible `.UnderlineNav` component

Same as above ☝️ .

Description | Screenshot
--- | ---
Default | ![Screenshot default](https://user-images.githubusercontent.com/378023/86208216-138c8780-bbab-11ea-8072-34753118556e.png)
Before (almost invisible selected state) | ![Screenshot before](https://user-images.githubusercontent.com/378023/86208219-14bdb480-bbab-11ea-8205-bd37dad66137.png)
After | ![Screenshot after](https://user-images.githubusercontent.com/378023/86208222-15564b00-bbab-11ea-8c6a-929a0cdd202d.png)
