### PR TITLE
Marketing typography: 64px → 68px for third size step

### DIFF
--- a/.changeset/kind-roses-lie.md
+++ b/.changeset/kind-roses-lie.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Marketing typography: 64px → 68px for third size step

--- a/src/marketing/support/variables.scss
+++ b/src/marketing/support/variables.scss
@@ -27,7 +27,7 @@ $mktg-h-size-10: 16px !default;
 // Header Line-height steps
 $mktg-h-lh-0:  100px !default;
 $mktg-h-lh-1:  76px !default;
-$mktg-h-lh-2:  64px !default;
+$mktg-h-lh-2:  68px !default;
 $mktg-h-lh-3:  60px !default;
 $mktg-h-lh-4:  52px !default;
 $mktg-h-lh-5:  44px !default;


### PR DESCRIPTION
This PR fixes an issue where the `line-height` for the third step in the marketing type scale was set too low (64px, should be 68px).