### PR TITLE
mx-auto is responsive

### DIFF
--- a/docs/content/utilities/margin.md
+++ b/docs/content/utilities/margin.md
@@ -85,7 +85,7 @@ Reset margins built into typography elements or other components with `m-0`, `mt
 
 ## Responsive margins
 
-All margin utilities, except `mx-auto`, can be adjusted per [breakpoint](/objects/grid#breakpoints) using the following formula: `m[direction]-[breakpoint]-[spacer]`. Each responsive style is applied to the specified breakpoint and up.
+All margin utilities can be adjusted per [breakpoint](/objects/grid#breakpoints) using the following formula: `m[direction]-[breakpoint]-[spacer]`. Each responsive style is applied to the specified breakpoint and up.
 
 ```html live
 <div class="bg-yellow d-inline-block">


### PR DESCRIPTION
### Summary

Quick docs change, `mx-auto` is in fact responsive this was added in 96d1e4fe5456331833d449d01316a1f2e5302a1f. This removes the docs line that states it is not "margin utilities, except `mx-auto`, can be adjusted"

https://github.com/primer/css/blob/cdaaba69b53d6e57afd46b4b4b090bad4f8233f4/src/utilities/margin.scss#L44-L48
