### PR TITLE
Remove .autocomplete-results inset border that is occluded by items

### DIFF
--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -11,7 +11,7 @@
   background: $bg-white;
   border-radius: $border-radius;
   // stylelint-disable-next-line primer/box-shadow
-  box-shadow: inset 0 0 0 1px $border-color, $box-shadow-medium;
+  box-shadow: $box-shadow-medium;
 }
 
 // One of the items that appears within an autocomplete group

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -9,8 +9,8 @@
   font-size: 13px;
   list-style: none;
   background: $bg-white;
+  border: $border;
   border-radius: $border-radius;
-  // stylelint-disable-next-line primer/box-shadow
   box-shadow: $box-shadow-medium;
 }
 


### PR DESCRIPTION
Individual `. autocomplete-item` children of `.autocomplete-results` all have a background color, which completely covers the inset border.

This becomes evident if any individual items have margin overrides, or the parent results view has additional padding added.

/cc @primer/ds-core
