### PR TITLE
Adding text-semibold and text-light utility classes

### DIFF
--- a/.changeset/polite-swans-push.md
+++ b/.changeset/polite-swans-push.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': minor
+---
+
+Adding text-semibold and text-light utility classes

--- a/docs/content/utilities/typography.md
+++ b/docs/content/utilities/typography.md
@@ -93,6 +93,8 @@ Change the font weight, styles, and alignment with these utilities.
 <p class="text-normal">Normal</p>
 <p class="text-italic">Italic</p>
 <p class="text-bold">Bold</p>
+<p class="text-semibold">Semi-bold</p>
+<p class="text-light">Light</p>
 <p class="text-uppercase">Uppercase</p>
 <p class="no-wrap">No wrap</p>
 <p class="ws-normal">Normal whitespace</p>

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -191,7 +191,9 @@
 /* Set the font weight to normal */
 .text-normal { font-weight: $font-weight-normal !important; }
 /* Set the font weight to bold */
-.text-bold { font-weight: $font-weight-bold !important;}
+.text-bold { font-weight: $font-weight-bold !important; }
+.text-semibold { font-weight: $font-weight-semibold !important; }
+.text-light { font-weight: $font-weight-light !important; }
 /* Set the font to italic */
 .text-italic { font-style: italic !important; }
 /* Make text uppercase */


### PR DESCRIPTION
This adds [text utilities from GitHub](https://github.com/github/github/blob/9e452b6fe0cc66065e764441a58a3ae3f4af7b0c/app/assets/stylesheets/hacks/hx_primer.scss#L177-L182) for `text-semibold` and `text-light`

@tobiasahlin there's also a `text-semibold-mktg` [that does the same](https://github.com/github/github/blob/9e452b6fe0cc66065e764441a58a3ae3f4af7b0c/app/assets/stylesheets/marketing/utilities/typography.scss#L251-L253) as this we should combine them 

/cc @primer/ds-core
