### PR TITLE
Make final position responsive

### DIFF
--- a/docs/content/utilities/layout.md
+++ b/docs/content/utilities/layout.md
@@ -246,7 +246,7 @@ The position of an element depends on the content. Use `top-0`, `right-0`, `bott
 </div>
 ```
 
-Using the **responsive variants** (e.g. `.right-md-0`) can be helpful for positioning select menus, dropdowns, popovers etc. when the content gets shuffled around for certain responsive breakpoints.
+Using the **responsive variants** (e.g. `.right-md-0`) can be helpful for positioning select menus, dropdowns, popovers etc. when the content gets shuffled around for certain responsive breakpoints. You can also use `auto` to "reset" a final position for wider breakpoints (e.g. `right-0 right-md-auto`).
 
 ### Relative
 

--- a/docs/content/utilities/layout.md
+++ b/docs/content/utilities/layout.md
@@ -227,6 +227,29 @@ Use `.height-full` to set height to 100%.
 ## Position
 Position utilities can be used to alter the default document flow. **Be careful when using positioning, it's often unnecessary and commonly misused.**
 
+The position of an element depends on the content. Use `top-0`, `right-0`, `bottom-0`, and `left-0` to further specify an elements final position.
+
+```html live
+<div style="height: 64px;">
+  <div class="border position-absolute top-0 left-0">
+    .top-0 .left-0
+  </div>
+  <div class="border position-absolute top-0 right-0">
+    .top-0 .right-0
+  </div>
+  <div class="border position-absolute bottom-0 right-0">
+    .bottom-0 .right-0
+  </div>
+  <div class="border position-absolute bottom-0 left-0">
+    .bottom-0 .left-0
+  </div>
+</div>
+```
+
+Using the **responsive variants** (e.g. `.right-md-0`) can be helpful for positioning select menus, dropdowns, popovers etc. when the content gets shuffled around for certain responsive breakpoints.
+
+### Relative
+
 Use `.position-relative` to create a new stacking context.
 
 _Note how the other elements are displayed as if "Two" were in its normal position and taking up space._
@@ -246,6 +269,8 @@ _Note how the other elements are displayed as if "Two" were in its normal positi
 </div>
 ```
 
+### Absolute
+
 Use `.position-absolute` to take elements out of the normal document flow.
 
 ```html live
@@ -258,6 +283,8 @@ Use `.position-absolute` to take elements out of the normal document flow.
 </div>
 ```
 
+### Fixed
+
 Use `.position-fixed` to position an element relative to the viewport. **Be careful when using fixed positioning. It is tricky to use and can lead to unwanted side effects.**
 
 _Note: This example is shown in an `<iframe>` and therefore will not be positioned to the viewport of this page._
@@ -266,25 +293,6 @@ _Note: This example is shown in an `<iframe>` and therefore will not be position
 <div style="height: 64px;">
   <div class="position-fixed right-0 bottom-0 bg-gray-light border p-2">
     .position-fixed
-  </div>
-</div>
-```
-
-Use `top-0`, `right-0`, `bottom-0`, and `left-0` with `position-absolute`, `position-fixed`, or `position-relative` to further specify an elements position.
-
-```html live
-<div style="height: 64px;">
-  <div class="border position-absolute top-0 left-0">
-    .top-0 .left-0
-  </div>
-  <div class="border position-absolute top-0 right-0">
-    .top-0 .right-0
-  </div>
-  <div class="border position-absolute bottom-0 right-0">
-    .bottom-0 .right-0
-  </div>
-  <div class="border position-absolute bottom-0 left-0">
-    .bottom-0 .left-0
   </div>
 </div>
 ```

--- a/src/utilities/layout.scss
+++ b/src/utilities/layout.scss
@@ -12,14 +12,15 @@
   }
 }
 
-/* Set top 0 */
-.top-0    { top: 0 !important; }
-/* Set right 0 */
-.right-0  { right: 0 !important; }
-/* Set bottom 0 */
-.bottom-0 { bottom: 0 !important; }
-/* Set left 0 */
-.left-0   { left: 0 !important; }
+/* Set final location to 0 */
+@each $breakpoint, $variant in $responsive-variants {
+  @include breakpoint($breakpoint) {
+    .top#{$variant}-0 { top: 0 !important; }
+    .right#{$variant}-0 { right: 0 !important; }
+    .bottom#{$variant}-0 { bottom: 0 !important; }
+    .left#{$variant}-0 { left: 0 !important; }
+  }
+}
 
 /* Vertical align middle */
 .v-align-middle      { vertical-align: middle !important; }

--- a/src/utilities/layout.scss
+++ b/src/utilities/layout.scss
@@ -1,7 +1,7 @@
 // Layout
 // stylelint-disable block-opening-brace-space-after, block-opening-brace-space-before, comment-empty-line-before
 
-// Loop through the breakpoint values
+/* Position */
 @each $breakpoint, $variant in $responsive-variants {
   @include breakpoint($breakpoint) {
     @each $position in $responsive-positions {
@@ -12,13 +12,17 @@
   }
 }
 
-/* Set final location to 0 */
+/* Final position */
 @each $breakpoint, $variant in $responsive-variants {
   @include breakpoint($breakpoint) {
     .top#{$variant}-0 { top: 0 !important; }
     .right#{$variant}-0 { right: 0 !important; }
     .bottom#{$variant}-0 { bottom: 0 !important; }
     .left#{$variant}-0 { left: 0 !important; }
+    .top#{$variant}-auto { top: auto !important; }
+    .right#{$variant}-auto { right: auto !important; }
+    .bottom#{$variant}-auto { bottom: auto !important; }
+    .left#{$variant}-auto { left: auto !important; }
   }
 }
 


### PR DESCRIPTION
This makes the "final position" utilities (`[top/left/right/bottom]-0`) responsive (e.g. `right-md-0`, `bottom-lg-0`). This can be handy when moving select menus, dropdowns, popovers etc. around for certain responsive breakpoints. This came up in https://github.com/github/github/pull/153189.

It also adds an option to "reset" a final position (e.g. `right-0 right-md-auto`).

/cc @primer/ds-core
