### PR TITLE
Support SF Mono font in Firefox and Safari (take 2)

### DIFF
--- a/.changeset/early-ducks-decide.md
+++ b/.changeset/early-ducks-decide.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Support SF Mono font in Firefox and Safari

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -35,7 +35,8 @@ $lh-default: 1.5 !default;
 $body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji" !default;
 
 // Monospace font stack
-$mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace !default;
+// Note: SFMono-Regular needs to come before SF Mono to fix an older version of the font in Chrome
+$mono-font: ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace !default;
 
 // The base body size
 $body-font-size: 14px !default;


### PR DESCRIPTION
This is another attempt after reverting https://github.com/primer/css/pull/992#issuecomment-850019238.

I paired with @nickcanz (thanks 🙇 ) and we found the following:

- This [stackoverflow](https://stackoverflow.com/a/58851680) is correct and an older version of `SF Mono` causes the "bold" problem. Updating to a [new version](https://developer.apple.com/fonts/) fixed it.
- For users that still have the old version installed, having `SFMono-Regular` declared **before** `SF Mono` also fixes the problem.

With that we have the following stack:

```scss
$mono-font:
  ui-monospace, // support for Safari
  SFMono-Regular, // support for Chrome with an older version of SF Mono
  SF Mono, // support for Firefox
  Consolas, Liberation Mono, Menlo, monospace !default;
```

Also removed the `"` since it gets stripped anyways when compiling the SCSS.