### PR TITLE
ignore stats files

### DIFF
--- a/.changeset/brown-berries-deliver.md
+++ b/.changeset/brown-berries-deliver.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Ignored stats files

--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,6 @@ docs.scss
 *.log
 vercel.json
 *.config.js
+dist/stats/
+dist/*.js
+dist/*.json


### PR DESCRIPTION
It seems that the stats files were accidentally published to npm:

https://unpkg.com/browse/@primer/css@17.2.1/dist/

<img src="https://user-images.githubusercontent.com/9209882/120169616-b8d43380-c232-11eb-819f-e404009546e4.jpg" width="320" />


