### PR TITLE
Update `Counter--secondary` bg

### DIFF
--- a/.changeset/stupid-oranges-drop.md
+++ b/.changeset/stupid-oranges-drop.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Update `Counter--secondary` bg

--- a/src/labels/counters.scss
+++ b/src/labels/counters.scss
@@ -32,4 +32,5 @@
 
 .Counter--secondary {
   color: var(--color-counter-secondary-text);
+  background-color: var(--color-counter-secondary-bg);
 }


### PR DESCRIPTION
We got some feedback that the text color of `.Counter--secondary` didn't have enough contrast. This PR uses the `--color-counter-secondary-bg` that is semi-transparent and overrides the default background.

Before | After
--- | ---
![Screen Shot 2021-03-29 at 16 22 00](https://user-images.githubusercontent.com/378023/112804744-b842e380-90af-11eb-8300-9153090b32e5.png) | ![image](https://user-images.githubusercontent.com/378023/112810181-be3bc300-90b5-11eb-886b-45082ec3caab.png)

The columns ☝️  above are `.Counter`, `.Counter--primary` and `.Counter--secondary`. Only the dark themes in the last column (`.Counter--secondary`) are affected.

## TODO

- [x] Use `--color-counter-secondary-bg`
- [x] Depends on [@primer/primitives@4.1.0](https://github.com/primer/primitives/pull/63)