### PR TITLE
color-mode mixin fix for keyboard toggle

### DIFF
--- a/.changeset/slow-masks-itch.md
+++ b/.changeset/slow-masks-itch.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+color-mode mixin fix for keyboard toggle

--- a/.github/workflows/bundle_report.yml
+++ b/.github/workflows/bundle_report.yml
@@ -2,7 +2,7 @@ name: Bundle report
 on:
   push:
     paths:
-      - 'src'
+      - 'src/**'
 jobs:
   bundle:
     runs-on: ubuntu-latest

--- a/src/support/mixins/color-modes.scss
+++ b/src/support/mixins/color-modes.scss
@@ -29,14 +29,14 @@
 @mixin color-mode($mode) {
   @if $mode == light {
     :root,
-    [data-color-mode="dark"][data-dark-theme*="#{$mode}"],
-    [data-color-mode="light"][data-light-theme*="#{$mode}"] {
+    [data-color-mode="light"][data-light-theme*="#{$mode}"],
+    [data-color-mode="dark"][data-dark-theme*="#{$mode}"] {
       @content;
     }
   }
   @else {
-    [data-color-mode="dark"][data-dark-theme*="#{$mode}"],
-    [data-color-mode="light"][data-light-theme*="#{$mode}"] {
+    [data-color-mode="light"][data-light-theme*="#{$mode}"],
+    [data-color-mode="dark"][data-dark-theme*="#{$mode}"] {
       @content;
     }
   }

--- a/src/support/mixins/color-modes.scss
+++ b/src/support/mixins/color-modes.scss
@@ -55,7 +55,7 @@
 }
 
 // This mixin takes a map of color mode vars and splits them into dark and light mode
-// The goal is to reduce the amount of dark/light mode selectors compiled
+// The goal is to reduce the amount of dark/light mode selectors compiled.
 //
 // Example input for $color-map
 //

--- a/src/support/mixins/color-modes.scss
+++ b/src/support/mixins/color-modes.scss
@@ -29,12 +29,14 @@
 @mixin color-mode($mode) {
   @if $mode == light {
     :root,
-    [data-color-mode="#{$mode}"][data-#{$mode}-theme*="#{$mode}"] {
+    [data-color-mode="dark"][data-dark-theme*="#{$mode}"],
+    [data-color-mode="light"][data-light-theme*="#{$mode}"] {
       @content;
     }
   }
   @else {
-    [data-color-mode="#{$mode}"][data-#{$mode}-theme*="#{$mode}"] {
+    [data-color-mode="dark"][data-dark-theme*="#{$mode}"],
+    [data-color-mode="light"][data-light-theme*="#{$mode}"] {
       @content;
     }
   }


### PR DESCRIPTION
In https://github.com/primer/css/pull/1261 I missed fixing the `color-mode` mixin as well.

The problem is if we're letting the configuration `data-color-mode="light" data-light-theme="dark"` then we have variables/code added with the mixin that never reaches that selector.

For example: 

| Before | After |
| :- | :- |
| ![image](https://user-images.githubusercontent.com/54012/113049011-04e1f980-9158-11eb-9c98-e856fdcb3552.png) | ![image](https://user-images.githubusercontent.com/54012/113049055-0f03f800-9158-11eb-8181-91821f8e4d4c.png) |
| ![image](https://user-images.githubusercontent.com/54012/113049121-1fb46e00-9158-11eb-95b0-99ce4b63bae6.png) | ![image](https://user-images.githubusercontent.com/54012/113049162-2a6f0300-9158-11eb-80f7-26270e0d82f8.png) |

/cc @primer/ds-core
