### PR TITLE
typography-base: process 'type' attribute of HTML <ol> tag

### DIFF
--- a/.changeset/odd-foxes-invite.md
+++ b/.changeset/odd-foxes-invite.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+typography-base: process 'type' attribute of HTML <ol> tag

--- a/src/base/typography-base.scss
+++ b/src/base/typography-base.scss
@@ -58,6 +58,18 @@ ol ol ol {
   list-style-type: lower-alpha;
 }
 
+ol[type="1"] {
+  list-style-type: decimal;
+}
+
+ol[type="a"] {
+  list-style-type: lower-alpha;
+}
+
+ol[type="i"] {
+  list-style-type: lower-roman;
+}
+
 dd {
   margin-left: 0;
 }

--- a/src/base/typography-base.scss
+++ b/src/base/typography-base.scss
@@ -58,18 +58,6 @@ ol ol ol {
   list-style-type: lower-alpha;
 }
 
-ol[type="1"] {
-  list-style-type: decimal;
-}
-
-ol[type="a"] {
-  list-style-type: lower-alpha;
-}
-
-ol[type="i"] {
-  list-style-type: lower-roman;
-}
-
 dd {
   margin-left: 0;
 }

--- a/src/markdown/lists.scss
+++ b/src/markdown/lists.scss
@@ -13,6 +13,19 @@
       list-style-type: none;
     }
   }
+  
+  ol[type="1"] {
+    list-style-type: decimal;
+  }
+
+  ol[type="a"] {
+    list-style-type: lower-alpha;
+  }
+
+  ol[type="i"] {
+    list-style-type: lower-roman;
+  }
+
 
   // Did someone complain about list spacing? Encourage them
   // to create the spacing with their markdown formatting.


### PR DESCRIPTION
Some markup languages like AsciiDoc, allow defining the 'type'
attribute of HTML `<ol>` tag.
For instance, the following AsciiDoc code:

	[loweralpha]
	. item1
	. item2

Produces in GitHub the HTML code:

	<ol type="a">
		<li>item1</li>
		<li>item2</li>
	</ol>

The current SCSS doesn't cover this 'type' attribute, so the regular
default symbol (decimal) applies, instead of the one intended by the
author.

Signed-off-by: Hector Palacios <scarzia00@hotmail.com>
