### PR TITLE
Properly calculating the variables computed value for dist folder

### DIFF
--- a/.changeset/fuzzy-cars-promise.md
+++ b/.changeset/fuzzy-cars-promise.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Properly calculating the variables computed value for dist folder

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "jest": "26.6.3",
     "js-yaml": "4.1.0",
     "postcss": "8.3.0",
+    "postcss-calc": "8.0.0",
     "postcss-import": "14.0.2",
     "postcss-load-config": "3.0.1",
     "postcss-node-sass": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5337,6 +5337,14 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+postcss-calc@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-8.0.0.tgz#a05b87aacd132740a5db09462a3612453e5df90a"
+  integrity sha512-5NglwDrcbiy8XXfPM11F3HeC6hoT9W7GUH/Zi5U/p7u3Irv4rHhdDcIZwG0llHXV4ftsBjpfWMXAnXNl4lnt8g==
+  dependencies:
+    postcss-selector-parser "^6.0.2"
+    postcss-value-parser "^4.0.2"
+
 postcss-custom-properties@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-10.0.0.tgz#5cb31afc530f58ad241f1e836dd5f5f7065334df"


### PR DESCRIPTION
This update fixes an issue with our `/dist/variables.json` file. We weren't properly computing the values, which creates a bug in our stylelint.

[Example output from canary release](https://unpkg.com/browse/@primer/css@0.0.0-202142521310/dist/variables.json)

<table>
<tr>
<td>
<h3>Before</h3>
<pre><code>"$spacer-1": {
  "values": [
    "round($spacer / 2)",
    "round(8px / 2)"
  ],
  "source": {
    "path": "src/support/variables/layout.scss",
    "line": 36
  },
  "computed": "round(8px / 2)"
},
"$spacer-2": {
  "values": [
    "$spacer",
    "8px"
  ],
  "source": {
    "path": "src/support/variables/layout.scss",
    "line": 37
  },
  "computed": "8px"
},
"$spacer-3": {
  "values": [
    "$spacer * 2",
    "8px * 2"
  ],
  "source": {
    "path": "src/support/variables/layout.scss",
    "line": 38
  },
  "computed": "8px * 2"
}</code></pre>
</td>
<td>
<h3>After</h3>
<pre><code>"$spacer-1": {
  "values": [
    "round($spacer / 2)",
    "round(8px / 2)"
  ],
  "source": {
    "path": "src/support/variables/layout.scss",
    "line": 36
  },
  "computed": "4px"
},
"$spacer-2": {
  "values": [
    "$spacer",
    "8px"
  ],
  "source": {
    "path": "src/support/variables/layout.scss",
    "line": 37
  },
  "computed": "8px"
},
"$spacer-3": {
  "values": [
    "$spacer * 2",
    "8px * 2"
  ],
  "source": {
    "path": "src/support/variables/layout.scss",
    "line": 38
  },
  "computed": "16px"
}</code></pre>
</td>
</tr>
</table>