### PR TITLE
lists.scss: reset <ol> without 'type' attr to "decimal"

### DIFF
--- a/.changeset/quiet-rings-confess.md
+++ b/.changeset/quiet-rings-confess.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+lists.scss: reset <ol> without 'type' attr to "decimal"

--- a/src/markdown/lists.scss
+++ b/src/markdown/lists.scss
@@ -26,6 +26,12 @@
     list-style-type: lower-roman;
   }
 
+  // Reset <ol> style to decimal (HTML default) specifically for AsciiDoc
+  // <div><ol> construction (doesn't affect MarkDown)
+  div > ol:not([type]) {
+    list-style-type: decimal;
+  }
+
   // Did someone complain about list spacing? Encourage them
   // to create the spacing with their markdown formatting.
   // List behavior should be controled by the markup, not the css.


### PR DESCRIPTION
HTML default list-style-type is "decimal" when there is no 'type'
attribute.

In MarkDown language, you can't specify the style type of a list
item, so nested lists *always* represent with decimal numbers at
any level. Since this is not user friendly, GitHub CSS styling
overrides the HTML standard by setting lower-roman for second-level
items and lower-alpha for third-level items.

In AsciiDoc language, you can specify the style type of a list
item using a tage before the list, for example:

```
   Tag		    Produces
   [loweralpha]     <ol type="a">
   [lowerroman]     <ol type="i">
   [decimal]        <ol>
```

The [decimal] tag doesn't generate any 'type' attribute because
the HTML standard when there is no type, *is* decimal.
If such a [decimal] tag is used on a second-level or third-level
item, GitHub CSS for MarkDown overrides HTML standard and you get
instead a lowerroman or loweralpha sign.

The added CSS resets the list-style-type of `<ol>` without type to
decimal, as it should be in the first place, for the construction
div > ol, which is only produced by AsciiDoc files, to avoid any effect
on existing MarkDown files.

