### PR TITLE
Add note about new color docs

### DIFF
--- a/docs/content/support/color-system.mdx
+++ b/docs/content/support/color-system.mdx
@@ -1,7 +1,7 @@
 ---
 title: Color system
 description: 'Sass variables, mixins, and functions for use in our components.'
-status: Stable
+status: Deprecated
 source: 'https://github.com/primer/css/blob/master/src/support/variables/color-system.scss'
 bundle: support
 ---
@@ -11,6 +11,12 @@ import {Box, Flex, Heading, Link, StyledOcticon} from '@primer/components'
 import {Link as LinkIcon} from '@primer/octicons-react'
 import {palettes, variables} from '../../src/color-variables'
 import {PaletteTable, PaletteCell, overlayColor} from '../../src/color-system'
+
+> ⚠️ Hubbers only! These color variables are deprecated and will be replaced at some point. On "dotcom" please use the [new functional variables](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/support/color-system).
+
+> Also take a look at the [migration guide](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/support/v16-migration) when replacing existing colors.
+
+---
 
 ## Color palette
 

--- a/docs/content/support/color-system.mdx
+++ b/docs/content/support/color-system.mdx
@@ -12,7 +12,7 @@ import {Link as LinkIcon} from '@primer/octicons-react'
 import {palettes, variables} from '../../src/color-variables'
 import {PaletteTable, PaletteCell, overlayColor} from '../../src/color-system'
 
-> ⚠️ Hubbers only! These color variables are deprecated and will be replaced at some point. On "dotcom" please use the [new functional variables](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/support/color-system).
+> ⚠️ Hubbers only! These color variables are deprecated and will be replaced at some point. On "_dotcom_" please use the [new functional variables](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/support/color-system).
 
 > Also take a look at the [migration guide](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/support/v16-migration) when replacing existing colors.
 

--- a/docs/content/support/variables.mdx
+++ b/docs/content/support/variables.mdx
@@ -7,7 +7,7 @@ bundle: alerts
 
 import {Variables, DeprecationIcon} from '../../src/variables'
 
-> ⚠️ Hubbers only! These color variables are deprecated and will be replaced at some point. On "dotcom" please use the [new functional variables](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/support/color-system).
+> ⚠️ Hubbers only! These color variables are deprecated and will be replaced at some point. On "_dotcom_" please use the [new functional variables](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/support/color-system).
 
 > Also take a look at the [migration guide](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/support/v16-migration) when replacing existing colors.
 

--- a/docs/content/support/variables.mdx
+++ b/docs/content/support/variables.mdx
@@ -7,6 +7,12 @@ bundle: alerts
 
 import {Variables, DeprecationIcon} from '../../src/variables'
 
+> ⚠️ Hubbers only! These color variables are deprecated and will be replaced at some point. On "dotcom" please use the [new functional variables](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/support/color-system).
+
+> Also take a look at the [migration guide](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/support/v16-migration) when replacing existing colors.
+
+---
+
 <Variables>
 
 The tables below list all of the global SCSS variables defined in [the `support/variables` directory](https://github.com/primer/css/tree/master/src/support/variables).

--- a/docs/content/utilities/colors.mdx
+++ b/docs/content/utilities/colors.mdx
@@ -1,13 +1,19 @@
 ---
 title: Colors
 description: 'Immutable, atomic CSS classes to rapidly build product'
-status: Stable
+status: Deprecated
 status_issue: 'https://github.com/github/design-systems/issues/97'
 ---
 
 import {Box, BorderBox} from '@primer/components'
 import {palettes, allColors} from '../../src/color-variables'
 import {PaletteTable, PaletteTableFragment, PaletteHeading, PaletteCell, PaletteValue} from '../../src/color-system'
+
+> ⚠️ Hubbers only! These color utilities are deprecated and will be replaced at some point. On "dotcom" please use the [new functional utilities](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/utilities/colors).
+
+> Also take a look at the [migration guide](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/support/v16-migration) when replacing existing colors.
+
+---
 
 Use color utilities to apply color to the background of elements, text, and borders.
 

--- a/docs/content/utilities/colors.mdx
+++ b/docs/content/utilities/colors.mdx
@@ -9,7 +9,7 @@ import {Box, BorderBox} from '@primer/components'
 import {palettes, allColors} from '../../src/color-variables'
 import {PaletteTable, PaletteTableFragment, PaletteHeading, PaletteCell, PaletteValue} from '../../src/color-system'
 
-> ⚠️ Hubbers only! These color utilities are deprecated and will be replaced at some point. On "dotcom" please use the [new functional utilities](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/utilities/colors).
+> ⚠️ Hubbers only! These color utilities are deprecated and will be replaced at some point. On "_dotcom_" please use the [new functional utilities](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/utilities/colors).
 
 > Also take a look at the [migration guide](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css/support/v16-migration) when replacing existing colors.
 


### PR DESCRIPTION
There seems to be some confusing due to the new colors already being available on dotcom but the docs not updated yet. So this PR adds a note at the top that links to the new color docs that exist as [preview](https://primer-css-git-mkt-color-modes-docs.primer.now.sh/css) under the `primer.now.sh` domain.

![Screen Shot 2021-02-18 at 17 07 46](https://user-images.githubusercontent.com/378023/108324946-e3622980-720b-11eb-819f-e40756f73614.png)

People might skip it, but maybe still better than nothing. 🤷 

ps. merging the docs PR https://github.com/primer/css/pull/1186 is somewhat blocked by https://github.com/primer/css/issues/1224.