### PR TITLE
Marketing: Fix letter spacing for headers not being correctly overridden at break points

### DIFF
--- a/.changeset/seven-files-guess.md
+++ b/.changeset/seven-files-guess.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Marketing: Fix letter spacing for headers not being correctly overridden at break points

--- a/src/marketing/type/typography.scss
+++ b/src/marketing/type/typography.scss
@@ -28,7 +28,7 @@
         font-size: map-get($pairing-md, "size") !important;
         line-height: map-get($pairing-md, "lh") !important;
         @if (map-get($pairing-md, "size") >= $mktg-header-spacing-threshold and map-get($pairing, "size") < $mktg-header-spacing-threshold) {
-          letter-spacing: $mktg-header-spacing-large;
+          letter-spacing: $mktg-header-spacing-large !important;
         }
         @if (map-get($pairing-md, "size") >= $mktg-header-weight-threshold and map-get($pairing, "size") < $mktg-header-weight-threshold) {
           font-weight: $mktg-header-weight-large !important;
@@ -41,7 +41,7 @@
         font-size: map-get($pairing-lg, "size") !important;
         line-height: map-get($pairing-lg, "lh") !important;
         @if (map-get($pairing-lg, "size") >= $mktg-header-spacing-threshold and map-get($pairing-md, "size") < $mktg-header-spacing-threshold) {
-          letter-spacing: $mktg-header-spacing-large;
+          letter-spacing: $mktg-header-spacing-large !important;
         }
         @if (map-get($pairing-lg, "size") >= $mktg-header-weight-threshold and map-get($pairing-md, "size") < $mktg-header-weight-threshold) {
           font-weight: $mktg-header-weight-large !important;


### PR DESCRIPTION
This PR fixes an issue where the `letter-spacing` of the marketing headers wouldn't change at any breakpoint, since the default value is declared with `!important`, but the breakpoint values aren't. This PR changes it so that all `letter-spacing` declarations are set with `!important`. 