### PR TITLE
Marketing: Remove !important from all body content utilities weight declarations

### DIFF
--- a/.changeset/twenty-apples-attack.md
+++ b/.changeset/twenty-apples-attack.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Remove !important for base styles for body utilities

--- a/src/marketing/type/typography.scss
+++ b/src/marketing/type/typography.scss
@@ -72,7 +72,7 @@
     font-size: map-get($pairing, "size") !important;
     line-height: map-get($pairing, "lh") !important;
     @if (map-get($pairing, "size") >= $mktg-body-spacing-threshold) { letter-spacing: $mktg-body-spacing-large !important; }
-    @if (map-get($pairing, "size") >= $mktg-body-weight-threshold) { font-weight: $font-weight-semibold !important; }
+    @if (map-get($pairing, "size") >= $mktg-body-weight-threshold) { font-weight: $font-weight-semibold; }
 
     @if (nth($sizes, 1) != nth($sizes, 2)) {
       @include breakpoint(md) {


### PR DESCRIPTION
I missed an instance of `!important` in https://github.com/primer/css/pull/1392—this PR fixes that oversight, so that all marketing body utilities (`.f0-mktg` - `.f6-mktg`) can be overridden with text utilities, e.g. `.text-bold`.