### PR TITLE
docs(progress): fix not valid html example

### DIFF
--- a/docs/content/components/progress.md
+++ b/docs/content/components/progress.md
@@ -41,7 +41,7 @@ For inline progress indicators, use the `Progress` and `d-inline-flex` with an i
 ```html live
 <span class="text-small text-gray mr-2">4 of 16</span>
 <span class="Progress d-inline-flex" style="width: 160px">
-  <div class="Progress-item color-bg-success-inverse" style="width: 25%"></div>
+  <span class="Progress-item color-bg-success-inverse" style="width: 25%"></span>
 </span>
 ```
 


### PR DESCRIPTION
`<span>` can include only phrasing content.

1. [W3C validator](https://validator.w3.org/check)
2. [MDN span docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
3. [primer inline-progress](https://primer.style/css/components/progress#inline-progress)

## Live check
![change div to span](https://user-images.githubusercontent.com/16810067/115804334-175ff380-a3e3-11eb-9d82-b115e5d246e0.png)
