### PR TITLE
Improve dividers and allow sidebar positioning when `Layout` is flowing as row.

### DIFF
--- a/.changeset/large-masks-walk.md
+++ b/.changeset/large-masks-walk.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Improve dividers in `Layout` when flowing as row.

--- a/.changeset/large-masks-walk.md
+++ b/.changeset/large-masks-walk.md
@@ -2,4 +2,4 @@
 '@primer/css': patch
 ---
 
-Improve dividers in `Layout` when flowing as row.
+Improve dividers and allow sidebar positioning when `Layout` is flowing as row.

--- a/docs/content/components/layout.md
+++ b/docs/content/components/layout.md
@@ -40,8 +40,8 @@ of the sidebar position.
 
 ### Dividers
 
-Add `Layout--divided` to the `Layout` to show the dividers.
-Add `Layout--divided-shallow` to change the divider on `sm` to be filled and 8px tall.
+Use `Layout--divided` in conjuction with a `Layout-divider` to show a divider between the main content and the sidebar.
+Add `Layout-divider--shallow` to change the divider on `sm` to be filled and 8px tall.
 
 
 ```html live
@@ -55,7 +55,7 @@ Add `Layout--divided-shallow` to change the divider on `sm` to be filled and 8px
   <div class="Layout-divider"></div>
   <div class="Layout-sidebar border">divider hidden</div>
 </div>
-<div class="Layout Layout--divided Layout--divided-shallow ">
+<div class="Layout Layout--divided">
   <div class="Layout-main border">main content</div>
   <div class="Layout-divider Layout-divider--shallow"></div>
   <div class="Layout-sidebar border">shallow divider</div>

--- a/docs/content/components/layout.md
+++ b/docs/content/components/layout.md
@@ -41,7 +41,10 @@ of the sidebar position.
 ### Dividers
 
 Use `Layout--divided` in conjuction with a `Layout-divider` to show a divider between the main content and the sidebar.
-Add `Layout-divider--shallow` to change the divider on `sm` to be filled and 8px tall.
+Flowing as row:
+- default: shows a `1px` line between main and sidebar
+- `Layout-divider--flowRow-shallow`: shows a filled `8px` divider.
+- `Layout-divider--flowRow-hidden`: hides the divider
 
 
 ```html live
@@ -57,8 +60,13 @@ Add `Layout-divider--shallow` to change the divider on `sm` to be filled and 8px
 </div>
 <div class="Layout Layout--divided">
   <div class="Layout-main border">main content</div>
-  <div class="Layout-divider Layout-divider--shallow"></div>
-  <div class="Layout-sidebar border">shallow divider</div>
+  <div class="Layout-divider Layout-divider--flowRow-shallow"></div>
+  <div class="Layout-sidebar border">flowRow shallow divider</div>
+</div>
+<div class="Layout Layout--divided">
+  <div class="Layout-main border">main content</div>
+  <div class="Layout-divider Layout-divider--flowRow-hidden"></div>
+  <div class="Layout-sidebar border">flowRow hidden divider</div>
 </div>
 ```
 

--- a/docs/content/components/layout.md
+++ b/docs/content/components/layout.md
@@ -41,6 +41,8 @@ of the sidebar position.
 ### Dividers
 
 Add `Layout--divided` to the `Layout` to show the dividers.
+Add `Layout--divided-shallow` to change the divider on `sm` to be filled and 8px tall.
+
 
 ```html live
 <div class="Layout Layout--divided">
@@ -52,6 +54,11 @@ Add `Layout--divided` to the `Layout` to show the dividers.
   <div class="Layout-main border">main content</div>
   <div class="Layout-divider"></div>
   <div class="Layout-sidebar border">divider hidden</div>
+</div>
+<div class="Layout Layout--divided Layout--divided-shallow ">
+  <div class="Layout-main border">main content</div>
+  <div class="Layout-divider Layout-divider--shallow"></div>
+  <div class="Layout-sidebar border">shallow divider</div>
 </div>
 ```
 

--- a/docs/content/components/layout.md
+++ b/docs/content/components/layout.md
@@ -188,6 +188,27 @@ Add `Layout-divider--shallow` to change the divider on `sm` to be filled and 8px
 </div>
 ```
 
+### Sidebar positioning as rows
+
+- `Layout--sidebarPosition-flowRow-start` (default): when stacked, render the sidebar first
+- `Layout--sidebarPosition-flowRow-end`: when stacked, render the sidebar last
+- `Layout--sidebarPosition-flowRow-none`: when stacked, hide the sidebar
+
+```html live
+<div class="Layout Layout--sidebarPosition-flowRow-start">
+  <div class="Layout-main border">main</div>
+  <div class="Layout-sidebar border">sidebar</div>
+</div>
+<div class="Layout Layout--sidebarPosition-flowRow-end">
+  <div class="Layout-main border">main</div>
+  <div class="Layout-sidebar border">sidebar</div>
+</div>
+<div class="Layout Layout--sidebarPosition-flowRow-none">
+  <div class="Layout-main border">main</div>
+  <div class="Layout-sidebar border">sidebar</div>
+</div>
+```
+
 ### Layout stacking
 
 - Default: stacks when container is `sm`.

--- a/src/layout/index.scss
+++ b/src/layout/index.scss
@@ -1,4 +1,6 @@
 @import "../support/index.scss";
+@import "./mixins.scss";
+
 @import "./container.scss";
 @import "./grid.scss";
 @import "./grid-offset.scss";

--- a/src/layout/layout.scss
+++ b/src/layout/layout.scss
@@ -6,42 +6,18 @@
   --Layout-gutter: 16px;
 
   @media (max-width: calc(#{$width-sm} - 1px)) {
-    grid-auto-flow: row;
-    grid-template-columns: 1fr !important;
-
-    .Layout-sidebar,
-    .Layout-divider,
-    .Layout-main {
-        width: 100% !important;
-        grid-column: 1 !important;
-      }
+    @include flow-as-row;
   }
 
   &.Layout--flowRow-until-md {
     @media (max-width: calc(#{$width-md} - 1px)) {
-      grid-auto-flow: row;
-      grid-template-columns: 1fr !important;
-
-      .Layout-sidebar,
-      .Layout-divider,
-      .Layout-main {
-        width: 100% !important;
-        grid-column: 1 !important;
-      }
+      @include flow-as-row;
     }
   }
 
   &.Layout--flowRow-until-lg {
     @media (max-width: calc(#{$width-lg} - 1px)) {
-      grid-auto-flow: row;
-      grid-template-columns: 1fr !important;
-
-      .Layout-sidebar,
-      .Layout-divider,
-      .Layout-main {
-        width: 100% !important;
-        grid-column: 1 !important;
-      }
+      @include flow-as-row;
     }
   }
 
@@ -139,23 +115,6 @@
   // Sidebar divider
 
   &.Layout--divided {
-    @media (max-width: calc(#{$width-sm} - 1px)) {
-      --Layout-gutter: 0;
-
-      .Layout-divider {
-        height: 1px;
-
-        &.Layout-divider--shallow {
-          margin-right: 0;
-          height: 8px;
-          background: var(--color-bg-canvas-inset);
-          border-width: $border-width 0;
-          border-color: var(--color-border-primary);
-          border-style: solid;
-        }
-      }
-    }
-
     .Layout-divider {
       display: block;
       grid-column: 2;

--- a/src/layout/layout.scss
+++ b/src/layout/layout.scss
@@ -139,13 +139,13 @@
   // Sidebar divider
 
   &.Layout--divided {
-    &.Layout--divided-shallow {
-      @media (max-width: calc(#{$width-sm} - 1px)) {
-        --Layout-gutter: 0;
-      }
+    @media (max-width: calc(#{$width-sm} - 1px)) {
+      --Layout-gutter: 0;
 
       .Layout-divider {
-        @media (max-width: calc(#{$width-sm} - 1px)) {
+        height: 1px;
+
+        &.Layout-divider--shallow {
           margin-right: 0;
           height: 8px;
           background: var(--color-bg-canvas-inset);

--- a/src/layout/layout.scss
+++ b/src/layout/layout.scss
@@ -139,6 +139,23 @@
   // Sidebar divider
 
   &.Layout--divided {
+    &.Layout--divided-shallow {
+      @media (max-width: calc(#{$width-sm} - 1px)) {
+        --Layout-gutter: 0;
+      }
+
+      .Layout-divider {
+        @media (max-width: calc(#{$width-sm} - 1px)) {
+          margin-right: 0;
+          height: 8px;
+          background: var(--color-bg-canvas-inset);
+          border-width: $border-width 0;
+          border-color: var(--color-border-primary);
+          border-style: solid;
+        }
+      }
+    }
+
     .Layout-divider {
       display: block;
       grid-column: 2;

--- a/src/layout/mixins.scss
+++ b/src/layout/mixins.scss
@@ -48,7 +48,11 @@
   .Layout-divider {
     height: 1px;
 
-    &.Layout-divider--shallow {
+    &.Layout-divider--flowRow-hidden {
+      display: none;
+    }
+
+    &.Layout-divider--flowRow-shallow {
       height: 8px;
       margin-right: 0;
       background: var(--color-bg-canvas-inset);

--- a/src/layout/mixins.scss
+++ b/src/layout/mixins.scss
@@ -12,7 +12,7 @@
     }
 
   &.Layout--divided {
-    @include flow-as-row-divider
+    @include flow-as-row-divider;
   }
 }
 
@@ -23,12 +23,12 @@
     height: 1px;
 
     &.Layout-divider--shallow {
-      margin-right: 0;
       height: 8px;
+      margin-right: 0;
       background: var(--color-bg-canvas-inset);
-      border-width: $border-width 0;
       border-color: var(--color-border-primary);
       border-style: solid;
+      border-width: $border-width 0;
     }
   }
 }

--- a/src/layout/mixins.scss
+++ b/src/layout/mixins.scss
@@ -1,0 +1,34 @@
+// Layout mixins
+
+@mixin flow-as-row {
+  grid-auto-flow: row;
+  grid-template-columns: 1fr !important;
+
+  .Layout-sidebar,
+  .Layout-divider,
+  .Layout-main {
+      width: 100% !important;
+      grid-column: 1 !important;
+    }
+
+  &.Layout--divided {
+    @include flow-as-row-divider
+  }
+}
+
+@mixin flow-as-row-divider {
+  --Layout-gutter: 0;
+
+  .Layout-divider {
+    height: 1px;
+
+    &.Layout-divider--shallow {
+      margin-right: 0;
+      height: 8px;
+      background: var(--color-bg-canvas-inset);
+      border-width: $border-width 0;
+      border-color: var(--color-border-primary);
+      border-style: solid;
+    }
+  }
+}

--- a/src/layout/mixins.scss
+++ b/src/layout/mixins.scss
@@ -14,6 +14,32 @@
   &.Layout--divided {
     @include flow-as-row-divider;
   }
+
+  &.Layout--sidebarPosition-flowRow-start {
+    .Layout-sidebar {
+      grid-row: 1;
+    }
+
+    .Layout-main {
+      grid-row: 2 / span 2;
+    }
+  }
+
+  &.Layout--sidebarPosition-flowRow-end {
+    .Layout-sidebar {
+      grid-row: 2 / span 2;
+    }
+
+    .Layout-main {
+      grid-row: 1;
+    }
+  }
+
+  &.Layout--sidebarPosition-flowRow-none {
+    .Layout-sidebar {
+      display: none;
+    }
+  }
 }
 
 @mixin flow-as-row-divider {


### PR DESCRIPTION
### Dividers

Dividers in the `Layout` component weren't correctly set when the layout was flowing as a row. Here, I extracted the `flow-as-row` logic to a mixing, making it also adjust the necessary gutters and sizes for dividers. I'm also adding the `Layout-divider--flowRow-shallow` and `Layout-divider--flowRow-hidden` classes that were missing.

| Before | After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/11280312/119565530-adcf5e00-bd6f-11eb-842c-8d7a73da5cd0.png) | ![image](https://user-images.githubusercontent.com/11280312/119688860-f9384980-be0d-11eb-8291-1e1ad80a5838.png) |

### Sidebar positioning

This PR also adds the `Layout--sidebarPosition-flowRow-XYZ` classes, which allows the user to decide where the sidebar should be placed when the Layout is flowing as row.

![image](https://user-images.githubusercontent.com/11280312/119568230-e290e480-bd72-11eb-98ab-9d5caf6761ce.png)

cc @vdepizzol 