### PR TITLE
Place search subnav example on new line

### DIFF
--- a/docs/content/components/navigation.md
+++ b/docs/content/components/navigation.md
@@ -459,8 +459,9 @@ You can also use a `subnav-search-context` to display search help in a select me
     <a class="subnav-item" href="#url">Item 2</a>
     <a class="subnav-item" href="#url">Item 3</a>
   </nav>
-
-  <div class="float-left ml-3 subnav-search-context">
+</div>
+<div class="subnav">
+  <div class="float-left subnav-search-context">
     <button class="btn" type="button" name="button" aria-expanded="false" aria-haspopup="true">
       Filters
       <span class="dropdown-caret"></span>
@@ -471,5 +472,5 @@ You can also use a `subnav-search-context` to display search help in a select me
     <!-- <%= octicon "search", :class = "subnav-search-icon" %> -->
     <svg class="subnav-search-icon octicon octicon-search" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"> <path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z" /> </svg>
   </div>
-</div>
+</div
 ```

--- a/docs/content/components/navigation.md
+++ b/docs/content/components/navigation.md
@@ -472,5 +472,5 @@ You can also use a `subnav-search-context` to display search help in a select me
     <!-- <%= octicon "search", :class = "subnav-search-icon" %> -->
     <svg class="subnav-search-icon octicon octicon-search" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"> <path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z" /> </svg>
   </div>
-</div
+</div>
 ```


### PR DESCRIPTION
Fixes break in search subnav component within docs.

-  Fixes:

Current | Fix
:--: | :--:
![image](https://user-images.githubusercontent.com/10384315/92018896-a6ac7f80-ed0a-11ea-97a1-6f3fcc59a954.png) | ![image](https://user-images.githubusercontent.com/10384315/92018965-c0e65d80-ed0a-11ea-9dae-9706a135348a.png)

/cc @primer/ds-core
