### PR TITLE
Hide overflowing part of .SideNav & .menu

### DIFF
--- a/src/navigation/menu.scss
+++ b/src/navigation/menu.scss
@@ -8,6 +8,7 @@
   background-color: $bg-white;
   border: $border;
   border-radius: $border-radius;
+  overflow: hidden;
 }
 
 .menu-item {

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -4,6 +4,7 @@
 
 .SideNav {
   background-color: $bg-gray-light;
+  overflow: hidden;
 }
 
 .SideNav-item {


### PR DESCRIPTION
Hide overflowing part of `.SideNav`.

`.SideNav-item` in `.SideNav` overflows, and they overlays on their parent element, so part of the border of their parent element is hidden. So I added `overflow: hidden` to `.SideNav`.

| Before | After |
| --- | --- |
| ![Before this edit](https://user-images.githubusercontent.com/47271684/108584260-d152c900-737a-11eb-920c-8c7165f19dbe.png) | ![image](https://user-images.githubusercontent.com/47271684/108584373-b6348900-737b-11eb-816a-6e4f6ced78aa.png) |
