### PR TITLE
Update layout when the Counter is empty

### DIFF
--- a/src/labels/counters.scss
+++ b/src/labels/counters.scss
@@ -17,7 +17,7 @@
   border-radius: 2em;
 
   &:empty {
-    visibility: hidden;
+    display: none;
   }
 
   .octicon {


### PR DESCRIPTION
Replacing `visibility:hidden` with `display:none` for empty Counter so that the layout is always optimal and consistent with the common usage of the `hidden` html tag when its value is 0. To be considered also that `visibility:hidden` works as non-disruptive placeholder for the incoming amount only if it has 1 digit.

/cc @primer/ds-core

---

Revert https://github.com/github/github/pull/148773/commits/5138e844464f77549c8174d04eda83f9428d55ff once this is released.

Closes https://github.com/github/design-systems/issues/915