### PR TITLE
Marketing: Deprecate bg-shade-gradient

### DIFF
--- a/.changeset/modern-zebras-press.md
+++ b/.changeset/modern-zebras-press.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": major
+---
+
+Marketing: Deprecate bg-shade-gradient

--- a/deprecations.js
+++ b/deprecations.js
@@ -5,6 +5,10 @@
  */
 const versionDeprecations = {
   '17.0.0': [
+      {
+      selectors: ['.bg-shade-gradient'],
+      message: `This selector is deprecated, please use "color-bg-secondary" instead of "bg-shade-gradient".`
+    },
     {
       selectors: ['.btn-large-mktg'],
       message: `Please use the ".btn-lg-mktg" class instead of "btn-large-mktg".`

--- a/src/marketing/utilities/index.scss
+++ b/src/marketing/utilities/index.scss
@@ -5,5 +5,4 @@
 @import "./filters.scss";
 @import "./layout.scss";
 @import "./margin.scss";
-@import "./misc.scss";
 @import "./padding.scss";

--- a/src/marketing/utilities/misc.scss
+++ b/src/marketing/utilities/misc.scss
@@ -1,5 +1,0 @@
-.bg-shade-gradient {
-  background-image: linear-gradient(180deg, var(--color-mktg-bg-shade-gradient-top), var(--color-mktg-bg-shade-gradient-bottom)) !important;
-  background-repeat: no-repeat !important;
-  background-size: 100% 200px !important;
-}


### PR DESCRIPTION
This PR deprecates the `bg-shade-gradient` utility (no longer in use), and encourages use of `color-bg-secondary` instead.

/cc @primer/ds-core
