### PR TITLE
Fix false deprecation of marketing button's [aria-disabled=true] states

### DIFF
--- a/deprecations.js
+++ b/deprecations.js
@@ -6,16 +6,6 @@
 const versionDeprecations = {
   '17.0.0': [
     {
-      selectors: [
-        '.btn-mktg[aria-disabled=true]',
-        '.btn-primary-mktg[aria-disabled=true]',
-        '.btn-outline-mktg[aria-disabled=true]',
-        '.btn-transparent[aria-disabled=true]',
-        '.btn-large-mktg'
-      ],
-      message: 'Removing marketing buttons'
-    },
-    {
       selectors: [':-ms-input-placeholder'],
       message: 'Browserslist update to match github has removed the need for this pseudoselector'
     }

--- a/deprecations.js
+++ b/deprecations.js
@@ -6,6 +6,10 @@
 const versionDeprecations = {
   '17.0.0': [
     {
+      selectors: ['.btn-large-mktg'],
+      message: `Please use the ".btn-lg-mktg" class instead of "btn-large-mktg".`
+    },
+    {
       selectors: [':-ms-input-placeholder'],
       message: 'Browserslist update to match github has removed the need for this pseudoselector'
     }

--- a/src/marketing/support/mixins.scss
+++ b/src/marketing/support/mixins.scss
@@ -11,7 +11,7 @@
   &.hover,
   &:active,
   &.selected,
-  &[aria-selected="true"],
+  &[aria-selected=true],
   [open] > & {
     background-color: $bg2;
     background-image: linear-gradient(-180deg, $bg 0%, $bg2 100%);
@@ -25,7 +25,7 @@
 
   &:disabled,
   &.disabled,
-  &[aria-disabled="true"] {
+  &[aria-disabled=true] {
     pointer-events: none;
     cursor: default;
     opacity: 0.5;
@@ -45,7 +45,7 @@
   &.hover,
   &:active,
   &.selected,
-  &[aria-selected="true"],
+  &[aria-selected=true],
   [open] > & {
     color: $color2;
     background: none;
@@ -60,7 +60,7 @@
 
   &:disabled,
   &.disabled,
-  &[aria-disabled="true"] {
+  &[aria-disabled=true] {
     opacity: 0.5;
   }
 }


### PR DESCRIPTION
Our test thinks there's been a deprecation of marketing button states, but there hasn't. This PR tries to fix that by removing the quotes around `true` for `&[aria-disabled="true"]`.

cc @simurai @jonrohan 