### PR TITLE
Set up primer/no-undefined-vars stylelint rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6801,13 +6801,13 @@
       }
     },
     "browserslist": {
-      "version": "4.14.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.4.tgz",
-      "integrity": "sha512-7FOuawafVdEwa5Jv4nzeik/PepAjVte6HmVGHsjt2bC237jeL9QlcTBDF3PnHEvcC6uHwLGYPwZHNZMB7wWAnw==",
+      "version": "4.14.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.5.tgz",
+      "integrity": "sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==",
       "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001135",
-        "electron-to-chromium": "^1.3.570",
+        "electron-to-chromium": "^1.3.571",
         "escalade": "^3.1.0",
         "node-releases": "^1.1.61"
       },
@@ -7007,9 +7007,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001135",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz",
-      "integrity": "sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ==",
+      "version": "1.0.30001142",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001142.tgz",
+      "integrity": "sha512-pDPpn9ankEpBFZXyCv2I4lh1v/ju+bqb78QfKf+w9XgDAFWBwSYPswXqprRdrgQWK0wQnpIbfwRjNHO1HWqvoQ==",
       "dev": true
     },
     "cardinal": {
@@ -9114,9 +9114,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.571",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.571.tgz",
-      "integrity": "sha512-UYEQ2Gtc50kqmyOmOVtj6Oqi38lm5yRJY3pLuWt6UIot0No1L09uu6Ja6/1XKwmz/p0eJFZTUZi+khd1PV1hHA==",
+      "version": "1.3.576",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.576.tgz",
+      "integrity": "sha512-uSEI0XZ//5ic+0NdOqlxp0liCD44ck20OAGyLMSymIWTEAtHKVJi6JM18acOnRgUgX7Q65QqnI+sNncNvIy8ew==",
       "dev": true
     },
     "element-resize-detector": {
@@ -23843,9 +23843,9 @@
       }
     },
     "stylelint-config-primer": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-primer/-/stylelint-config-primer-9.1.0.tgz",
-      "integrity": "sha512-pFzUbvwJhmYVIdPJZQv+Eoc06uH/cVNcE2Iu56+TYnKG5Tr2DA39rGD4PzkpME2KJApq9cuYzFqCU0bgloJlDQ==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-primer/-/stylelint-config-primer-9.2.1.tgz",
+      "integrity": "sha512-4tpNgAZosmONtVmWKwufdiagEsR2He4j17tn0MtX9NdtSWKfeANrJsUeEFr2WDJR+YuAOSVwytQIP55u5reSEw==",
       "dev": true,
       "requires": {
         "anymatch": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "style-loader": "^0.18.2",
     "styled-components": "4.1.2",
     "stylelint": "^10.1.0",
-    "stylelint-config-primer": "^9.1.0",
+    "stylelint-config-primer": "^9.2.1",
     "stylelint-disable": "^0.1.5",
     "stylelint-only": "^1.0.1",
     "stylelint-scss": "^3.12.0",

--- a/src/box/box.scss
+++ b/src/box/box.scss
@@ -144,7 +144,7 @@
 
     // Row dragging styles
     &.sortable-chosen {
-      background-color: var(--color-bg-primary-light);
+      background-color: var(--color-bg-primary);
     }
 
     // Makes dragging row background gray

--- a/src/box/box.scss
+++ b/src/box/box.scss
@@ -144,7 +144,7 @@
 
     // Row dragging styles
     &.sortable-chosen {
-      background-color: var(--color-bg-primary);
+      background-color: var(--color-bg-tertiary);
     }
 
     // Makes dragging row background gray

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -154,13 +154,13 @@
 // Mixin: btn-inverse-on-hover
 
 @mixin btn-inverse-on-hover($type) {
-  color: var(--color-btn-#{$type}-text);
+  color: var(--color-btn-#{$type}-text); // stylelint-disable-line primer/no-undefined-vars
   transition: none;
 
   &:hover,
   [open] > & {
     color: var(--color-text-inverse);
-    background-color: var(--color-btn-#{$type}-bg-hover);
+    background-color: var(--color-btn-#{$type}-bg-hover); // stylelint-disable-line primer/no-undefined-vars
     border-color: var(--color-btn-inverse-on-hover-border);
     box-shadow: var(--color-btn-inverse-on-hover-shadow), var(--color-btn-inverse-on-hover-shadow-inset);
 
@@ -177,31 +177,31 @@
   &.selected,
   &[aria-selected=true] {
     color: var(--color-text-inverse);
-    background-color: var(--color-btn-#{$type}-bg-active);
+    background-color: var(--color-btn-#{$type}-bg-active); // stylelint-disable-line primer/no-undefined-vars
     border-color: var(--color-btn-inverse-on-hover-border);
-    box-shadow: var(--color-btn-#{$type}-shadow);
+    box-shadow: var(--color-btn-#{$type}-shadow); // stylelint-disable-line primer/no-undefined-vars
   }
 
   &:disabled,
   &.disabled,
   &[aria-disabled=true] {
-    color: var(--color-btn-#{$type}-text-disabled);
+    color: var(--color-btn-#{$type}-text-disabled); // stylelint-disable-line primer/no-undefined-vars
     background-color: var(--color-bg-tertiary);
     border-color: var(--color-btn-border);
     box-shadow: var(--color-shadow-small), var(--color-shadow-highlight);
 
     .Counter {
-      background-color: var(--color-btn-#{$type}-counter-bg-disabled);
+      background-color: var(--color-btn-#{$type}-counter-bg-disabled); // stylelint-disable-line primer/no-undefined-vars
     }
   }
 
   &:focus {
-    box-shadow: var(--color-btn-#{$type}-shadow-focus);
+    box-shadow: var(--color-btn-#{$type}-shadow-focus); // stylelint-disable-line primer/no-undefined-vars
   }
 
   .Counter {
     color: inherit;
-    background-color: var(--color-btn-#{$type}-counter-bg);
+    background-color: var(--color-btn-#{$type}-counter-bg); // stylelint-disable-line primer/no-undefined-vars
   }
 }
 

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -154,7 +154,7 @@
 // Mixin: btn-inverse-on-hover
 
 @mixin btn-inverse-on-hover($type) {
-  color: var(--color-btn-#{$type}-text); // stylelint-disable-line primer/no-undefined-vars
+  color: var(--color-btn-#{$type}-text);
   transition: none;
 
   &:hover,

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -12,6 +12,7 @@ module.exports = {
     'primer/spacing': true,
     'primer/typography': true,
     'primer/box-shadow': true,
-    'primer-css/TODO': [true, {currentVersion, severity: 'error'}]
+    'primer-css/TODO': [true, {currentVersion, severity: 'error'}],
+    'primer/no-undefined-vars': [true, {files: 'node_modules/@primer/primitives/dist/scss/colors/*.scss'}]
   }
 }


### PR DESCRIPTION
## Problem

To enable [color modes](https://github.com/primer/css/pull/1131) in Primer CSS, we are transitioning from SCSS variables for colors to CSS variables. Using CSS variables means that the SCSS compiler will no longer fail if someone misspells a variable name.

## Solution

https://github.com/primer/stylelint-config-primer/pull/66 added a `primer/no-undefined-vars` rule to catch references to CSS variables that aren't defined. This PR updates our version of `stylelint-config-primer` (to make use of the changes made in https://github.com/primer/stylelint-config-primer/pull/66) and fixes all the new linting errors.
