### PR TITLE
If the release doesn't publish, then publish rc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,36 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
+
+      - name: Create .npmrc
+        if: steps.changesets.outputs.published != 'true'
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
+
+      - name: Publish release candidate
+        if: steps.changesets.outputs.published != 'true'
+        run: |
+          echo "$( jq ".version = \"$(echo $version)-rc.$(echo $GITHUB_SHA)\"" package.json )" > package.json
+          yarn publish -tag next
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Output canary version number
+        if: steps.changesets.outputs.published != 'true'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const package = require(`${process.env.GITHUB_WORKSPACE}/package.json`)
+            github.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: 'success',
+              context: `Published ${package.name}`,
+              description: package.version,
+              target_url: `https://unpkg.com/${package.name}@${package.version}/`
+            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Publish release candidate
         if: steps.changesets.outputs.published != 'true'
         run: |
+          version=$(jq -r .version package.json)
           echo "$( jq ".version = \"$(echo $version)-rc.$(echo $GITHUB_SHA)\"" package.json )" > package.json
           yarn publish -tag next
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Output canary version number
+      - name: Output release candidate number
         if: steps.changesets.outputs.published != 'true'
         uses: actions/github-script@v3
         with:


### PR DESCRIPTION
This is an attempt to add `-rc` publishing to primer releases after changesets does it's thing https://github.com/changesets/action#with-publishing

We can't used the normal changesets pre because that assumes we're on a pre branch and will merge that into main at some point. And we can't run an action on changeset prs because github restricts actions on `github-actions` prs to escape infinite loops.

