### PR TITLE
Increase border contrast for Label--yellow

### DIFF
--- a/src/labels/labels.scss
+++ b/src/labels/labels.scss
@@ -50,7 +50,7 @@
   // stylelint-disable-next-line primer/colors
   color: $yellow-900;
   // stylelint-disable-next-line primer/borders
-  border-color: $yellow-700;
+  border-color: $yellow-800;
 }
 
 .Label--orange {

--- a/src/labels/labels.scss
+++ b/src/labels/labels.scss
@@ -50,7 +50,7 @@
   // stylelint-disable-next-line primer/colors
   color: $yellow-900;
   // stylelint-disable-next-line primer/borders
-  border-color: $yellow-600;
+  border-color: $yellow-700;
 }
 
 .Label--orange {


### PR DESCRIPTION
This makes the **border** of the `Label--yellow` a bit darker:

Before | After
--- | ---
![600](https://user-images.githubusercontent.com/378023/87888426-cf80fa00-ca67-11ea-8fce-8d6425dcc669.png) | ![800](https://user-images.githubusercontent.com/378023/87888449-ede6f580-ca67-11ea-8bb2-42ceee5c809c.png)
`yellow-600` | `yellow-800`

## Reasoning

We got feedback that the yellow labels are harder to see: https://github.com/github/github/issues/149846 (internal)

## Alternatives

We could also use `yellow-700` for the border.

![700](https://user-images.githubusercontent.com/378023/87888436-e0317000-ca67-11ea-92e3-571b8a8f9451.png)

It would fail the `AA` color contrast ratio for graphical objects. But at the same time it would be more recognizable as "yellow".
