### PR TITLE
Changing the browserslist supported browsers to match dotcom.

### DIFF
--- a/.changeset/silly-goats-breathe.md
+++ b/.changeset/silly-goats-breathe.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': major
+---
+
+Changeset change supported browsers.

--- a/package.json
+++ b/package.json
@@ -70,12 +70,13 @@
     ]
   },
   "browserslist": [
-    "> 5%",
-    "last 2 firefox versions",
-    "last 2 chrome versions",
-    "last 2 safari versions",
-    "last 2 edge versions",
-    "ie 11"
+    "last 10 Chrome versions",
+    "last 4 Firefox versions",
+    "last 3 Safari versions",
+    "not Safari 12",
+    "last 4 Edge versions",
+    "not Edge <= 18",
+    "Firefox ESR"
   ],
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
This changes the supported browser versions to match the [supported browsers](https://help.github.com/articles/supported-browsers/) on GitHub and the browserslistrc file in the dotcom codebase.

Because this drops some vendored selectors from our dist, it needs to be in the next major version. I've already added the deprecations to our deprecations file.