### PR TITLE
Remove emoji fonts from font-family

### DIFF
--- a/src/marketing/support/variables.scss
+++ b/src/marketing/support/variables.scss
@@ -25,7 +25,7 @@ $marketing-font-path: "/fonts/" !default;
   font-display: swap;
 }
 
-$font-mktg: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$font-mktg: Inter, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif !default;
 
 // Builds upon @primer/css/support/variables/typography.scss
 $h000-size: 64px !default;

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -32,7 +32,7 @@ $lh-condensed: 1.25 !default;
 $lh-default: 1.5 !default;
 
 // Font stacks
-$body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif !default;
+$body-font: -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif !default;
 
 // Monospace font stack
 $mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace !default;

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -32,7 +32,7 @@ $lh-condensed: 1.25 !default;
 $lh-default: 1.5 !default;
 
 // Font stacks
-$body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji" !default;
+$body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif !default;
 
 // Monospace font stack
 $mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace !default;


### PR DESCRIPTION
This PR does a few things.

- Removes `Segoe UI Symbol` from the marketing `font-family`. It was already removed from the default `font-family` in https://github.com/primer/css/pull/906
- Remove the Apple and Windows Emoji fonts from both font families. The assumption is that most if not all modern systems can render emojis without these denoted in the font family.
- Remove `Segoe UI` from all font families. This font is causing emoji rendering issues on Windows 10 on github.com and as far as I can tell can be safely removed.

/cc @primer/ds-core
