### PR TITLE
Fix CSS error reported by W3C validator

### DIFF
--- a/src/markdown/lists.scss
+++ b/src/markdown/lists.scss
@@ -46,10 +46,6 @@
     margin-bottom: 0;
   }
 
-  li {
-    word-wrap: break-word;
-  }
-
   li > p {
     margin-top: $spacer-3;
   }

--- a/src/markdown/lists.scss
+++ b/src/markdown/lists.scss
@@ -47,7 +47,7 @@
   }
 
   li {
-    word-wrap: break-all;
+    word-wrap: break-word;
   }
 
   li > p {


### PR DESCRIPTION
## Context

In pages-themes/primer#18, @benbalter noticed some W3C validation errors for CSS rules from `primer-markdown`. The issue is now stale, but I still see two errors in the latest version of Primer CSS. This PR proposes a fix for one of the validation errors.

**FIXED:** The `word-wrap` property (which is an alias of [`overflow-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap#Values)) does not accept `break-all` as a value. I think `break-word` may have been the intended value.

**NOT FIXED:** The [W3C validator](https://jigsaw.w3.org/css-validator/#validate_by_input) reports that the `max-width` property cannot take the value `auto`. However, the [MDN page for the rule](https://developer.mozilla.org/en-US/docs/Web/CSS/max-width) lists `auto` as an acceptable value; the [linked section in the CSS spec](https://drafts.csswg.org/css-sizing-3/#sizing-values) does not clearly indicate whether `auto` is an acceptable value for `max-width`. In any case, I couldn't decide whether to propose a change in this PR.

Feedback and suggestions would be appreciated. 😃 

## Validation

I used the [W3C online CSS validator](https://jigsaw.w3.org/css-validator/#validate_by_input) to test the subset of rules I modified. The validator reports no errors with the new change.

/cc @primer/ds-core
