### PR TITLE
Adding timeline-badge success border

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3499,9 +3499,9 @@
       }
     },
     "@primer/primitives": {
-      "version": "0.0.0-202121782215",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-0.0.0-202121782215.tgz",
-      "integrity": "sha512-W3tdfiQ/6wSVkbwmv0RmIiZmzqcgQJKCwTjEUp1qMreQqe+smrtYq6u9pbWGlMgxX8aX79duNwwfiQ44eGO4NA=="
+      "version": "0.0.0-2021219201035",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-0.0.0-2021219201035.tgz",
+      "integrity": "sha512-J6Fq782XjhVAOZ8cfzMmEC/olbtqzRCoU6s2oTB7Yq4/a9RAxEeXN4d4Toz/ReOSkhV2+zMNpKjiej+v9N37Xw=="
     },
     "@reach/router": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@primer/octicons": "^9.1.1",
-    "@primer/primitives": "0.0.0-202121782215"
+    "@primer/primitives": "0.0.0-2021219201035"
   },
   "devDependencies": {
     "@octokit/rest": "^16.34.0",

--- a/src/timeline/timeline-item.scss
+++ b/src/timeline/timeline-item.scss
@@ -44,7 +44,7 @@
   &--success {
     color: var(--color-text-white);
     background-color: var(--color-btn-primary-bg);
-    border: $border-width $border-style var(--color-merge-box-success-indicator-border);
+    border: $border-width $border-style var(--color-timeline-badge-success-border);
   }
 }
 


### PR DESCRIPTION
This PR creates uses the `--color-timeline-badge-success-border` added to primitives, in case we want to componentize the merge box in the future and separate the variables.