### PR TITLE
Bump @primer/primitives

### DIFF
--- a/.changeset/chatty-sloths-knock.md
+++ b/.changeset/chatty-sloths-knock.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Bump @primer/primitives to 4.0.2.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/css",
-  "version": "16.0.0",
+  "version": "16.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4540,9 +4540,9 @@
       }
     },
     "@primer/primitives": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-4.0.1.tgz",
-      "integrity": "sha512-TFbO/duRByLSGsCuDRo5Qgd+NOZmMKCB+au32ZHgGfn9KDdlGbbwvGKOx6c56jRWDCHk27aRL2bG4Hc9tFgHpA=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-4.0.2.tgz",
+      "integrity": "sha512-aNuNi3U5NixEwfo8rb3SYycQ31CdNfoL/Kcaea90tD0MUNDqAmIgicYQswXOkHU2KnxkWw1089nBAu81aiYRiw=="
     },
     "@reach/router": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@primer/octicons": "^9.1.1",
-    "@primer/primitives": "^4.0.1"
+    "@primer/primitives": "^4.0.2"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.3.0",


### PR DESCRIPTION
This bumps `@primer/primitives` to [`4.0.2`](https://github.com/primer/primitives/releases/tag/v4.0.2).

- [x] Revert "Update bg-overlay" https://github.com/primer/primitives/pull/60
