### PR TITLE
Update CSS for breadcrumb slash separator

### DIFF
--- a/.changeset/violet-peaches-retire.md
+++ b/.changeset/violet-peaches-retire.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Ensures that the visual slash separator for breadcrumbs is not announced by screenreaders.

--- a/src/breadcrumb/breadcrumb.scss
+++ b/src/breadcrumb/breadcrumb.scss
@@ -6,12 +6,13 @@
   list-style: none;
 
   &::after {
-    margin: 0 $em-spacer-5;
     display: inline-block;
-    transform: rotate(15deg);
-    border-right: 0.1em solid var(--color-text-disabled);;
     height: 0.8em;
+    margin: 0 $em-spacer-5;
     content: '';
+    // stylelint-disable-next-line primer/borders
+    border-right: 0.1em $border-style var(--color-text-disabled);
+    transform: rotate(15deg);
   }
 
   &:first-child {

--- a/src/breadcrumb/breadcrumb.scss
+++ b/src/breadcrumb/breadcrumb.scss
@@ -6,10 +6,12 @@
   list-style: none;
 
   &::after {
-    padding-right: $em-spacer-5;
-    padding-left: $em-spacer-5;
-    color: var(--color-text-disabled);
-    content: "/";
+    margin: 0 $em-spacer-5;
+    display: inline-block;
+    transform: rotate(15deg);
+    border-right: 0.1em solid var(--color-text-disabled);;
+    height: 0.8em;
+    content: '';
   }
 
   &:first-child {


### PR DESCRIPTION
This PR updates the css used to render the breadcrumb separator and ensures that the separator is **not** announced by screen readers. Right now, the separator is announced as "slash"  but this is unnecessary and can be potentially distracting:

From [wai-aria breadcrumb practices](https://www.w3.org/TR/wai-aria-practices-1.1/examples/breadcrumb/index.html):
> The separators are part of the visual presentation that signifies the breadcrumb trail, which is already semantically represented by the nav element with its label of Breadcrumb. So, using a display technique that is not represented in the accessibility tree used by screen readers prevents redundant and potentially distracting verbosity.

before:
<img width="248" alt="breadcrumb before change" src="https://user-images.githubusercontent.com/16447748/119578154-e02d8b00-bd70-11eb-81e1-96d84048e53d.png">

after:
<img width="248" alt="breadcrumb after change" src="https://user-images.githubusercontent.com/16447748/119577554-b4f66c00-bd6f-11eb-906b-a2d6dee7b12a.png">


