### PR TITLE
Improve Layout dividers when flowing as row

### DIFF
--- a/.changeset/large-masks-walk.md
+++ b/.changeset/large-masks-walk.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Improve dividers in `Layout` when flowing as row.

--- a/docs/content/components/layout.md
+++ b/docs/content/components/layout.md
@@ -40,8 +40,8 @@ of the sidebar position.
 
 ### Dividers
 
-Add `Layout--divided` to the `Layout` to show the dividers.
-Add `Layout--divided-shallow` to change the divider on `sm` to be filled and 8px tall.
+Use `Layout--divided` in conjuction with a `Layout-divider` to show a divider between the main content and the sidebar.
+Add `Layout-divider--shallow` to change the divider on `sm` to be filled and 8px tall.
 
 
 ```html live
@@ -55,7 +55,7 @@ Add `Layout--divided-shallow` to change the divider on `sm` to be filled and 8px
   <div class="Layout-divider"></div>
   <div class="Layout-sidebar border">divider hidden</div>
 </div>
-<div class="Layout Layout--divided Layout--divided-shallow ">
+<div class="Layout Layout--divided">
   <div class="Layout-main border">main content</div>
   <div class="Layout-divider Layout-divider--shallow"></div>
   <div class="Layout-sidebar border">shallow divider</div>

--- a/docs/content/components/layout.md
+++ b/docs/content/components/layout.md
@@ -41,6 +41,8 @@ of the sidebar position.
 ### Dividers
 
 Add `Layout--divided` to the `Layout` to show the dividers.
+Add `Layout--divided-shallow` to change the divider on `sm` to be filled and 8px tall.
+
 
 ```html live
 <div class="Layout Layout--divided">
@@ -52,6 +54,11 @@ Add `Layout--divided` to the `Layout` to show the dividers.
   <div class="Layout-main border">main content</div>
   <div class="Layout-divider"></div>
   <div class="Layout-sidebar border">divider hidden</div>
+</div>
+<div class="Layout Layout--divided Layout--divided-shallow ">
+  <div class="Layout-main border">main content</div>
+  <div class="Layout-divider Layout-divider--shallow"></div>
+  <div class="Layout-sidebar border">shallow divider</div>
 </div>
 ```
 

--- a/src/layout/index.scss
+++ b/src/layout/index.scss
@@ -1,4 +1,6 @@
 @import "../support/index.scss";
+@import "./mixins.scss";
+
 @import "./container.scss";
 @import "./grid.scss";
 @import "./grid-offset.scss";

--- a/src/layout/layout.scss
+++ b/src/layout/layout.scss
@@ -6,42 +6,18 @@
   --Layout-gutter: 16px;
 
   @media (max-width: calc(#{$width-sm} - 1px)) {
-    grid-auto-flow: row;
-    grid-template-columns: 1fr !important;
-
-    .Layout-sidebar,
-    .Layout-divider,
-    .Layout-main {
-        width: 100% !important;
-        grid-column: 1 !important;
-      }
+    @include flow-as-row;
   }
 
   &.Layout--flowRow-until-md {
     @media (max-width: calc(#{$width-md} - 1px)) {
-      grid-auto-flow: row;
-      grid-template-columns: 1fr !important;
-
-      .Layout-sidebar,
-      .Layout-divider,
-      .Layout-main {
-        width: 100% !important;
-        grid-column: 1 !important;
-      }
+      @include flow-as-row;
     }
   }
 
   &.Layout--flowRow-until-lg {
     @media (max-width: calc(#{$width-lg} - 1px)) {
-      grid-auto-flow: row;
-      grid-template-columns: 1fr !important;
-
-      .Layout-sidebar,
-      .Layout-divider,
-      .Layout-main {
-        width: 100% !important;
-        grid-column: 1 !important;
-      }
+      @include flow-as-row;
     }
   }
 
@@ -139,23 +115,6 @@
   // Sidebar divider
 
   &.Layout--divided {
-    @media (max-width: calc(#{$width-sm} - 1px)) {
-      --Layout-gutter: 0;
-
-      .Layout-divider {
-        height: 1px;
-
-        &.Layout-divider--shallow {
-          margin-right: 0;
-          height: 8px;
-          background: var(--color-bg-canvas-inset);
-          border-width: $border-width 0;
-          border-color: var(--color-border-primary);
-          border-style: solid;
-        }
-      }
-    }
-
     .Layout-divider {
       display: block;
       grid-column: 2;

--- a/src/layout/layout.scss
+++ b/src/layout/layout.scss
@@ -139,13 +139,13 @@
   // Sidebar divider
 
   &.Layout--divided {
-    &.Layout--divided-shallow {
-      @media (max-width: calc(#{$width-sm} - 1px)) {
-        --Layout-gutter: 0;
-      }
+    @media (max-width: calc(#{$width-sm} - 1px)) {
+      --Layout-gutter: 0;
 
       .Layout-divider {
-        @media (max-width: calc(#{$width-sm} - 1px)) {
+        height: 1px;
+
+        &.Layout-divider--shallow {
           margin-right: 0;
           height: 8px;
           background: var(--color-bg-canvas-inset);

--- a/src/layout/layout.scss
+++ b/src/layout/layout.scss
@@ -139,6 +139,23 @@
   // Sidebar divider
 
   &.Layout--divided {
+    &.Layout--divided-shallow {
+      @media (max-width: calc(#{$width-sm} - 1px)) {
+        --Layout-gutter: 0;
+      }
+
+      .Layout-divider {
+        @media (max-width: calc(#{$width-sm} - 1px)) {
+          margin-right: 0;
+          height: 8px;
+          background: var(--color-bg-canvas-inset);
+          border-width: $border-width 0;
+          border-color: var(--color-border-primary);
+          border-style: solid;
+        }
+      }
+    }
+
     .Layout-divider {
       display: block;
       grid-column: 2;

--- a/src/layout/mixins.scss
+++ b/src/layout/mixins.scss
@@ -12,7 +12,7 @@
     }
 
   &.Layout--divided {
-    @include flow-as-row-divider
+    @include flow-as-row-divider;
   }
 }
 
@@ -23,12 +23,12 @@
     height: 1px;
 
     &.Layout-divider--shallow {
-      margin-right: 0;
       height: 8px;
+      margin-right: 0;
       background: var(--color-bg-canvas-inset);
-      border-width: $border-width 0;
       border-color: var(--color-border-primary);
       border-style: solid;
+      border-width: $border-width 0;
     }
   }
 }

--- a/src/layout/mixins.scss
+++ b/src/layout/mixins.scss
@@ -1,0 +1,34 @@
+// Layout mixins
+
+@mixin flow-as-row {
+  grid-auto-flow: row;
+  grid-template-columns: 1fr !important;
+
+  .Layout-sidebar,
+  .Layout-divider,
+  .Layout-main {
+      width: 100% !important;
+      grid-column: 1 !important;
+    }
+
+  &.Layout--divided {
+    @include flow-as-row-divider
+  }
+}
+
+@mixin flow-as-row-divider {
+  --Layout-gutter: 0;
+
+  .Layout-divider {
+    height: 1px;
+
+    &.Layout-divider--shallow {
+      margin-right: 0;
+      height: 8px;
+      background: var(--color-bg-canvas-inset);
+      border-width: $border-width 0;
+      border-color: var(--color-border-primary);
+      border-style: solid;
+    }
+  }
+}


### PR DESCRIPTION
Dividers in the `Layout` component weren't being properly set when the layout was flowing as a row. Here, I extracted the `flow-as-row` logic to a mixing, making it also adjust the necessary gutters and sizes for dividers. I'm also adding the `Layout-divider--shallow` class that was missing.

| Before | After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/11280312/119565530-adcf5e00-bd6f-11eb-842c-8d7a73da5cd0.png) | ![image](https://user-images.githubusercontent.com/11280312/119565670-dbb4a280-bd6f-11eb-8355-fafcc06e24a4.png) | 

cc @vdepizzol 