### PR TITLE
Caret clip-path updates

### DIFF
--- a/src/support/mixins/misc.scss
+++ b/src/support/mixins/misc.scss
@@ -5,25 +5,24 @@
     position: absolute;
     top: 11px;
     right: 100%;
-    left: -16px;
+    left: -8px;
     display: block;
-    width: 0;
-    height: 0;
+    width: 8px;
+    height: 16px;
     pointer-events: none;
     content: " ";
-    border-color: transparent;
-    border-style: solid solid outset;
+    clip-path: polygon(0 50%, 100% 0, 100% 100%);
   }
 
   &::after {
+    height: 14px;
     margin-top: 1px;
-    margin-left: 2px;
-    border-width: 7px;
-    border-right-color: $background;
+    margin-left: 1px;
+    background-color: var(--color-bg-primary);
+    background-image: linear-gradient($background, $background);
   }
 
   &::before {
-    border-width: 8px;
-    border-right-color: $border;
+    background-color: $border;
   }
 }

--- a/src/support/mixins/misc.scss
+++ b/src/support/mixins/misc.scss
@@ -15,8 +15,6 @@
   }
 
   &::after {
-    height: 14px;
-    margin-top: 1px;
     margin-left: 1px;
     background-color: var(--color-bg-primary);
     background-image: linear-gradient($background, $background);


### PR DESCRIPTION
This PR updates how we draw carets. This is important for supporting color modes.

**Problem:** The comment box headers use transparent colors for various states. eg. current, selected. Because of the way we draw them, this becomes a problem when the colors are stacked. 

**Solution:** 

The main part of this solution has to do with these declarations:

```scss
background-color: var(--color-bg-primary);
background-image: linear-gradient($background, $background);
```

> The borders of the element are then drawn on top of them, and the background-color is drawn beneath them. How the images are drawn relative to the box and its borders is defined by the background-clip and background-origin CSS properties.

cite: https://developer.mozilla.org/en-US/docs/Web/CSS/background-image

because the `background-color` is drawn below the `background-image` we can use it as a background for the foreground caret. This helps our situation with the transparent colors.

![image](https://user-images.githubusercontent.com/54012/112234017-cd73ca00-8bf8-11eb-9a1a-93b7400e8989.png)

If we combine this technique with `clip-path` to draw a triangle polygon we have correct carets:

![image](https://user-images.githubusercontent.com/54012/112234061-e41a2100-8bf8-11eb-895d-008e12d2c0ce.png)
