### PR TITLE
Typo: Unpaired <\strong>

### DIFF
--- a/docs/content/components/toasts.md
+++ b/docs/content/components/toasts.md
@@ -156,7 +156,7 @@ Include a link to allow users to take actions within a Toast.
         />
       </svg>
     </span>
-    <span class="Toast-content">Toast message goes here </strong><a href="#">Action.</a></span>
+    <span class="Toast-content">Toast message goes here<a href="#">Action.</a></span>
   </div>
 </div>
 ```


### PR DESCRIPTION
In line 159 exists a </strong> with out a <strong> in front of it.

First, briefly describe your proposal in the title and delete this line.

If your proposal fixes any issues, please list them below, then delete this line:

-  Fixes: # (type an issue number after the # if applicable)

Finally, tell us more about the change here, in the description.

/cc @primer/ds-core
