### PR TITLE
Undeprecate .css-truncate

### DIFF
--- a/.changeset/sixty-drinks-dress.md
+++ b/.changeset/sixty-drinks-dress.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Undeprecate .css-truncate

--- a/deprecations.js
+++ b/deprecations.js
@@ -4,12 +4,6 @@
  * array and a "message" string.
  */
 const versionDeprecations = {
-  '18.0.0': [
-    {
-      selectors: ['.css-truncate', '.css-truncate-target', '.css-truncate-overflow', '.expandable'],
-      message: '.css-truncate has been deprecated in favor of .Truncate'
-    }
-  ],
   '17.0.0': [
     {
       variables: ['$h000-size', '$h000-size-mobile'],


### PR DESCRIPTION
This removes the deprecation for `.css-truncate` again since it makes the linter on dotcom fail.