### PR TITLE
Setting min-height on input-sm

### DIFF
--- a/.changeset/twelve-taxis-press.md
+++ b/.changeset/twelve-taxis-press.md
@@ -1,5 +1,5 @@
 ---
-'@primer/css': patch
+'@primer/css': minor
 ---
 
 Adding a min-height to input-sm

--- a/.changeset/twelve-taxis-press.md
+++ b/.changeset/twelve-taxis-press.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Adding a min-height to input-sm

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -76,6 +76,7 @@ textarea.form-control {
 
 // Mini inputs, to match .minibutton
 .input-sm {
+  min-height: $size-4;
   // stylelint-disable-next-line primer/spacing
   padding-top: 3px;
   // stylelint-disable-next-line primer/spacing


### PR DESCRIPTION
This adds a hack from dotcom https://github.com/github/github/blob/9e452b6fe0cc66065e764441a58a3ae3f4af7b0c/app/assets/stylesheets/hacks/hx_primer.scss#L160-L162

Setting the `input-sm` class to have a min-height

/cc @primer/ds-core
