### PR TITLE
Add support for table border

### DIFF
--- a/src/markdown/tables.scss
+++ b/src/markdown/tables.scss
@@ -4,7 +4,9 @@
   // Tables
   table {
     display: block;
-    width: 100%;
+    width: 100%; // keep for backwards compatibility
+    width: max-content;
+    max-width: 100%;
     overflow: auto;
 
     th {

--- a/src/markdown/tables.scss
+++ b/src/markdown/tables.scss
@@ -8,6 +8,8 @@
     width: max-content;
     max-width: 100%;
     overflow: auto;
+    border-color: $border-gray-darker;
+    border-style: $border-style;
 
     th {
       font-weight: $font-weight-bold;

--- a/src/markdown/tables.scss
+++ b/src/markdown/tables.scss
@@ -8,8 +8,6 @@
     width: max-content;
     max-width: 100%;
     overflow: auto;
-    border-color: $border-gray-darker;
-    border-style: $border-style;
 
     th {
       font-weight: $font-weight-bold;


### PR DESCRIPTION
This makes `table` inside `.markdown-body` adjust in width based on the content.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/378023/88255083-59dc8e80-ccf2-11ea-988c-a0ad381f8ca6.png) | ![image](https://user-images.githubusercontent.com/378023/88255054-42050a80-ccf2-11ea-83c3-f790bb228b9c.png)

**Note**: The `border` for `table` is not set and thus the "outer" border is not visible by default. But it can be enabled when using the `MediaWiki` format in Wikis. See #1127.

Test 👉  https://github.com/simcado/test/wiki/Table-in-MediaWiki-test

---

Fixes https://github.com/primer/css/issues/1127
