### PR TITLE
Improve focus state for .SideNav and .menu

### DIFF
--- a/.changeset/chilly-yaks-hope.md
+++ b/.changeset/chilly-yaks-hope.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Improve focus state for .SideNav and .menu

--- a/src/navigation/menu.scss
+++ b/src/navigation/menu.scss
@@ -33,11 +33,15 @@
     &::before { border-bottom-left-radius: $border-radius; }
   }
 
-  &:focus,
+  &:focus {
+    z-index: 1;
+    outline: none;
+    box-shadow: var(--color-state-focus-shadow);
+  }
+
   &:hover {
     text-decoration: none;
     background-color: var(--color-state-hover-secondary-bg);
-    outline: none;
   }
 
   &:active {

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -43,8 +43,13 @@
 
 // States
 
-.SideNav-item:hover,
 .SideNav-item:focus {
+  z-index: 1;
+  outline: none;
+  box-shadow: var(--color-state-focus-shadow);
+}
+
+.SideNav-item:hover {
   text-decoration: none;
   background-color: var(--color-state-hover-secondary-bg);
   outline: none;


### PR DESCRIPTION
This makes the `:focus` state more visible for `.SideNav` and `.menu`. Currently only the background changes, but it's too subtle.

![sidenav](https://user-images.githubusercontent.com/378023/117787286-4995a000-b281-11eb-8175-aeac8f128951.gif)

![menu](https://user-images.githubusercontent.com/378023/117787291-4ac6cd00-b281-11eb-861e-a7acfd1c60b4.gif)

It doesn't look that great, but maybe still better than only have a subtle change in background. Also, the these two components will probably be replaced sooner or later.