### PR TITLE
Move marketing @font-face declarations from vars to type

### DIFF
--- a/src/marketing/support/variables.scss
+++ b/src/marketing/support/variables.scss
@@ -1,30 +1,5 @@
 $marketing-font-path: "/fonts/" !default;
 
-// Type
-@font-face {
-  font-family: Inter;
-  font-style: normal;
-  font-weight: $font-weight-normal;
-  src: local("Inter"), local("Inter-Regular"), url("#{$marketing-font-path}Inter-Regular.woff") format("woff");
-  font-display: swap;
-}
-
-@font-face {
-  font-family: Inter;
-  font-style: normal;
-  font-weight: $font-weight-semibold;
-  src: local("Inter Medium"), local("Inter-Medium"), url("#{$marketing-font-path}Inter-Medium.woff") format("woff");
-  font-display: swap;
-}
-
-@font-face {
-  font-family: Inter;
-  font-style: normal;
-  font-weight: $font-weight-bold;
-  src: local("Inter Bold"), local("Inter-Bold"), url("#{$marketing-font-path}Inter-Bold.woff") format("woff");
-  font-display: swap;
-}
-
 $font-mktg: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
 
 // Builds upon @primer/css/support/variables/typography.scss

--- a/src/marketing/type/typography.scss
+++ b/src/marketing/type/typography.scss
@@ -1,5 +1,29 @@
-// Headings
+// Type
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: $font-weight-normal;
+  src: local("Inter"), local("Inter-Regular"), url("#{$marketing-font-path}Inter-Regular.woff") format("woff");
+  font-display: swap;
+}
 
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: $font-weight-semibold;
+  src: local("Inter Medium"), local("Inter-Medium"), url("#{$marketing-font-path}Inter-Medium.woff") format("woff");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: $font-weight-bold;
+  src: local("Inter Bold"), local("Inter-Bold"), url("#{$marketing-font-path}Inter-Bold.woff") format("woff");
+  font-display: swap;
+}
+
+// Headings
 .h000-mktg,
 .h00-mktg,
 .h0-mktg,


### PR DESCRIPTION
This PR moves all the marketing `@font-face` declarations from `marketing/support/variables.scss` to  `marketing/type/typography.scss`. Since variables can be expected to be imported multiple times in another bundle, having anything other than variables in `variables.scss` risks introducing duplication of styles.

/cc @primer/ds-core
