### PR TITLE
Remove reference to Crema

### DIFF
--- a/docs/content/components/alerts.md
+++ b/docs/content/components/alerts.md
@@ -104,7 +104,7 @@ When using a `24px` icon, add a `.v-align-bottom` class and increase the font-si
 
 ## With dismiss
 
-Add a JavaScript enabled (via Crema) dismiss (close) icon on the right of any flash message.
+Add a close icon on the right to allow users to dismiss a flash message.
 
 ```html live
 <div class="flash">


### PR DESCRIPTION
This removes the `via Crema` reference in the [docs](https://primer.style/css/components/alerts#with-dismiss). It seems to be an internal JS framework that isn't really used anymore.

---

Closes #1124 