### PR TITLE
Removing google analytics

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -24,13 +24,6 @@ module.exports = {
       }
     },
     {
-      resolve: 'gatsby-plugin-google-analytics',
-      options: {
-        trackingId: 'UA-126681523-2',
-        anonymize: true
-      }
-    },
-    {
       resolve: `gatsby-plugin-alias-imports`,
       options: {
         alias: {

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,6 @@
     "core-js": "^3.6.5",
     "gatsby": "^2.24.62",
     "gatsby-plugin-alias-imports": "^1.0.5",
-    "gatsby-plugin-google-analytics": "^2.3.14",
     "gatsby-plugin-sass": "^2.3.13",
     "gatsby-plugin-svgr": "^2.0.2",
     "postcss-loader": "^3.0.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -6935,14 +6935,6 @@ gatsby-plugin-catch-links@^2.1.2:
     "@babel/runtime" "^7.12.5"
     escape-string-regexp "^1.0.5"
 
-gatsby-plugin-google-analytics@^2.3.14:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.11.0.tgz#8d74bd3c100706f03bbccf7b130a758fce9994ad"
-  integrity sha512-aVFmzoozd0ifn5HJJY0W8R7DHkyTEvj/ueRyJJNlQMadQagIAYq+7efKon4gJzd4NZkLcoDb6moiAR066FwIIg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    minimatch "3.0.4"
-
 gatsby-plugin-manifest@^2.2.1:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.12.1.tgz#d92f23d2d17d3c69445ef7b7842e5441e8dd785e"

--- a/static/analytics.js
+++ b/static/analytics.js
@@ -1,4 +1,0 @@
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', 'UA-126681523-2');


### PR DESCRIPTION
I noticed we still have google analytics running on https://primer.style/css/

With our push to remove it from dotcom last year I figured we should remove here too?


