### PR TITLE
Don't run dependabot releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - 'main'
+    branches-ignore:
+      - 'dependabot/**'
 jobs:
   release:
     if: ${{ github.repository == 'primer/css' }}

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -4,6 +4,7 @@ on:
     branches-ignore:
       - 'main'
       - 'changeset-release/main'
+      - 'dependabot/**'
     # Don't release canary when these paths change
     # It's not necessary because we don't ship them and it creates noise
     paths-ignore:


### PR DESCRIPTION
This stops the release checks from running on PRs from dependabot like https://github.com/primer/css/pull/1267

The bot can't do this because they don't have access to our secrets.