### PR TITLE
Remove btn-danger hover effect when disabled

### DIFF
--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -260,6 +260,11 @@
     .Counter {
       background-color: var(--color-btn-danger-disabled-counter-bg);
     }
+
+    .octicon {
+      // stylelint-disable-next-line primer/colors
+      color: var(--color-btn-danger-disabled-text);
+    }
   }
 
   &:focus {


### PR DESCRIPTION
Override hover state's octicon color assignment.

Demo:
https://gist.run/?id=e36e29756f5d19e4cc94e88eed0022e1