### PR TITLE
Revert "Support SF Mono font in Firefox and Safari"

### DIFF
--- a/.changeset/long-clouds-retire.md
+++ b/.changeset/long-clouds-retire.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Revert "Support SF Mono font in Firefox and Safari"

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -35,7 +35,7 @@ $lh-default: 1.5 !default;
 $body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji" !default;
 
 // Monospace font stack
-$mono-font: ui-monospace, "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace !default;
+$mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace !default;
 
 // The base body size
 $body-font-size: 14px !default;


### PR DESCRIPTION
Reverts primer/css#992

Some users in chrome are seeing all bold code, reverting this pr.