### PR TITLE
Added structure with headings and reorg content

### DIFF
--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -149,7 +149,7 @@ Add the `disabled` attribute to make a `.form-control` appear disabled.
 </div>
 ```
 
-### Hide webkit's contact info autofill icon
+### Hide WebKit's contact info autofill icon
 
 Webkit sometimes gets confused and tries to add an icon/dropdown to autofill contact information on fields that may not be appropriate (such as input for number of users). Use this class to override the display of this icon.
 

--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -151,7 +151,7 @@ Add the `disabled` attribute to make a `.form-control` appear disabled.
 
 ### Hide WebKit's contact info autofill icon
 
-Webkit sometimes gets confused and tries to add an icon/dropdown to autofill contact information on fields that may not be appropriate (such as input for number of users). Use this class to override the display of this icon.
+WebKit sometimes gets confused and tries to add an icon/dropdown to autofill contact information on fields that may not be appropriate (such as input for number of users). Use this class to override the display of this icon.
 
 ```html live
 <form>

--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -15,7 +15,7 @@ Overview:
 - Always declare a `type` on your `<button>`s.
 - Form layouts rely on form groups.
 
-#### Kitchen sink
+## Kitchen sink
 
 All our inputs and buttons side-by-side for easy testing of sizing and alignment with one another.
 
@@ -48,7 +48,7 @@ All our inputs and buttons side-by-side for easy testing of sizing and alignment
 </p>
 ```
 
-#### Example form
+## Example form
 
 Form controls in Primer CSS currently have no basic layout specified (this is by design). You'll need to use `<fieldset>`s, `<div>`s, or other elements and styles to rearrange them.
 
@@ -69,7 +69,57 @@ Form controls in Primer CSS currently have no basic layout specified (this is by
 </form>
 ```
 
-#### Form contrast
+## Inputs
+
+### Sizing
+
+Make inputs smaller, larger, or full-width with an additional class.
+
+#### Small
+
+```html live
+<form>
+  <input class="form-control input-sm" type="text" placeholder="Small input" aria-label="Small input" />
+</form>
+```
+
+#### Large
+
+```html live
+<form>
+  <input class="form-control input-lg" type="text" placeholder="Large input" aria-label="Large input" />
+</form>
+```
+
+#### Block
+
+```html live
+<form>
+  <input class="form-control input-block" type="text" placeholder="Full-width input" aria-label="Full-width input" />
+</form>
+```
+
+### Input group
+
+Attached an input and button to one another.
+
+```html live
+<form>
+  <div class="input-group">
+    <input class="form-control" type="text" placeholder="Username" aria-label="Username">
+    <span class="input-group-button">
+      <button class="btn" type="button" aria-label="Copy to clipboard">
+        <!-- <%= octicon "clippy" %> -->
+        <svg class="octicon octicon-clippy" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"></path></svg>
+      </button>
+    </span>
+  </div>
+</form>
+```
+
+## Customization
+
+### Form contrast
 
 Textual form controls have a white background by default. You can change this to a light gray with `.input-contrast`.
 
@@ -80,7 +130,7 @@ Textual form controls have a white background by default. You can change this to
 </form>
 ```
 
-#### Disabled state
+### Disabled state
 
 Add the `disabled` attribute to make a `.form-control` appear disabled.
 
@@ -90,35 +140,7 @@ Add the `disabled` attribute to make a `.form-control` appear disabled.
 </form>
 ```
 
-#### Sizing
-
-Make inputs smaller, larger, or full-width with an additional class.
-
-##### Small
-
-```html live
-<form>
-  <input class="form-control input-sm" type="text" placeholder="Small input" aria-label="Small input" />
-</form>
-```
-
-##### Large
-
-```html live
-<form>
-  <input class="form-control input-lg" type="text" placeholder="Large input" aria-label="Large input" />
-</form>
-```
-
-##### Block
-
-```html live
-<form>
-  <input class="form-control input-block" type="text" placeholder="Full-width input" aria-label="Full-width input" />
-</form>
-```
-
-##### Dark
+### Dark
 
 ```html live
 <div class="bg-gray-dark p-3 mt-n3 ml-n3 mr-n3">
@@ -127,7 +149,7 @@ Make inputs smaller, larger, or full-width with an additional class.
 </div>
 ```
 
-##### Hide webkit's contact info autofill icon
+### Hide webkit's contact info autofill icon
 
 Webkit sometimes gets confused and tries to add an icon/dropdown to autofill contact information on fields that may not be appropriate (such as input for number of users). Use this class to override the display of this icon.
 
@@ -142,7 +164,7 @@ Webkit sometimes gets confused and tries to add an icon/dropdown to autofill con
 </form>
 ```
 
-#### Selects
+## Selects
 
 Primer CSS adds light `height` and `vertical-align` styles to `<select>`s for all browsers to render them consistently with textual inputs.
 
@@ -160,7 +182,7 @@ Primer CSS adds light `height` and `vertical-align` styles to `<select>`s for al
 </form>
 ```
 
-##### Small
+### Small
 
 Use the `.select-sm` class to resize both default and custom `<select>`s to match the size of [our small buttons](./buttons#default-buttons).
 
@@ -178,7 +200,7 @@ Use the `.select-sm` class to resize both default and custom `<select>`s to matc
 <button class="btn btn-sm ml-1"> Small button</button>
 ```
 
-#### Form groups
+## Form groups
 
 ```html live
 <form>
@@ -219,9 +241,11 @@ Use the `.select-sm` class to resize both default and custom `<select>`s to matc
 </form>
 ```
 
-#### Form group validation
+## Form group validation
 
 Convey success, errors and warnings for form groups. For github.com consider using the [`<auto-check>`](https://github.github.io/web-systems-documentation/#custom-elements-auto-check-md) element to perform server-side validation on an input.
+
+### Success
 
 If the input is **valid**, add the `.successed` class to the `<div class="form-group">` element. Next add/update a success message to the `.note` element, as well as the `.success` class.
 
@@ -245,6 +269,8 @@ If the input is **valid**, add the `.successed` class to the `<div class="form-g
 </form>
 ```
 
+### Error
+
 If the input is **not valid**, add the `.errored` class to the `<div class="form-group">` element. Next add/update an error message to the `.note` element, as well as the `.error` class.
 
 ```html live
@@ -266,6 +292,8 @@ If the input is **not valid**, add the `.errored` class to the `<div class="form
   </div>
 </form>
   ```
+  
+### Warning
 
 If the input should show a **warning**, add the `.warn` class to the `<div class="form-group">` element. Next add/update a warning message to the `.note` element, as well as the `.warning` class.
 
@@ -289,7 +317,18 @@ If the input should show a **warning**, add the `.warn` class to the `<div class
 </form>
 ```
 
-#### Checkboxes and radios
+### Form actions
+
+Align buttons to the right—via `float: right` on the buttons—in forms with `.form-actions`. The floats are automatically cleared for you.
+
+```html live
+<div class="form-actions">
+  <button type="submit" class="btn btn-primary">Save changes</button>
+  <button type="button" class="btn">Cancel</button>
+</div>
+```
+
+## Checkboxes and radios
 
 Utilities to spice up the alignment and styling of checkbox and radio controls.
 
@@ -320,7 +359,7 @@ You may also add emphasis to the label:
 </form>
 ```
 
-##### Show / hide content based on a checkbox or radio button state
+### Toggle content visibility based on a checkbox or radio button state
 
 Content that is hidden by default should only be done so if it is non-essential for the context of the surrounding content. Be sure to use the `aria-live="polite"` attribute on the parent label for added content to be announced when displayed.
 
@@ -346,7 +385,7 @@ Content that is hidden by default should only be done so if it is non-essential 
 </form>
 ```
 
-#### Radio group
+## Radio group
 
 Radio groups are tab like controls. Their blue border gives extra emphasis to what is selected.
 
@@ -361,33 +400,4 @@ Radio groups are tab like controls. Their blue border gives extra emphasis to wh
     <label class="radio-label" for="option-c">Option C</label>
   </div>
 </form>
-```
-
-#### Input group
-
-Attached an input and button to one another.
-
-```html live
-<form>
-  <div class="input-group">
-    <input class="form-control" type="text" placeholder="Username" aria-label="Username">
-    <span class="input-group-button">
-      <button class="btn" type="button" aria-label="Copy to clipboard">
-        <!-- <%= octicon "clippy" %> -->
-        <svg class="octicon octicon-clippy" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"></path></svg>
-      </button>
-    </span>
-  </div>
-</form>
-```
-
-#### Form actions
-
-Align buttons to the right—via `float: right` on the buttons—in forms with `.form-actions`. The floats are automatically cleared for you.
-
-```html live
-<div class="form-actions">
-  <button type="submit" class="btn btn-primary">Save changes</button>
-  <button type="button" class="btn">Cancel</button>
-</div>
 ```

--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -330,7 +330,7 @@ Align buttons to the right—via `float: right` on the buttons—in forms with `
 
 ## Checkboxes and radios
 
-Utilities to spice up the alignment and styling of checkbox and radio controls.
+Utilities to control alignment and styling of checkbox and radio controls.
 
 ```html live
 <form>


### PR DESCRIPTION
This PR adds H2 headings to add structure to the page so that page headings can allow for anchors and the table of contents appears on the side. This is to improve readability and navigation throughout the page.

/cc @primer/ds-core
