### PR TITLE
Don't use btn-outline-blue in docs

### DIFF
--- a/deprecations.js
+++ b/deprecations.js
@@ -18,10 +18,6 @@ const versionDeprecations = {
     {
       selectors: [':-ms-input-placeholder'],
       message: 'Browserslist update to match github has removed the need for this pseudoselector'
-    },
-    {
-      selectors: ['.btn-outline-blue'],
-      message: `This selector is not available in Primer CSS 17.0.0. Please refer to the documentation.`
     }
   ],
   '16.0.0': [

--- a/deprecations.js
+++ b/deprecations.js
@@ -11,7 +11,7 @@ const versionDeprecations = {
     },
     {
       selectors: ['.btn-outline-blue'],
-      message: `This selector is not available in Primer CSS 16.0.0. Please refer to the documentation.`
+      message: `This selector is not available in Primer CSS 17.0.0. Please refer to the documentation.`
     }
   ],
   '16.0.0': [

--- a/deprecations.js
+++ b/deprecations.js
@@ -8,6 +8,10 @@ const versionDeprecations = {
     {
       selectors: [':-ms-input-placeholder'],
       message: 'Browserslist update to match github has removed the need for this pseudoselector'
+    },
+    {
+      selectors: ['.btn-outline-blue'],
+      message: `This selector is not available in Primer CSS 16.0.0. Please refer to the documentation.`
     }
   ],
   '16.0.0': [

--- a/docs/content/components/buttons.md
+++ b/docs/content/components/buttons.md
@@ -105,7 +105,7 @@ Use `.btn-large` with a type scale utility to transform the text to a bigger siz
 
 ```html live
 <div class="f3">
-  <button class="btn btn-large btn-outline-blue mr-2" type="button">Large button button</button>
+  <button class="btn btn-large btn-outline mr-2" type="button">Large button button</button>
   <a class="btn btn-large" href="#url" role="button">Large link button</a>
 </div>
 ```


### PR DESCRIPTION
This PR only updates the docs to not use the deprecated (?) `btn-outline-blue` in the `btn-large` example, and moves to the existing `btn-outline` instead.

Before:

<img width="970" alt="Screen Shot 2021-04-22 at 17 36 39" src="https://user-images.githubusercontent.com/211284/115743265-ce338380-a391-11eb-9392-13066a5d7dac.png">


After:

<img width="488" alt="Screen Shot 2021-04-22 at 17 38 13" src="https://user-images.githubusercontent.com/211284/115743284-d390ce00-a391-11eb-9e67-47d575aaefe0.png">


/cc @primer/ds-core
