### PR TITLE
Removing postpublish hook

### DIFF
--- a/.changeset/silent-mangos-hang.md
+++ b/.changeset/silent-mangos-hang.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Removing post publish storybook hook

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "stylelint": "stylelint --quiet src",
     "eslint": "eslint script deprecations.js lib .storybook",
     "eslint-docs": "eslint docs/{content,src,*.js}",
-    "postpublish": "script/postpublish",
     "prepublishOnly": "script/prepublish",
     "publish-storybook": "script/publish-storybook",
     "start": "npm run dev",


### PR DESCRIPTION
Removes the postpublish hook temporarily so we can get changesets releases going.