### PR TITLE
Fix style lint errors introduced in new marketing type scale PR

### DIFF
--- a/.changeset/four-peaches-reflect.md
+++ b/.changeset/four-peaches-reflect.md
@@ -1,5 +1,0 @@
----
-"@primer/css": patch
----
-
-Fix style lint errors introduced in new marketing type scale PR

--- a/deprecations.js
+++ b/deprecations.js
@@ -6,6 +6,10 @@
 const versionDeprecations = {
   '17.0.0': [
     {
+      variables: ['$h000-size', '$h000-size-mobile'],
+      message: `This variable is deprecated, please refer to the Marketing Typography documentation.`
+    },
+    {
       selectors: ['.h000-mktg', '.h00-mktg', '.lead-mktg'],
       message: `This selector is deprecated, please refer to the Marketing Typography documentation.`
     },

--- a/deprecations.js
+++ b/deprecations.js
@@ -6,11 +6,7 @@
 const versionDeprecations = {
   '17.0.0': [
     {
-      selectors: [
-          '.h000-mktg',
-          '.h00-mktg',
-          '.lead-mktg'
-      ],
+      selectors: ['.h000-mktg', '.h00-mktg', '.lead-mktg'],
       message: `This selector is deprecated, please refer to the Marketing Typography documentation.`
     },
     {

--- a/src/marketing/support/variables.scss
+++ b/src/marketing/support/variables.scss
@@ -1,3 +1,4 @@
+// stylelint-disable unit-no-unknown
 // Typography
 $marketing-font-path: "/fonts/" !default;
 

--- a/src/marketing/type/typography.scss
+++ b/src/marketing/type/typography.scss
@@ -8,6 +8,7 @@
 .h6-mktg {
   font-family: $font-mktg;
   font-feature-settings: $mktg-font-feature-settings;
+  // stylelint-disable-next-line primer/typography
   font-weight: $mktg-header-weight-default !important;
   letter-spacing: $mktg-header-spacing-default !important;
 }


### PR DESCRIPTION
This PR fixes three stylelint/eslint errors that were introduced in https://github.com/primer/css/pull/1379. One for `unit-no-unkown`, triggered by the scale map/lists:

```
$mktg-headers: (
  0: [4, 1, 0],
  1: [5, 3, 1],
  2: [6, 4, 2],
  3: [7, 5, 4],
  4: [8, 7, 6],
  5: [9, 8, 8],
  6: [10, 9, 9]
) !default;
```

And one `primer/typography` error, where the font-weight is set via a variable:

```
font-weight: $mktg-header-weight-default !important;
```

Both of these errors have been fixed by disabling these rules for these instances.