### PR TITLE
Increase input font-size on iOS

### DIFF
--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -46,9 +46,12 @@ label {
     background-color: #f3f4f6; // custom gray
   }
 
-  // Ensures inputs don't zoom on mobile but are body-font size on desktop
-  @include breakpoint(md) {
-    font-size: $body-font-size;
+  // Ensures inputs don't zoom on mobile iPhone but are body-font size on iPad
+  @supports (-webkit-touch-callout: none) {
+    font-size: $h4-size;
+    @include breakpoint(md) {
+      font-size: $body-font-size;
+    }
   }
 }
 


### PR DESCRIPTION
This increases the font-size for `.form-control` and  `.form-select` when used on iOS and the viewport is narrow (smaller than md). It fixes the "zoom into inputs when focused" problem, see https://github.com/github/design-systems/issues/959.

![input zoom safari ios](https://user-images.githubusercontent.com/293280/88836136-1f0fa600-d18b-11ea-8d9a-54b81e532db9.gif)

---

Closes https://github.com/github/design-systems/issues/959