### PR TITLE
Docs typo: dropdown

### DIFF
--- a/docs/content/support/v16-migration.mdx
+++ b/docs/content/support/v16-migration.mdx
@@ -24,7 +24,7 @@ Most components don't need to be updated and should work without making changes.
 | `.Counter--gray`                                             | `.Counter--primary`   |
 | `.Counter--gray-light`                                       | `.Counter--secondary` |
 
-### Dropdwon
+### Dropdown
 
 | [`v15`](https://primer.style/css/components/dropdown#dark) | `v16` |
 | ---------------------------------------------------------- | ----- |


### PR DESCRIPTION
The heading for "dropdown" is misspelled.

/cc @primer/ds-core
