### PR TITLE
Re-enable stylelint in CI workflow on color modes branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
           node-version: 11
       - name: install
         run: npm install
-      # - name: lint
-      #   run: script/lint-ci
+      - name: lint
+        run: script/lint-ci
       - name: test
         run: npm test
       - name: prepublish

--- a/package-lock.json
+++ b/package-lock.json
@@ -9114,9 +9114,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.570",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.570.tgz",
-      "integrity": "sha512-Y6OCoVQgFQBP5py6A/06+yWxUZHDlNr/gNDGatjH8AZqXl8X0tE4LfjLJsXGz/JmWJz8a6K7bR1k+QzZ+k//fg==",
+      "version": "1.3.571",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.571.tgz",
+      "integrity": "sha512-UYEQ2Gtc50kqmyOmOVtj6Oqi38lm5yRJY3pLuWt6UIot0No1L09uu6Ja6/1XKwmz/p0eJFZTUZi+khd1PV1hHA==",
       "dev": true
     },
     "element-resize-detector": {
@@ -23843,9 +23843,9 @@
       }
     },
     "stylelint-config-primer": {
-      "version": "0.0.0-7629056",
-      "resolved": "https://registry.npmjs.org/stylelint-config-primer/-/stylelint-config-primer-0.0.0-7629056.tgz",
-      "integrity": "sha512-am6o66GfENclYun2cK2G34o24ZtIgmfBq9bTwsMhzPNuofJnu1RMk6SKlnAwQEt/Y836A/Zn8PvEs21Qo88IFg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-primer/-/stylelint-config-primer-9.1.0.tgz",
+      "integrity": "sha512-pFzUbvwJhmYVIdPJZQv+Eoc06uH/cVNcE2Iu56+TYnKG5Tr2DA39rGD4PzkpME2KJApq9cuYzFqCU0bgloJlDQ==",
       "dev": true,
       "requires": {
         "anymatch": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6801,14 +6801,23 @@
       }
     },
     "browserslist": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-      "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.4.tgz",
+      "integrity": "sha512-7FOuawafVdEwa5Jv4nzeik/PepAjVte6HmVGHsjt2bC237jeL9QlcTBDF3PnHEvcC6uHwLGYPwZHNZMB7wWAnw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000955",
-        "electron-to-chromium": "^1.3.122",
-        "node-releases": "^1.1.13"
+        "caniuse-lite": "^1.0.30001135",
+        "electron-to-chromium": "^1.3.570",
+        "escalade": "^3.1.0",
+        "node-releases": "^1.1.61"
+      },
+      "dependencies": {
+        "escalade": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
+          "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
+          "dev": true
+        }
       }
     },
     "btoa-lite": {
@@ -6998,9 +7007,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000956",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000956.tgz",
-      "integrity": "sha512-3o7L6XkQ01Oney+x2fS5UVbQXJ7QQkYxrSfaLmFlgQabcKfploI8bhS2nmQ8Unh5MpMONAMeDEdEXG9t9AK6uA==",
+      "version": "1.0.30001135",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz",
+      "integrity": "sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ==",
       "dev": true
     },
     "cardinal": {
@@ -9105,9 +9114,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.122",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.122.tgz",
-      "integrity": "sha512-3RKoIyCN4DhP2dsmleuFvpJAIDOseWH88wFYBzb22CSwoFDSWRc4UAMfrtc9h8nBdJjTNIN3rogChgOy6eFInw==",
+      "version": "1.3.570",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.570.tgz",
+      "integrity": "sha512-Y6OCoVQgFQBP5py6A/06+yWxUZHDlNr/gNDGatjH8AZqXl8X0tE4LfjLJsXGz/JmWJz8a6K7bR1k+QzZ+k//fg==",
       "dev": true
     },
     "element-resize-detector": {
@@ -14656,13 +14665,10 @@
       }
     },
     "node-releases": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.13.tgz",
-      "integrity": "sha512-fKZGviSXR6YvVPyc011NHuJDSD8gFQvLPmc2d2V3BS4gr52ycyQ1Xzs7a8B+Ax3Ni/W+5h1h4SqmzeoA8WZRmA==",
-      "dev": true,
-      "requires": {
-        "semver": "^5.3.0"
-      }
+      "version": "1.1.61",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
+      "integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
+      "dev": true
     },
     "node-sass": {
       "version": "4.12.0",
@@ -23837,9 +23843,9 @@
       }
     },
     "stylelint-config-primer": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-primer/-/stylelint-config-primer-9.0.0.tgz",
-      "integrity": "sha512-jM/D1qB33wMb6Q19iWHDfowB9Sb4LwbR4wtCWz9qeZIapGJ1nclVxJ63HgDherzXl1Im2pXa69RdOX51trrR0Q==",
+      "version": "0.0.0-7629056",
+      "resolved": "https://registry.npmjs.org/stylelint-config-primer/-/stylelint-config-primer-0.0.0-7629056.tgz",
+      "integrity": "sha512-am6o66GfENclYun2cK2G34o24ZtIgmfBq9bTwsMhzPNuofJnu1RMk6SKlnAwQEt/Y836A/Zn8PvEs21Qo88IFg==",
       "dev": true,
       "requires": {
         "anymatch": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "style-loader": "^0.18.2",
     "styled-components": "4.1.2",
     "stylelint": "^10.1.0",
-    "stylelint-config-primer": "^9.0.0",
+    "stylelint-config-primer": "0.0.0-7629056",
     "stylelint-disable": "^0.1.5",
     "stylelint-only": "^1.0.1",
     "stylelint-scss": "^3.12.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "style-loader": "^0.18.2",
     "styled-components": "4.1.2",
     "stylelint": "^10.1.0",
-    "stylelint-config-primer": "0.0.0-7629056",
+    "stylelint-config-primer": "^9.1.0",
     "stylelint-disable": "^0.1.5",
     "stylelint-only": "^1.0.1",
     "stylelint-scss": "^3.12.0",

--- a/src/alerts/flash.scss
+++ b/src/alerts/flash.scss
@@ -65,9 +65,7 @@
 //
 
 .flash {
-  // stylelint-disable-next-line primer/colors
   background-color: var(--color-alert-bg);
-  // stylelint-disable-next-line primer/borders
   border-color: var(--color-alert-border);
 
   .octicon {
@@ -77,9 +75,7 @@
 }
 
 .flash-warn {
-  // stylelint-disable-next-line primer/colors
   background-color: var(--color-alert-warn-bg);
-  // stylelint-disable-next-line primer/borders
   border-color: var(--color-alert-warn-border);
 
   .octicon {
@@ -89,9 +85,7 @@
 }
 
 .flash-error {
-  // stylelint-disable-next-line primer/colors
   background-color: var(--color-alert-error-bg);
-  // stylelint-disable-next-line primer/borders
   border-color: var(--color-alert-error-border);
 
   .octicon {
@@ -102,7 +96,6 @@
 
 .flash-success {
   background-color: var(--color-alert-success-bg);
-  // stylelint-disable-next-line primer/borders
   border-color: var(--color-alert-success-border);
 
   .octicon {
@@ -140,6 +133,5 @@
   // stylelint-disable-next-line primer/spacing
   margin-bottom: 0.8em;
   font-weight: $font-weight-bold;
-  // stylelint-disable-next-line primer/colors
   background-color: var(--color-alert-warn-bg);
 }

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -10,7 +10,6 @@
   list-style: none;
   background: var(--color-bg-canvas);
   border-radius: $border-radius;
-  // stylelint-disable-next-line primer/box-shadow
   box-shadow: inset 0 0 0 1px var(--color-border-primary), var(--color-shadow-medium);
 }
 

--- a/src/avatars/avatar-parent-child.scss
+++ b/src/avatars/avatar-parent-child.scss
@@ -13,6 +13,5 @@
   background-color: var(--color-bg-canvas); // For transparent backgrounds
   // stylelint-disable-next-line primer/borders
   border-radius: $border-radius-1;
-  // stylelint-disable-next-line primer/box-shadow
   box-shadow: var(--color-avatar-child-shadow);
 }

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -21,7 +21,7 @@ body {
 }
 
 a {
-  color: var(--color-link-primary);
+  color: var(--color-link-primary); // stylelint-disable-line primer/colors
   text-decoration: none;
 
   &:hover {

--- a/src/base/modes.scss
+++ b/src/base/modes.scss
@@ -15,6 +15,6 @@
 // Enables nesting of different color modes
 
 [data-color-mode] {
-	color: var(--color-text-primary);
-	background-color: var(--color-bg-canvas);
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-canvas);
 }

--- a/src/box/box.scss
+++ b/src/box/box.scss
@@ -268,7 +268,6 @@
 // Box row highlight themes
 
 .Box-row--yellow {
-  // stylelint-disable-next-line primer/colors
   background-color: var(--color-bg-warning);
 }
 

--- a/src/box/box.scss
+++ b/src/box/box.scss
@@ -4,8 +4,8 @@
 .Box {
   background-color: var(--color-bg-canvas);
   border-color: var(--color-border-primary);
-  border-width: $border-width;
   border-style: $border-style;
+  border-width: $border-width;
   border-radius: $border-radius;
 }
 
@@ -37,7 +37,6 @@
   .Box-row {
     padding: $spacer-2 $spacer-3;
   }
-
 }
 
 .Box--spacious {
@@ -69,7 +68,6 @@
   .Box-row {
     padding: $spacer-4;
   }
-
 }
 
 .Box-header {
@@ -108,9 +106,9 @@
   // stylelint-disable-next-line primer/spacing
   margin-top: -1px;
   list-style-type: none; // To account for applying Box component to a list
-  border-top-width: $border-width;
-  border-top-style: $border-style;
   border-top-color: var(--color-border-primary);
+  border-top-style: $border-style;
+  border-top-width: $border-width;
 
   &:first-of-type {
     border-top-left-radius: $border-radius;
@@ -158,7 +156,6 @@
         opacity: 0;
       }
     }
-
   }
 }
 
@@ -191,7 +188,6 @@
 // and links are dark-gray with blue hover on desktop.
 .Box-row-link {
   @include breakpoint(md) {
-
     color: var(--color-text-primary);
     text-decoration: none;
 
@@ -199,7 +195,6 @@
       color: var(--color-text-link-primary);
       text-decoration: none;
     }
-
   }
 }
 
@@ -213,9 +208,9 @@
   padding: $spacer-3;
   // stylelint-disable-next-line primer/spacing
   margin-top: -1px; // prevents double border when used with .Box-body
+  border-top-color: var(--color-border-primary);
   border-top-style: $border-style;
   border-top-width: $border-width;
-  border-top-color: var(--color-border-primary);
 }
 
 // Option for a box with scrolling content
@@ -287,7 +282,6 @@
 
 //Box with btn-octicon
 .Box-btn-octicon {
-
   // Increase specificity when btn-octicon is used because comes after .Box in the cascade
   &.btn-octicon {
     padding: $spacer-3 $spacer-3;

--- a/src/branch-name/branch-name.scss
+++ b/src/branch-name/branch-name.scss
@@ -5,9 +5,7 @@
   // stylelint-disable-next-line primer/spacing
   padding: 2px 6px;
   font: 12px $mono-font;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-branch-name-text);
-  // stylelint-disable-next-line primer/colors
   background-color: var(--color-branch-name-bg);
   border-radius: $border-radius;
 

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -54,7 +54,6 @@
     color: inherit;
     text-shadow: none;
     vertical-align: top;
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-btn-counter-bg);
   }
 
@@ -91,7 +90,6 @@
   &:disabled,
   &.disabled,
   &[aria-disabled=true] {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-text-disabled);
     background-color: var(--color-btn-bg);
     border-color: var(--color-btn-border);
@@ -131,7 +129,6 @@
   &:disabled,
   &.disabled,
   &[aria-disabled=true] {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-btn-primary-disabled-text);
     background-color: var(--color-btn-primary-bg-disabled);
     border-color: var(--color-btn-primary-border-disabled);
@@ -146,7 +143,6 @@
 
   .Counter {
     color: inherit;
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-btn-primary-counter-bg);
   }
 

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -122,7 +122,6 @@
   &.selected,
   &[aria-selected=true] {
     background-color: var(--color-btn-primary-bg-active);
-    // stylelint-disable-next-line primer/box-shadow
     box-shadow: var(--color-btn-primary-shadow-selected);
   }
 
@@ -137,7 +136,6 @@
 
   &:focus,
   &.focus {
-    // stylelint-disable-next-line primer/box-shadow
     box-shadow: var(--color-btn-primary-disabled-shadow);
   }
 

--- a/src/buttons/misc.scss
+++ b/src/buttons/misc.scss
@@ -24,7 +24,6 @@
   &[aria-disabled=true] {
     &,
     &:hover {
-      // stylelint-disable-next-line primer/colors
       color: var(--color-text-disabled);
       cursor: default;
     }
@@ -76,11 +75,9 @@
 
   &.disabled,
   &[aria-disabled=true] {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-text-disabled);
     cursor: default;
 
-    // stylelint-disable-next-line primer/colors
     &:hover { color: var(--color-text-disabled); }
   }
 }
@@ -129,7 +126,6 @@
   color: var(--color-scale-grey-7);
   text-decoration: none;
   vertical-align: middle;
-  // stylelint-disable-next-line primer/colors
   background: var(--color-hidden-text-expander-bg);
   border: 0;
   // stylelint-disable-next-line primer/borders
@@ -137,13 +133,11 @@
 
   &:hover {
     text-decoration: none;
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-hidden-text-expander-bg-hover);
   }
 
   &:active {
     color: var(--color-text-inverse);
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-bg-info-inverse);
   }
 }

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -41,7 +41,6 @@ label {
   }
 
   &[disabled] {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-text-disabled);
     // stylelint-disable-next-line primer/colors
     background-color: #f3f4f6; // custom gray
@@ -234,9 +233,7 @@ input::-webkit-inner-spin-button {
   // stylelint-disable-next-line primer/spacing
   margin: 10px 0;
   font-size: $h5-size;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-text-warning);
-  // stylelint-disable-next-line primer/colors
   background: var(--color-bg-warning);
   border: $border-width $border-style var(--color-border-warning);
   border-radius: $border-radius;

--- a/src/forms/form-group.scss
+++ b/src/forms/form-group.scss
@@ -192,7 +192,6 @@
     .success {
       // stylelint-disable-next-line primer/colors
       color: var(--color-scale-green-9);
-      // stylelint-disable-next-line primer/colors
       background-color: var(--color-bg-success);
       border-color: var(--color-border-success);
 
@@ -214,7 +213,6 @@
     }
 
     .warning {
-      // stylelint-disable-next-line primer/colors
       background-color: var(--color-bg-warning);
       border-color: var(--color-border-warning);
 

--- a/src/forms/form-validation.scss
+++ b/src/forms/form-validation.scss
@@ -129,7 +129,6 @@ dl.form-group > dd, // TODO: Deprecate
   line-height: 16px;
   color: var(--color-text-secondary);
   background-color: var(--color-bg-tertiary);
-  // stylelint-disable-next-line primer/borders
   border: $border-width $border-style var(--color-drag-and-drop-border);
   border-top: 0;
   border-bottom-right-radius: $border-radius;
@@ -244,7 +243,6 @@ dl.form-group > dd, // TODO: Deprecate
     }
 
     .drag-and-drop {
-      // stylelint-disable-next-line primer/borders
       border-color: var(--color-upload-enabled-border-focused);
     }
   }
@@ -271,7 +269,6 @@ dl.form-group > dd, // TODO: Deprecate
   }
 
   .comment {
-    // stylelint-disable-next-line primer/borders
     border: $border-width $border-style var(--color-previewable-comment-form-border);
   }
 

--- a/src/forms/form-validation.scss
+++ b/src/forms/form-validation.scss
@@ -72,7 +72,6 @@ dl.form-group > dd, // TODO: Deprecate
 
   .octicon-check {
     display: inline-block;
-    // stylelint-disable-next-line primer/colors
     color: var(--color-text-success);
     fill: var(--color-icon-success);
   }

--- a/src/header/header.scss
+++ b/src/header/header.scss
@@ -4,7 +4,6 @@
   padding: $spacer-3;
   font-size: $h5-size;
   line-height: $lh-default;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-header-text);
   background-color: var(--color-bg-canvas-inverse);
   align-items: center;
@@ -30,7 +29,6 @@
 
   &:hover,
   &:focus {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-header-text);
     text-decoration: none;
   }

--- a/src/labels/counters.scss
+++ b/src/labels/counters.scss
@@ -10,7 +10,6 @@
   line-height: $size-2 - 2px; // remove borders
   color: var(--color-text-primary);
   text-align: center;
-  // stylelint-disable-next-line primer/colors
   background-color: var(--color-counter-bg);
   border: $border-width $border-style transparent; // Support Firfox custom colors
   // stylelint-disable-next-line primer/borders

--- a/src/labels/labels.scss
+++ b/src/labels/labels.scss
@@ -34,60 +34,49 @@
 
 .Label--outline, // TODO: Deprecate? It's now the default
 .Label--gray {
-  color: var(--color-scale-gray-6);
-  border-color: var(--color-scale-gray-2);
+  color: var(--color-scale-gray-6); // stylelint-disable-line primer/colors
+  border-color: var(--color-scale-gray-2); // stylelint-disable-line primer/borders
 }
 
 .Label--gray-darker {
-  color: var(--color-scale-gray-9);
-  // stylelint-disable-next-line primer/borders
-  border-color: var(--color-scale-gray-5);
+  color: var(--color-scale-gray-9); // stylelint-disable-line primer/colors
+  border-color: var(--color-scale-gray-5); // stylelint-disable-line primer/borders
 }
 
 // Colors
 
 .Label--yellow {
-  // stylelint-disable-next-line primer/colors
-  color: var(--color-scale-yellow-9);
-  // stylelint-disable-next-line primer/borders
-  border-color: var(--color-scale-yellow-6);
+  color: var(--color-scale-yellow-9); // stylelint-disable-line primer/colors
+  border-color: var(--color-scale-yellow-6); // stylelint-disable-line primer/borders
 }
 
 .Label--orange {
-  // stylelint-disable-next-line primer/colors
-  color: var(--color-scale-orange-8);
-  // stylelint-disable-next-line primer/borders
-  border-color: var(--color-scale-orange-5);
+  color: var(--color-scale-orange-8); // stylelint-disable-line primer/colors
+  border-color: var(--color-scale-orange-5); // stylelint-disable-line primer/borders
 }
 
 .Label--red {
-  color: var(--color-scale-red-5);
-  // stylelint-disable-next-line primer/borders
-  border-color: var(--color-scale-red-6);
+  color: var(--color-scale-red-5); // stylelint-disable-line primer/colors
+  border-color: var(--color-scale-red-6); // stylelint-disable-line primer/borders
 }
 
 .Label--outline-green, // TODO: Deprecate
 .Label--green {
-  // stylelint-disable-next-line primer/colors
-  color: var(--color-scale-green-6);
-  // stylelint-disable-next-line primer/borders
-  border-color: var(--color-scale-green-5);
+  color: var(--color-scale-green-6); // stylelint-disable-line primer/colors
+  border-color: var(--color-scale-green-5); // stylelint-disable-line primer/borders
 }
 
 .Label--blue {
-  color: var(--color-scale-blue-5);
-  border-color: var(--color-scale-blue-5);
+  color: var(--color-scale-blue-5); // stylelint-disable-line primer/colors
+  border-color: var(--color-scale-blue-5); // stylelint-disable-line primer/borders
 }
 
 .Label--purple {
-  color: var(--color-scale-purple-5);
-  // stylelint-disable-next-line primer/borders
-  border-color: var(--color-scale-purple-4);
+  color: var(--color-scale-purple-5); // stylelint-disable-line primer/colors
+  border-color: var(--color-scale-purple-4); // stylelint-disable-line primer/borders
 }
 
 .Label--pink {
-  // stylelint-disable-next-line primer/colors
-  color: var(--color-scale-pink-6);
-  // stylelint-disable-next-line primer/borders
-  border-color: var(--color-scale-pink-4);
+  color: var(--color-scale-pink-6); // stylelint-disable-line primer/colors
+  border-color: var(--color-scale-pink-4); // stylelint-disable-line primer/borders
 }

--- a/src/labels/states.scss
+++ b/src/labels/states.scss
@@ -29,15 +29,15 @@
 }
 
 .State--green {
-  background-color: var(--color-scale-green-5);
+  background-color: var(--color-scale-green-5); // stylelint-disable-line primer/colors
 }
 
 .State--red {
-  background-color: var(--color-scale-red-5);
+  background-color: var(--color-scale-red-5); // stylelint-disable-line primer/colors
 }
 
 .State--purple {
-  background-color: var(--color-scale-purple-5);
+  background-color: var(--color-scale-purple-5); // stylelint-disable-line primer/colors
 }
 
 // Small

--- a/src/markdown/code.scss
+++ b/src/markdown/code.scss
@@ -8,7 +8,6 @@
     margin: 0;
     // stylelint-disable-next-line primer/typography
     font-size: 85%;
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-markdown-code-bg);
     border-radius: $border-radius;
 

--- a/src/markdown/images.scss
+++ b/src/markdown/images.scss
@@ -44,7 +44,6 @@
       // stylelint-disable-next-line primer/spacing
       margin: 13px 0 0;
       overflow: hidden;
-      // stylelint-disable-next-line primer/borders
       border: $border-width $border-style var(--color-markdown-frame-border);
     }
 

--- a/src/markdown/tables.scss
+++ b/src/markdown/tables.scss
@@ -15,13 +15,11 @@
     td {
       // stylelint-disable-next-line primer/spacing
       padding: 6px 13px;
-      // stylelint-disable-next-line primer/borders
       border: $border-width $border-style var(--color-markdown-table-border);
     }
 
     tr {
       background-color: var(--color-bg-primary);
-      // stylelint-disable-next-line primer/borders
       border-top: $border-width $border-style var(--color-markdown-table-tr-border);
 
       &:nth-child(2n) {

--- a/src/navigation/filter-list.scss
+++ b/src/navigation/filter-list.scss
@@ -59,7 +59,6 @@
     bottom: 2px;
     z-index: -1;
     display: inline-block;
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-filter-item-bar-bg);
   }
 }

--- a/src/navigation/menu.scss
+++ b/src/navigation/menu.scss
@@ -36,7 +36,6 @@
   &:focus,
   &:hover {
     text-decoration: none;
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-bg-secondary);
     outline: none;
   }

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -46,7 +46,6 @@
 .SideNav-item:hover,
 .SideNav-item:focus {
   text-decoration: none;
-  // stylelint-disable-next-line primer/colors
   background-color: var(--color-bg-secondary);
   outline: none;
 }

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -432,7 +432,6 @@ $SelectMenu-max-height: 480px !default;
   }
 
   body:not(.intent-mouse) .SelectMenu-tab:focus {
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-select-menu-tap-focus-bg);
   }
 

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -64,7 +64,6 @@ $SelectMenu-max-height: 480px !default;
   background-color: var(--color-bg-primary);
   // stylelint-disable-next-line primer/borders
   border-radius: $border-radius * 2;
-  // stylelint-disable-next-line primer/box-shadow
   box-shadow: var(--color-select-menu-shadow);
   animation: SelectMenu-modal-animation 0.12s cubic-bezier(0, 0.1, 0.1, 1) backwards;
 

--- a/src/timeline/timeline-item.scss
+++ b/src/timeline/timeline-item.scss
@@ -18,9 +18,7 @@
   }
 
   &:target .TimelineItem-badge {
-    // stylelint-disable-next-line primer/borders
     border-color: var(--color-timeline-target-badge-border);
-    // stylelint-disable-next-line primer/box-shadow
     box-shadow: 0 0 0.2em var(--color-timeline-target-badge-shadow);
   }
 }

--- a/src/timeline/timeline-item.scss
+++ b/src/timeline/timeline-item.scss
@@ -33,10 +33,8 @@
   height: $spacer-5;
   margin-right: $spacer-2;
   margin-left: -$spacer-3 + 1;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-timeline-text);
   align-items: center;
-  // stylelint-disable-next-line primer/colors
   background-color: var(--color-timeline-badge-bg);
   // stylelint-disable-next-line primer/borders
   border: 2px $border-style var(--color-bg-canvas);
@@ -49,7 +47,6 @@
   min-width: 0;
   max-width: 100%;
   margin-top: $spacer-1;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-timeline-text);
   flex: auto;
 }

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -6,7 +6,6 @@
   color: var(--color-text-primary);
   background-color: var(--color-bg-canvas);
   border-radius: $border-radius;
-  // stylelint-disable-next-line primer/box-shadow
   box-shadow: inset 0 0 0 1px var(--color-border-primary), var(--color-shadow-large);
 
   @include breakpoint(sm) {

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -57,7 +57,6 @@
 
 .Toast--warning .Toast-icon {
   color: var(--color-text-primary);
-  // stylelint-disable-next-line primer/colors
   background-color: var(--color-bg-warning-inverse);
 }
 
@@ -66,7 +65,6 @@
 }
 
 .Toast--loading .Toast-icon {
-  // stylelint-disable-next-line primer/colors
   background-color: var(--color-toast-ic-bg-loading);
 }
 

--- a/src/tooltips/tooltips.scss
+++ b/src/tooltips/tooltips.scss
@@ -32,7 +32,7 @@
   display: none;
   width: 0;
   height: 0;
-  color: var(--color-bg-canvas-inverse);
+  color: var(--color-bg-canvas-inverse); // stylelint-disable-line primer/colors
   pointer-events: none;
   content: "";
   // stylelint-disable-next-line primer/borders

--- a/src/utilities/borders.scss
+++ b/src/utilities/borders.scss
@@ -1,5 +1,5 @@
 // Core border utilities
-// stylelint-disable block-opening-brace-space-before, comment-empty-line-before
+// stylelint-disable block-opening-brace-space-before
 
 /* Add a gray border to the left and right */
 .border-x {

--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -1,4 +1,4 @@
-// stylelint-disable block-opening-brace-space-before, comment-empty-line-before
+// stylelint-disable block-opening-brace-space-before
 
 // TODO: Should these utility classes get prefixed with `color-` to match the variables?
 

--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -17,13 +17,13 @@
 .text-warning         { color: var(--color-text-warning) !important; }
 
 // Icon colors
-.icon-primary   { color: var(--color-icon-primary) !important; }
-.icon-secondary { color: var(--color-icon-secondary) !important; }
-.icon-tertiary  { color: var(--color-icon-tertiary) !important; }
-.icon-info      { color: var(--color-icon-info) !important; }
-.icon-danger    { color: var(--color-icon-danger) !important; }
-.icon-success   { color: var(--color-icon-success) !important; }
-.icon-warning   { color: var(--color-icon-warning) !important; }
+.icon-primary   { color: var(--color-icon-primary) !important; } // stylelint-disable-line primer/colors
+.icon-secondary { color: var(--color-icon-secondary) !important; } // stylelint-disable-line primer/colors
+.icon-tertiary  { color: var(--color-icon-tertiary) !important; } // stylelint-disable-line primer/colors
+.icon-info      { color: var(--color-icon-info) !important; } // stylelint-disable-line primer/colors
+.icon-danger    { color: var(--color-icon-danger) !important; } // stylelint-disable-line primer/colors
+.icon-success   { color: var(--color-icon-success) !important; } // stylelint-disable-line primer/colors
+.icon-warning   { color: var(--color-icon-warning) !important; } // stylelint-disable-line primer/colors
 
 // Border colors
 .border-primary         { border-color: var(--color-border-primary) !important; }
@@ -118,10 +118,10 @@
 .border-white-fade  { border-color: $border-white-fade !important; }
 
 .border-white-fade-15 { border-color: $border-white-fade !important; }
-.border-white-fade-30 { border-color: $white-fade-30 !important; }
-.border-white-fade-50 { border-color: $white-fade-50 !important; }
-.border-white-fade-70 { border-color: $white-fade-70 !important; }
-.border-white-fade-85 { border-color: $white-fade-85 !important; }
+.border-white-fade-30 { border-color: $white-fade-30 !important; } // stylelint-disable-line primer/borders
+.border-white-fade-50 { border-color: $white-fade-50 !important; } // stylelint-disable-line primer/borders
+.border-white-fade-70 { border-color: $white-fade-70 !important; } // stylelint-disable-line primer/borders
+.border-white-fade-85 { border-color: $white-fade-85 !important; } // stylelint-disable-line primer/borders
 
 // Link colors
 // Sets the links color to $text-gray and $text-blue on hover


### PR DESCRIPTION
**Blocked on https://github.com/primer/stylelint-config-primer/pull/62**

## Problem

In the [color modes branch](https://github.com/primer/css/pull/1131), we had to disable linting in our CI workflow because our [stylelint config](https://github.com/primer/stylelint-config-primer) was flagging all usages of CSS color variables as linting errors. This was happening because our stylelint config didn't recognize CSS color variables as valid values (https://github.com/primer/css/issues/1176). 

## Solution

https://github.com/primer/stylelint-config-primer/pull/62 added support for CSS color variables to our stylelint config. This PR updates our version of `stylelint-config-primer` (to make use of the changes made in https://github.com/primer/stylelint-config-primer/pull/62) and re-enables the linting step of our CI workflow. It also fixes all the linting errors we missed while we had linting disabled.