### PR TITLE
Fix broken links and update octicons

### DIFF
--- a/docs/content/components/blankslate.md
+++ b/docs/content/components/blankslate.md
@@ -29,25 +29,12 @@ When it helps the message, include (relevant) icons in your blank slate. Add `.b
 ```html live
 <div class="blankslate">
   <!-- <%= octicon "git-commit", :height = 32, :class => "blankslate-icon" %> -->
-  <svg width="28" height="32" viewBox="0 0 14 16" class="octicon octicon-git-commit blankslate-icon" aria-hidden="true">
-    <path
-      fill-rule="evenodd"
-      d="M10.86 7c-.45-1.72-2-3-3.86-3-1.86 0-3.41 1.28-3.86 3H0v2h3.14c.45 1.72 2 3 3.86 3 1.86 0 3.41-1.28 3.86-3H14V7h-3.14zM7 10.2c-1.22 0-2.2-.98-2.2-2.2 0-1.22.98-2.2 2.2-2.2 1.22 0 2.2.98 2.2 2.2 0 1.22-.98 2.2-2.2 2.2z"
-    />
-  </svg>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" class="octicon octicon-git-commit blankslate-icon" aria-hidden="true"><path fill-rule="evenodd" d="M10.5 7.75a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zm1.43.75a4.002 4.002 0 01-7.86 0H.75a.75.75 0 110-1.5h3.32a4.001 4.001 0 017.86 0h3.32a.75.75 0 110 1.5h-3.32z"></path></svg>
   <!-- <%= octicon "tag", :height = 32, :class => "blankslate-icon" %> -->
-  <svg width="28" height="32" viewBox="0 0 14 16" class="octicon octicon-tag blankslate-icon" aria-hidden="true">
-    <path
-      fill-rule="evenodd"
-      d="M7.73 1.73C7.26 1.26 6.62 1 5.96 1H3.5C2.13 1 1 2.13 1 3.5v2.47c0 .66.27 1.3.73 1.77l6.06 6.06c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41L7.73 1.73zM2.38 7.09c-.31-.3-.47-.7-.47-1.13V3.5c0-.88.72-1.59 1.59-1.59h2.47c.42 0 .83.16 1.13.47l6.14 6.13-4.73 4.73-6.13-6.15zM3.01 3h2v2H3V3h.01z"
-    />
-  </svg>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" class="octicon octicon-tag blankslate-icon" aria-hidden="true"><path fill-rule="evenodd" d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z"></path></svg>
   <!-- <%= octicon "git-branch", :height = 32, :class => "blankslate-icon" %> -->
-  <svg width="20" height="32" viewBox="0 0 10 16" class="octicon octicon-git-branch blankslate-icon" aria-hidden="true">
-    <path
-      fill-rule="evenodd"
-      d="M10 5c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v.3c-.02.52-.23.98-.63 1.38-.4.4-.86.61-1.38.63-.83.02-1.48.16-2 .45V4.72a1.993 1.993 0 0 0-1-3.72C.88 1 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2 1.11 0 2-.89 2-2 0-.53-.2-1-.53-1.36.09-.06.48-.41.59-.47.25-.11.56-.17.94-.17 1.05-.05 1.95-.45 2.75-1.25S8.95 7.77 9 6.73h-.02C9.59 6.37 10 5.73 10 5zM2 1.8c.66 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2C1.35 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2zm0 12.41c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm6-8c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
-    />
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" class="octicon octicon-git-branch blankslate-icon" aria-hidden="true">
+<path fill-rule="evenodd" d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V6A2.5 2.5 0 0110 8.5H6a1 1 0 00-1 1v1.128a2.251 2.251 0 11-1.5 0V5.372a2.25 2.25 0 111.5 0v1.836A2.492 2.492 0 016 7h4a1 1 0 001-1v-.628A2.25 2.25 0 019.5 3.25zM4.25 12a.75.75 0 100 1.5.75.75 0 000-1.5zM3.5 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0z"></path>
   </svg>
   <h3>This is a blank slate</h3>
   <p>Use it to provide information when no dynamic content exists.</p>
@@ -64,7 +51,7 @@ Narrows the blankslate container to not occupy the entire available width.
 
 ```html live
 <div class="blankslate blankslate-narrow">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3" />
+  <img src="https://ghicons.github.com/assets/images/blue/png/Pull%20request.png" alt="" class="mb-3" />
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
   <button class="btn btn-primary my-3" type="button">New pull request</button>
@@ -78,7 +65,7 @@ Significantly increases the vertical padding.
 
 ```html live
 <div class="blankslate blankslate-spacious">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3" />
+  <img src="https://ghicons.github.com/assets/images/blue/png/Pull%20request.png" alt="" class="mb-3" />
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
   <button class="btn btn-primary my-3" type="button">New pull request</button>
@@ -92,7 +79,7 @@ Increases the size of the text in the blankslate
 
 ```html live
 <div class="blankslate blankslate-large">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3" />
+  <img src="https://ghicons.github.com/assets/images/blue/png/Pull%20request.png" alt="" class="mb-3" />
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
   <button class="btn btn-primary my-3" type="button">New pull request</button>
@@ -107,7 +94,7 @@ To add a border, wrap the blankstate component with the [Box component](/compone
 ```html live
 <div class="Box">
   <div class="blankslate">
-    <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3" />
+    <img src="https://ghicons.github.com/assets/images/blue/png/Pull%20request.png" alt="" class="mb-3" />
     <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
     <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
     <button class="btn btn-primary my-3" type="button">New pull request</button>
@@ -123,7 +110,7 @@ Removes the `border-radius` on the top corners.
 ```html live
 <div class="Box rounded-top-0">
   <div class="blankslate">
-    <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3" />
+    <img src="https://ghicons.github.com/assets/images/blue/png/Pull%20request.png" alt="" class="mb-3" />
     <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
     <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
     <button class="btn btn-primary my-3" type="button">New pull request</button>

--- a/docs/content/components/blankslate.md
+++ b/docs/content/components/blankslate.md
@@ -14,7 +14,7 @@ Wrap some content in the outer `.blankslate` wrapper to give it the blankslate a
 
 ```html live
 <div class="blankslate">
-  <img src="https://ghicons.github.com/assets/images/light/Pull%20Request.png" alt="" class="mb-3" />
+  <img src="https://ghicons.github.com/assets/images/blue/png/Pull%20request.png" alt="" class="mb-3" />
   <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
   <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
   <button class="btn btn-primary my-3" type="button">New pull request</button>

--- a/docs/content/components/blankslate.md
+++ b/docs/content/components/blankslate.md
@@ -14,30 +14,35 @@ Wrap some content in the outer `.blankslate` wrapper to give it the blankslate a
 
 ```html live
 <div class="blankslate">
-  <img src="https://ghicons.github.com/assets/images/blue/png/Pull%20request.png" alt="" class="mb-3" />
-  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
-  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
-  <button class="btn btn-primary my-3" type="button">New pull request</button>
-  <p><button class="btn-link" type="button">Learn more</button></p>
+  <h3 class="mb-1">This is a blank slate</h3>
+  <p>Use it to provide information when no dynamic content exists.</p>
 </div>
 ```
 
 ## With Octicons
 
-When it helps the message, include (relevant) icons in your blank slate. Add `.blankslate-icon` to any `.mega-octicon`s as the first elements in the blankslate, like so.
+When it helps the message, include (relevant) icons in your blank slate. Add the `.blankslate-icon` class to give icons the proper styling.
 
 ```html live
 <div class="blankslate">
-  <!-- <%= octicon "git-commit", :height = 32, :class => "blankslate-icon" %> -->
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" class="octicon octicon-git-commit blankslate-icon" aria-hidden="true"><path fill-rule="evenodd" d="M10.5 7.75a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zm1.43.75a4.002 4.002 0 01-7.86 0H.75a.75.75 0 110-1.5h3.32a4.001 4.001 0 017.86 0h3.32a.75.75 0 110 1.5h-3.32z"></path></svg>
-  <!-- <%= octicon "tag", :height = 32, :class => "blankslate-icon" %> -->
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" class="octicon octicon-tag blankslate-icon" aria-hidden="true"><path fill-rule="evenodd" d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z"></path></svg>
-  <!-- <%= octicon "git-branch", :height = 32, :class => "blankslate-icon" %> -->
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" class="octicon octicon-git-branch blankslate-icon" aria-hidden="true">
-<path fill-rule="evenodd" d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V6A2.5 2.5 0 0110 8.5H6a1 1 0 00-1 1v1.128a2.251 2.251 0 11-1.5 0V5.372a2.25 2.25 0 111.5 0v1.836A2.492 2.492 0 016 7h4a1 1 0 001-1v-.628A2.25 2.25 0 019.5 3.25zM4.25 12a.75.75 0 100 1.5.75.75 0 000-1.5zM3.5 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0z"></path>
-  </svg>
+  <!-- <%= octicon "octoface", :height = 24, :class => "blankslate-icon" %> -->
+  <svg class="octicon octicon-octoface blankslate-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M7.75 11c-.69 0-1.25.56-1.25 1.25v1.5a1.25 1.25 0 102.5 0v-1.5C9 11.56 8.44 11 7.75 11zm1.27 4.5a.469.469 0 01.48-.5h5a.47.47 0 01.48.5c-.116 1.316-.759 2.5-2.98 2.5s-2.864-1.184-2.98-2.5zm7.23-4.5c-.69 0-1.25.56-1.25 1.25v1.5a1.25 1.25 0 102.5 0v-1.5c0-.69-.56-1.25-1.25-1.25z"></path><path fill-rule="evenodd" d="M21.255 3.82a1.725 1.725 0 00-2.141-1.195c-.557.16-1.406.44-2.264.866-.78.386-1.647.93-2.293 1.677A18.442 18.442 0 0012 5c-.93 0-1.784.059-2.569.17-.645-.74-1.505-1.28-2.28-1.664a13.876 13.876 0 00-2.265-.866 1.725 1.725 0 00-2.141 1.196 23.645 23.645 0 00-.69 3.292c-.125.97-.191 2.07-.066 3.112C1.254 11.882 1 13.734 1 15.527 1 19.915 3.13 23 12 23c8.87 0 11-3.053 11-7.473 0-1.794-.255-3.647-.99-5.29.127-1.046.06-2.15-.066-3.125a23.652 23.652 0 00-.689-3.292zM20.5 14c.5 3.5-1.5 6.5-8.5 6.5s-9-3-8.5-6.5c.583-4 3-6 8.5-6s7.928 2 8.5 6z"></path></svg>
   <h3>This is a blank slate</h3>
   <p>Use it to provide information when no dynamic content exists.</p>
+</div>
+```
+
+## With graphic, button and link
+
+Add a graphic, button and/or link to add additional information and provide users a way to add content to this page.
+
+```html live
+<div class="blankslate">
+  <img src="https://ghicons.github.com/assets/images/blue/png/Pull%20request.png" alt="" class="mb-3" />
+  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
+  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
 </div>
 ```
 
@@ -47,7 +52,7 @@ Add an additional optional class to the `.blankslate` to change its appearance.
 
 ### Narrow
 
-Narrows the blankslate container to not occupy the entire available width.
+`.blankslate-narrow` narrows the blankslate container to not occupy the entire available width.
 
 ```html live
 <div class="blankslate blankslate-narrow">
@@ -59,9 +64,23 @@ Narrows the blankslate container to not occupy the entire available width.
 </div>
 ```
 
+### Large
+
+`.blankslate-large` increases the size of the text in the blankslate
+
+```html live
+<div class="blankslate blankslate-large">
+  <img src="https://ghicons.github.com/assets/images/blue/png/Pull%20request.png" alt="" class="mb-3" />
+  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
+  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
+  <button class="btn btn-primary my-3" type="button">New pull request</button>
+  <p><button class="btn-link" type="button">Learn more</button></p>
+</div>
+```
+
 ### Spacious
 
-Significantly increases the vertical padding.
+`.blankslate-spacious` significantly increases the vertical padding.
 
 ```html live
 <div class="blankslate blankslate-spacious">
@@ -73,19 +92,7 @@ Significantly increases the vertical padding.
 </div>
 ```
 
-### Large
-
-Increases the size of the text in the blankslate
-
-```html live
-<div class="blankslate blankslate-large">
-  <img src="https://ghicons.github.com/assets/images/blue/png/Pull%20request.png" alt="" class="mb-3" />
-  <h3 class="mb-1">You don’t seem to have any pull requests.</h3>
-  <p>Pull requests help you discuss potential changes before they are merged into the base branch.</p>
-  <button class="btn btn-primary my-3" type="button">New pull request</button>
-  <p><button class="btn-link" type="button">Learn more</button></p>
-</div>
-```
+**Note**: It's possible to combine variations. Large and spacious (`blankslate blankslate-large blankslate-spacious`) is often used toghether. 
 
 ### Add border
 


### PR DESCRIPTION
This fixes broken links to image from GH icons and also updates to use new octicons

**Current**
![Screenshot of our blankslate with a missing pull request icon](https://user-images.githubusercontent.com/10384315/92977596-41f7d000-f442-11ea-8217-57e39a3cae16.png)

![Screenshot of our blankslate with old octicons](https://user-images.githubusercontent.com/10384315/92977687-82efe480-f442-11ea-818f-de5e9d7211b4.png)

