### PR TITLE
Fix CSS error reported by W3C validator

### DIFF
--- a/src/markdown/lists.scss
+++ b/src/markdown/lists.scss
@@ -46,11 +46,6 @@
     margin-bottom: 0;
   }
 
-  li {
-    // TODO@16.0.0: Remove this. See https://github.com/primer/css/pull/1137.
-    word-wrap: break-all;
-  }
-
   li > p {
     margin-top: $spacer-3;
   }


### PR DESCRIPTION
This is the same as https://github.com/primer/css/pull/1137 (that I tried to merged into `15.2.0`), but we have to wait for Primer CSS `16.0.0` because removing selectors is considered a breaking change.
