### PR TITLE
Marketing: use size modifiers that don't look like breakpoints modifiers

### DIFF
--- a/.changeset/thirty-experts-exist.md
+++ b/.changeset/thirty-experts-exist.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": major
+---
+
+Marketing: use size modifiers that don't look like breakpoints modifiers

--- a/deprecations.js
+++ b/deprecations.js
@@ -80,10 +80,6 @@ const versionDeprecations = {
       message: `This selector is deprecated, please use "color-bg-secondary" instead of "bg-shade-gradient".`
     },
     {
-      selectors: ['.btn-large-mktg'],
-      message: `Please use the ".btn-lg-mktg" class instead of "btn-large-mktg".`
-    },
-    {
       selectors: ['.color-border-overlay'],
       message: `Please use the ".color-border-primary" class instead of ".color-border-overlay".`
     },

--- a/src/marketing/buttons/button.scss
+++ b/src/marketing/buttons/button.scss
@@ -95,12 +95,12 @@
 
 // Size modifiers
 
-.btn-sm-mktg {
+.btn-small-mktg {
   // stylelint-disable-next-line primer/spacing
   padding: rem(10px) rem($spacer-3) rem(13px);
 }
 
-.btn-lg-mktg {
+.btn-large-mktg {
   // stylelint-disable-next-line primer/spacing
   padding: 20px 30px 23px !important;
 }


### PR DESCRIPTION
The `.btn-lg-mktg` and `.btn-sm-mktg` utility classes make buttons larger and smaller, but they can at a glance look like they will only apply a button style from `lg` and `sm` breakpoints and upwards. This PR updates these classes to be called `.btn-large-mktg` and `.btn-small-mktg` instead, to reduce similarity with the breakpoint modifiers.