### PR TITLE
Setting the gatsby defaultBranch

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -12,6 +12,7 @@ module.exports = {
     {
       resolve: '@primer/gatsby-theme-doctocat',
       options: {
+        defaultBranch: 'main',
         repoRootPath: '..'
       }
     },


### PR DESCRIPTION
Noticed the "Edit this page on GitHub" was pointing at the master branch.