### PR TITLE
Remove redundant marketing layout selectors

### DIFF
--- a/.changeset/smooth-eagles-tie.md
+++ b/.changeset/smooth-eagles-tie.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Remove redundant marketing layout selectors

--- a/.changeset/smooth-eagles-tie.md
+++ b/.changeset/smooth-eagles-tie.md
@@ -1,5 +1,5 @@
 ---
-"@primer/css": minor
+"@primer/css": major
 ---
 
 Remove redundant marketing layout selectors

--- a/deprecations.js
+++ b/deprecations.js
@@ -6,6 +6,23 @@
 const versionDeprecations = {
   '17.0.0': [
     {
+      selectors: [
+        '.top-n0',
+        '.right-n0',
+        '.bottom-n0',
+        '.left-n0',
+        '.top-md-n0',
+        '.right-md-n0',
+        '.bottom-md-n0',
+        '.left-md-n0',
+        '.top-lg-n0',
+        '.right-lg-n0',
+        '.bottom-lg-n0',
+        '.left-lg-n0'
+      ],
+      message: `This selector is deprecated, please use a non-negative selector to set the value to 0 (e.g. top-md-0)".`
+    },
+    {
       selectors: ['.bg-shade-gradient'],
       message: `This selector is deprecated, please use "color-bg-secondary" instead of "bg-shade-gradient".`
     },

--- a/src/marketing/utilities/layout.scss
+++ b/src/marketing/utilities/layout.scss
@@ -6,15 +6,19 @@
 @each $breakpoint, $variant in $marketing-position-variants {
   @include breakpoint($breakpoint) {
     @each $scale, $size in $marketing-all-spacers {
-      .top#{$variant}-#{$scale}     { top: $size !important; }
-      .right#{$variant}-#{$scale}   { right: $size !important; }
-      .bottom#{$variant}-#{$scale}  { bottom: $size !important; }
-      .left#{$variant}-#{$scale}    { left: $size !important; }
+      @if ($size != 0 or $variant != "") {
+        .top#{$variant}-#{$scale}     { top: $size !important; }
+        .right#{$variant}-#{$scale}   { right: $size !important; }
+        .bottom#{$variant}-#{$scale}  { bottom: $size !important; }
+        .left#{$variant}-#{$scale}    { left: $size !important; }
+      }
 
-      .top#{$variant}-n#{$scale}     { top: -$size !important; }
-      .right#{$variant}-n#{$scale}   { right: -$size !important; }
-      .bottom#{$variant}-n#{$scale}  { bottom: -$size !important; }
-      .left#{$variant}-n#{$scale}    { left: -$size !important; }
+      @if ($size != 0) {
+        .top#{$variant}-n#{$scale}     { top: -$size !important; }
+        .right#{$variant}-n#{$scale}   { right: -$size !important; }
+        .bottom#{$variant}-n#{$scale}  { bottom: -$size !important; }
+        .left#{$variant}-n#{$scale}    { left: -$size !important; }
+      }
     }
   }
 }


### PR DESCRIPTION
This PR removes redundant marketing layout selectors by checking for `0` in `marketing/utlities/layout.scss`:

```scss
@each $breakpoint, $variant in $marketing-position-variants {
  @include breakpoint($breakpoint) {
    @each $scale, $size in $marketing-all-spacers {
      @if ($size != 0 or $variant != "") {
        .top#{$variant}-#{$scale}     { top: $size !important; }
        .right#{$variant}-#{$scale}   { right: $size !important; }
        .bottom#{$variant}-#{$scale}  { bottom: $size !important; }
        .left#{$variant}-#{$scale}    { left: $size !important; }
      }

      @if ($size != 0) {
        .top#{$variant}-n#{$scale}     { top: -$size !important; }
        .right#{$variant}-n#{$scale}   { right: -$size !important; }
        .bottom#{$variant}-n#{$scale}  { bottom: -$size !important; }
        .left#{$variant}-n#{$scale}    { left: -$size !important; }
      }
    }
  }
}
```

This change removes these selectors from the `marketing-utilities` bundle (all redundant):

```scss
 // Already defined in primer core
.top-0 {}
.right-0 {}
.bottom-0 {}
.left-0 {}

// Redundant (they are not negative)
.top-n0 {}
.right-n0 {}
.bottom-n0 {}
.left-n0 {}
.top-md-n0 {}
.right-md-n0 {}
.bottom-md-n0 {}
.left-md-n0 {}
.top-lg-n0 {}
.right-lg-n0 {}
.bottom-lg-n0 {}
.left-lg-n0 {}
```