### PR TITLE
Fix colors v2 mixin names

### DIFF
--- a/src/base/modes-v2.scss
+++ b/src/base/modes-v2.scss
@@ -1,22 +1,22 @@
 // EXPERIMENTAL. DO NOT USE.
 
-@import "../support/mixins/color-modes.scss";
+@import '../support/mixins/color-modes.scss';
 
-@import "@primer/primitives/dist/scss/colors_v2/_light.scss";
-@import "@primer/primitives/dist/scss/colors_v2/_dark.scss";
-@import "@primer/primitives/dist/scss/colors_v2/_dark_dimmed.scss";
+@import '@primer/primitives/dist/scss/colors_v2/_light.scss';
+@import '@primer/primitives/dist/scss/colors_v2/_dark.scss';
+@import '@primer/primitives/dist/scss/colors_v2/_dark_dimmed.scss';
 
 // Outputs the CSS variables
 // Use :root (html element) to define a default
 
 @include color-mode-theme(light, true) {
-  @include primer-colors-light;
+  @include primer-colors_v2-light;
 }
 
 @include color-mode-theme(dark) {
-  @include primer-colors-dark;
+  @include primer-colors_v2-dark;
 }
 
 @include color-mode-theme(dark_dimmed) {
-  @include primer-colors-dark_dimmed;
+  @include primer-colors_v2-dark_dimmed;
 }


### PR DESCRIPTION
This PR fixes the mixin names used in `modes-v2.scss`. e.g: `primer-colors-light` → `primer-colors_v2-light`