### PR TITLE
Add note that .border-gray-darker doesn't exist

### DIFF
--- a/docs/content/utilities/borders.mdx
+++ b/docs/content/utilities/borders.mdx
@@ -233,3 +233,9 @@ You can adjust border widths on all sides or each side individually with respons
   ]}
   style={{borderSpacing: '0 4px'}}
 />
+
+**Note**: The `.border-gray-darker` class is falsely shown in the list above but is not supported. If you still like to use that utility class, you can do so by adding the following to your styles:
+
+```scss
+.border-gray-darker { border-color: $border-gray-darker !important; }
+```

--- a/docs/content/utilities/borders.mdx
+++ b/docs/content/utilities/borders.mdx
@@ -233,9 +233,3 @@ You can adjust border widths on all sides or each side individually with respons
   ]}
   style={{borderSpacing: '0 4px'}}
 />
-
-**Note**: The `.border-gray-darker` class is falsely shown in the list above but is not supported. If you still like to use that utility class, you can do so by adding the following to your styles:
-
-```scss
-.border-gray-darker { border-color: $border-gray-darker !important; }
-```

--- a/docs/src/color-variables.js
+++ b/docs/src/color-variables.js
@@ -53,6 +53,7 @@ export {colors, gradientHues, palettes, getPaletteByName, variables}
 export const allColors = palettes.reduce((all, {values}) => all.concat(values), [])
 
 export const borders = Object.keys(variables)
+  // Re: border-gray-darker, see https://github.com/primer/css/pull/1192
   .filter(key => key.startsWith('border-') && !variables[key].includes('$') && key !== 'border-gray-darker')
   .sort()
   .map(key => ({

--- a/docs/src/color-variables.js
+++ b/docs/src/color-variables.js
@@ -53,7 +53,7 @@ export {colors, gradientHues, palettes, getPaletteByName, variables}
 export const allColors = palettes.reduce((all, {values}) => all.concat(values), [])
 
 export const borders = Object.keys(variables)
-  .filter(key => key.startsWith('border-') && !variables[key].includes('$'))
+  .filter(key => key.startsWith('border-') && !variables[key].includes('$') && key !== 'border-gray-darker')
   .sort()
   .map(key => ({
     variable: key,


### PR DESCRIPTION
This supersedes https://github.com/primer/css/pull/1192 and instead just adds a note that the `.border-gray-darker` doesn't exist.

/cc @primer/ds-core
