### PR TITLE
Add .bg-orange to the list of colors

### DIFF
--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -34,6 +34,8 @@
 .bg-pink { background-color: $bg-pink !important; }
 /* Set the background to $bg-purple-light */
 .bg-purple-light     { background-color: $bg-purple-light !important; }
+/* Set the background to $bg-orange */
+.bg-orange { background-color: $bg-orange !important; }
 
 // Generate a foreground and background utility for every shade of every hue
 @each $hue, $shades in $hue-maps {


### PR DESCRIPTION
-  Fixes: The lack of a `bg-orange` class that is associated with `$orange-700` -> `#d15704`

Why:

* https://primer.style/css/utilities/colors#background-utilities
mentions `.bg-orange` as an accessibility approved background color.
However, the `src/utilities/colors.scss` file did not have this class
listed.

This change addresses the need by:

* Adding `.bg-orange` to `src/utilities/colors.scss`.

/cc @primer/ds-core
