### PR TITLE
Use `--color-icon-secondary` for `.blankslate-icon`

### DIFF
--- a/.changeset/breezy-chairs-cross.md
+++ b/.changeset/breezy-chairs-cross.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Use `--color-icon-secondary` for `.blankslate-icon`

--- a/src/blankslate/blankslate.scss
+++ b/src/blankslate/blankslate.scss
@@ -28,7 +28,7 @@
   margin-bottom: $spacer-2;
   margin-left: $spacer-1;
   // stylelint-disable-next-line primer/colors
-  color: var(--color-blankslate-icon);
+  color: var(--color-icon-secondary);
 }
 
 .blankslate-capped {


### PR DESCRIPTION
- [x] Use `--color-icon-secondary` for `.blankslate-icon`.

Part of https://github.com/github/design-systems/issues/1393
