### PR TITLE
Revert "Fix CSS error reported by W3C validator"

### DIFF
--- a/src/markdown/lists.scss
+++ b/src/markdown/lists.scss
@@ -47,6 +47,7 @@
   }
 
   li {
+    // TODO@16.0.0: Remove this. See https://github.com/primer/css/pull/1137.
     word-wrap: break-all;
   }
 

--- a/src/markdown/lists.scss
+++ b/src/markdown/lists.scss
@@ -46,6 +46,10 @@
     margin-bottom: 0;
   }
 
+  li {
+    word-wrap: break-all;
+  }
+
   li > p {
     margin-top: $spacer-3;
   }


### PR DESCRIPTION
Reverts primer/css#1137

Whoops.. I forgot that removing selectors needs a major update, see https://github.com/primer/css/pull/1162/checks?check_run_id=1084135905#step:9:9

```
𐄂 ".markdown-body li" has been removed, but was not listed in versionDeprecations['15.2.0']
```

We'll have to make another PR for Primer CSS `16.0.0`.

/cc @seshrs