### PR TITLE
Adding fill mode forwards to anim-fade-out

### DIFF
--- a/.changeset/neat-poems-flow.md
+++ b/.changeset/neat-poems-flow.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Adding fill mode forwards to anim-fade-out

--- a/src/utilities/animations.scss
+++ b/src/utilities/animations.scss
@@ -25,8 +25,8 @@
 .anim-fade-out {
   animation-name: fade-out;
   animation-duration: 1s;
-  animation-timing-function: ease-out;
   animation-fill-mode: forwards;
+  animation-timing-function: ease-out;
 
   &.fast {
     animation-duration: 0.3s;

--- a/src/utilities/animations.scss
+++ b/src/utilities/animations.scss
@@ -26,6 +26,7 @@
   animation-name: fade-out;
   animation-duration: 1s;
   animation-timing-function: ease-out;
+  animation-fill-mode: forwards;
 
   &.fast {
     animation-duration: 0.3s;


### PR DESCRIPTION
Fixes https://github.com/primer/css/issues/1185 by adding `animation-fill-mode: forwards` suggested by @vdepizzol 