### PR TITLE
Put back some utilities for view_components

### DIFF
--- a/src/utilities/box-shadow.scss
+++ b/src/utilities/box-shadow.scss
@@ -22,11 +22,11 @@
 // TODO: Remove once not used anymore.
 
 .box-shadow {
-  box-shadow: var(--color-shadow-small)  !important;
+  box-shadow: var(--color-shadow-small) !important;
 }
 
 .box-shadow-medium {
-  box-shadow: var(--color-shadow-medium)  !important;
+  box-shadow: var(--color-shadow-medium) !important;
 }
 
 .box-shadow-large {
@@ -34,7 +34,7 @@
 }
 
 .box-shadow-extra-large {
-  box-shadow: var(--color-shadow-extra-large)  !important;
+  box-shadow: var(--color-shadow-extra-large) !important;
 }
 
 // Keep .box-shadow-none

--- a/src/utilities/box-shadow.scss
+++ b/src/utilities/box-shadow.scss
@@ -18,6 +18,28 @@
   box-shadow: var(--color-shadow-extra-large) !important;
 }
 
+// Deprecated ---------------------------------------
+// TODO: Remove once not used anymore.
+
+.box-shadow {
+  box-shadow: var(--color-shadow-small)  !important;
+}
+
+.box-shadow-medium {
+  box-shadow: var(--color-shadow-medium)  !important;
+}
+
+.box-shadow-large {
+  box-shadow: var(--color-shadow-large) !important;
+}
+
+.box-shadow-extra-large {
+  box-shadow: var(--color-shadow-extra-large)  !important;
+}
+
+// Keep .box-shadow-none
+// End of deprecation ---------------------------------------
+
 // Turn off box shadow
 
 .box-shadow-none {

--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -57,7 +57,7 @@
 
 // background colors
 .bg-white         { background-color: var(--color-bg-primary) !important; }
-.bg-blue          { background-color: var(--color-bg-info-inverse)  !important; }
+.bg-blue          { background-color: var(--color-bg-info-inverse) !important; }
 .bg-blue-light    { background-color: var(--color-bg-info) !important; }
 .bg-gray-dark     { background-color: var(--color-bg-canvas-inverse) !important; }
 .bg-gray          { background-color: var(--color-bg-tertiary) !important; }

--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -56,6 +56,18 @@
 // Color utilities
 
 // background colors
+.bg-white         { background-color: var(--color-bg-primary) !important; }
+.bg-blue          { background-color: var(--color-bg-info-inverse)  !important; }
+.bg-blue-light    { background-color: var(--color-bg-info) !important; }
+.bg-gray-dark     { background-color: var(--color-bg-canvas-inverse) !important; }
+.bg-gray          { background-color: var(--color-bg-tertiary) !important; }
+.bg-gray-light    { background-color: var(--color-bg-secondary) !important; }
+.bg-green         { background-color: var(--color-bg-success-inverse) !important; }
+.bg-green-light   { background-color: var(--color-bg-success) !important; }
+.bg-red           { background-color: var(--color-bg-danger-inverse) !important; }
+.bg-red-light     { background-color: var(--color-bg-danger) !important; }
+.bg-yellow        { background-color: var(--color-bg-warning-inverse) !important; }
+.bg-yellow-light  { background-color: var(--color-bg-warning) !important; }
 .bg-yellow-dark   { background-color: $bg-yellow-dark !important; }
 .bg-purple        { background-color: $bg-purple !important; }
 .bg-pink          { background-color: $bg-pink !important; }
@@ -71,17 +83,32 @@
 }
 
 // text colors
+.text-blue          { color: var(--color-text-link) !important; }
+.text-red           { color: var(--color-text-danger) !important; }
+.text-gray-light    { color: var(--color-text-tertiary) !important; }
+.text-gray          { color: var(--color-text-secondary) !important; }
+.text-gray-dark     { color: var(--color-text-primary) !important; }
+.text-green         { color: var(--color-text-success) !important; }
+.text-yellow        { color: var(--color-text-warning) !important; }
 .text-orange        { color: $text-orange !important; }
 .text-orange-light  { color: $text-orange-light !important; }
 .text-purple        { color: $text-purple !important; }
 .text-pink          { color: $text-pink !important; }
+.text-white         { color: var(--color-text-white) !important; }
 
 .text-inherit       { color: inherit !important; } // TODO: Should this be moved to primer/primitives
 
 // Border colors
+.border-blue        { border-color: var(--color-border-info) !important; }
 .border-blue-light  { border-color: $border-blue-light !important; }
+.border-green       { border-color: var(--color-border-success) !important; }
+.border-green-light { border-color: var(--color-discussion-border) !important; }
+.border-red         { border-color: var(--color-border-danger) !important; }
 .border-red-light   { border-color: $border-red-light !important; }
 .border-purple      { border-color: $border-purple !important; }
+.border-yellow      { border-color: var(--color-border-warning) !important; }
+.border-gray-light  { border-color: var(--color-border-secondary) !important; }
+.border-gray-dark   { border-color: var(--color-border-tertiary) !important; }
 
 .border-black-fade  { border-color: $border-black-fade !important; }
 .border-white-fade  { border-color: $border-white-fade !important; }


### PR DESCRIPTION
This puts back some of the utilities removed in https://github.com/primer/css/pull/1233 but updates their values to css variables. 

We can't remove them yet because primer view_components still maps props to these class names https://github.com/primer/view_components/blob/af5f2a60bd1fd19b63c13ade4bfda8d97ac7538e/app/lib/primer/classify.rb#L206-L212



