### PR TITLE
Added missing </span> tag in labels.md

### DIFF
--- a/docs/content/components/labels.md
+++ b/docs/content/components/labels.md
@@ -158,7 +158,7 @@ Use the `Counter` in navigation to indicate the number of items without the user
 ```html live
 <div class="tabnav">
   <nav class="tabnav-tabs" aria-label="Foo bar">
-    <a href="#url" class="tabnav-tab" aria-current="page">Foo tab <span class="Counter">23</a>
+    <a href="#url" class="tabnav-tab" aria-current="page">Foo tab <span class="Counter">23</span></a>
     <a href="#url" class="tabnav-tab">Bar tab</a>
   </nav>
 </div>


### PR DESCRIPTION
Added missing `</span>` tag in the **Counters** section of labels.md

It's not strictly necessary - html would parse it correctly. 
But it's definitely not a best practice ;)

/cc @primer/ds-core
