### PR TITLE
Marketing buttons: don't animate everything

### DIFF
--- a/.changeset/strange-pots-allow.md
+++ b/.changeset/strange-pots-allow.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Marketing buttons: don't animate everything

--- a/src/marketing/buttons/button.scss
+++ b/src/marketing/buttons/button.scss
@@ -11,7 +11,8 @@
   background-color: var(--color-mktg-btn-bg);
   border: $border-width $border-style var(--color-mktg-btn-border);
   border-radius: $border-radius;
-  transition: $transition-time / 2;
+  transition-duration: $transition-time / 2;
+  transition-property: background-color, border-color, box-shadow;
   appearance: none; // Corrects inability to style clickable `input` types in iOS.
 
   &:hover {


### PR DESCRIPTION
The current `transition` for `.btn-mktg` lacks a property declaration, which implies `all`. This can cause the button to animate e.g. its size and font on page load:

![button-animation](https://user-images.githubusercontent.com/211284/112860794-6c466d80-90b4-11eb-8aa0-3481909550f8.gif)

This PR fixes this by explicitly only animating `background-color`, `box-shadow`, and `border-color` (the properties that change on `hover` and `focus`)

/cc @primer/ds-core
