### PR TITLE
Fix rounded-1 value in docs

### DIFF
--- a/docs/content/utilities/borders.mdx
+++ b/docs/content/utilities/borders.mdx
@@ -166,7 +166,7 @@ Use `border-dashed` to give an element a dashed border.
 
 ## Rounded corners
 
-Use the following utilities to add or remove rounded corners: `rounded-0` removes rounded corners, `rounded-1` applies a border radius of 3px, `rounded-2` applies a border radius of 6px. `.circle` applies a border radius of 50%, which turns square elements into perfect circles.
+Use the following utilities to add or remove rounded corners: `rounded-0` removes rounded corners, `rounded-1` applies a border radius of 4px, `rounded-2` applies a border radius of 6px. `.circle` applies a border radius of 50%, which turns square elements into perfect circles.
 
 ```html live
 <div class="border rounded-0 p-2 mb-2">


### PR DESCRIPTION
This fixes a report by @anywherepilot

> Adrian and I were just talking about border rounding and some strange things we saw happening, and I think I found a small doc issue. The [Primer doc for borders](https://primer.style/css/utilities/borders#rounded-corners) says that 1 in the context of border rounding means 3px, but the [code](https://github.com/primer/css/blob/cdaaba69b53d6e57afd46b4b4b090bad4f8233f4/src/support/variables/misc.scss#L10) says 4px.