### PR TITLE
Add missing .border-gray-darker utility

### DIFF
--- a/src/utilities/borders.scss
+++ b/src/utilities/borders.scss
@@ -103,6 +103,8 @@
 .border-gray-light  { border-color: $border-gray-light !important; }
 /* Use with .border to turn the border gray-dark */
 .border-gray-dark   { border-color: $border-gray-dark !important; }
+/* Use with .border to turn the border gray-darker */
+.border-gray-darker { border-color: $border-gray-darker !important; }
 
 /* Use with .border to turn the border rgba black 0.15 */
 .border-black-fade  { border-color: $border-black-fade !important; }


### PR DESCRIPTION
The [border color docs](https://primer.style/css/utilities/borders#border-color-utilities) mention a `.border-gray-darker` utility class, but it didn't actually exist.

/cc @primer/ds-core
