### PR TITLE
Fixing typo in release workflow

### DIFF
--- a/.changeset/silly-shoes-arrive.md
+++ b/.changeset/silly-shoes-arrive.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Fixing workflow for rc publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,19 @@ on:
     branches:
       - 'main'
       - '!dependabot/**'
+    # Don't release when these paths change
+    # It's not necessary because we don't ship them and it creates noise
+    paths-ignore:
+      - '.changeset/**'
+      - '.github/**'
+      - '.storybook/**'
+      - 'docs/**'
+      - 'lib/**'
+      - 'script/**'
+      - 'static/**'
+      - 'next.config.js'
+      - 'now.json'
+
 jobs:
   release:
     if: ${{ github.repository == 'primer/css' }}
@@ -37,7 +50,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
 
       - name: Create .npmrc
-        if: steps.changesets.outputs.published != 'true'
+        if: steps.changesets.outputs.published == 'false'
         run: |
           cat << EOF > "$HOME/.npmrc"
             //registry.npmjs.org/:_authToken=$NPM_TOKEN
@@ -46,16 +59,16 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
 
       - name: Publish release candidate
-        if: steps.changesets.outputs.published != 'true'
+        if: steps.changesets.outputs.published == 'false'
         run: |
           version=$(jq -r .version package.json)
           echo "$( jq ".version = \"$(echo $version)-rc.$(echo $GITHUB_SHA)\"" package.json )" > package.json
-          yarn publish -tag next
+          yarn publish --tag next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Output release candidate number
-        if: steps.changesets.outputs.published != 'true'
+        if: steps.changesets.outputs.published == 'false'
         uses: actions/github-script@v3
         with:
           script: |

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -15,6 +15,8 @@ on:
       - 'lib/**'
       - 'script/**'
       - 'static/**'
+      - 'next.config.js'
+      - 'now.json'
 
 jobs:
   release-canary:


### PR DESCRIPTION
I forgot to add an extra `-` in the `yarn publish -tag` line in this pr https://github.com/primer/css/pull/1277

I'm also adding a patch changeset here so we can bump the latest tag on npm.
