### PR TITLE
Removing primer/octicons dependency and adding octicons styles directly

### DIFF
--- a/.changeset/tiny-mangos-breathe.md
+++ b/.changeset/tiny-mangos-breathe.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': major
+---
+
+Remove dependency on primer/octicons and force overflow visible

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "release": "changeset publish"
   },
   "dependencies": {
-    "@primer/octicons": "13.0.0",
     "@primer/primitives": "4.3.0"
   },
   "devDependencies": {

--- a/src/base/index.scss
+++ b/src/base/index.scss
@@ -5,3 +5,4 @@
 @import "./base.scss";
 @import "./kbd.scss";
 @import "./typography-base.scss";
+@import "./octicons.scss";

--- a/src/base/octicons.scss
+++ b/src/base/octicons.scss
@@ -1,0 +1,6 @@
+.octicon {
+  display: inline-block;
+  overflow: visible !important;
+  vertical-align: text-bottom;
+  fill: currentColor;
+}

--- a/src/core/index.scss
+++ b/src/core/index.scss
@@ -5,9 +5,6 @@
  * Released under MIT license. Copyright (c) 2019 GitHub Inc.
  */
 
-// Include .octicon base styles
-@import "@primer/octicons/index.scss";
-
 // Global requirements
 @import "../support/index.scss";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,13 +760,6 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@primer/octicons@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons/-/octicons-13.0.0.tgz#dab1f156ac601d2cb7c83eab9242a1739429cf2e"
-  integrity sha512-kMNu3Ny3eocOTl2hxRC0YX0na7zJwpSIQNiZqmyqbLMKp2YwNAwk5Tan4RLGe35f30st+EbNq15dEjiMzslAcw==
-  dependencies:
-    object-assign "^4.1.1"
-
 "@primer/primitives@4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-4.3.0.tgz#446e868cd1c48437cbc3340c52b159ec2e015b78"
@@ -4976,7 +4969,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=


### PR DESCRIPTION
This removes the dependency for `@primer/octicons` we were using it to import the one stylesheet, which seemed like overkill and increased our package size.

I'm also adding `!important` to our overflow: visible; property to avoid icon clipping.

