### PR TITLE
Remove deprecated select menu from nav

### DIFF
--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -5,6 +5,10 @@ source: 'https://github.com/primer/css/tree/main/src/select-menu'
 bundle: select-menu
 ---
 
+<Note>
+  Please note that the `.select-menu` component is deprecated and `.SelectMenu` should be used instead. Check the <a href="/css/components/select-menu-deprecated">migration guide</a> to make sure your app is up to date.
+</Note>
+
 The `SelectMenu` component provides advanced support for navigation, filtering, and more. Any menu can make use of JavaScript-enabled live filtering, selected states, tabbed lists, and keyboard navigation with a bit of markup.
 
 ## Basic example

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -111,8 +111,6 @@
       url: /components/progress
     - title: Select menu
       url: /components/select-menu
-    - title: Select menu (deprecated)
-      url: /components/select-menu-deprecated
     - title: Subhead
       url: /components/subhead
     - title: Timeline


### PR DESCRIPTION
This PR removes the deprecated select menu from the navigation on primer.style/css. I've left the docs so we can still reference them but from a viewer's perspective it's confusing to have both. I think we can add a banner to notify folks on the current page to use the new component classes instead but wanted to leave that up to the maintainers.

cc @simurai 
