### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/content/support/color-system.mdx
+++ b/docs/content/support/color-system.mdx
@@ -16,7 +16,7 @@ import {PaletteTable, PaletteCell, ColorModeTable, CSSModeVars, overlayColor} fr
   Please note Primer v16 has changed the naming of these color classes. Check the <a href="/css/support/v16-migration">migration guide</a> to make sure your app is up to date.
 </Note>
 
-Sarting in v16, Primer CSS uses CSS variables for all colors. When using CSS variables like `--color-text-secondary` make sure to wrap them with [`var()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):
+Starting in v16, Primer CSS uses CSS variables for all colors. When using CSS variables like `--color-text-secondary` make sure to wrap them with [`var()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):
 
 ```css
 .my-class {


### PR DESCRIPTION
This just fixes a typo that I caught while reading the docs ;)

/cc @primer/ds-core
