### PR TITLE
Set this timeline item line to -1 zindex so it will be behind anything overlapping it

### DIFF
--- a/src/timeline/timeline-item.scss
+++ b/src/timeline/timeline-item.scss
@@ -10,6 +10,7 @@
     top: 0;
     bottom: 0;
     left: 0;
+    z-index: -1;
     display: block;
     width: 2px;
     content: "";


### PR DESCRIPTION
This PR gives the line that is the `TimelineItem` line a `z-index: -1;` To explain the need I need to show you what I'm trying to do.

Take this example, I'm using the TimelineItem for commits and on small screens I want the Box list to overlap the line. I can solve this by either pulling up the content above the line, or pushing back the line.

<img src="https://user-images.githubusercontent.com/54012/90663208-37a93400-e1fe-11ea-9397-a20e01454d23.png" width="50%" />

My first attempt was to pull up the content. But this has issues with anything in the content that needs to float above.

<img src="https://user-images.githubusercontent.com/54012/90663264-468fe680-e1fe-11ea-8bfb-1e67389b5182.png" width="50%" />

/cc @primer/ds-core
