### PR TITLE
Adding test to check that support size is always 0

### DIFF
--- a/__tests__/css.test.js
+++ b/__tests__/css.test.js
@@ -2,6 +2,7 @@ const {
   getCurrentVersion,
   getDeprecatedSelectors,
   getDeprecatedVariables,
+  getPackageStats,
   getSelectorDiff,
   getVariableDiff
 } = require('./utils/css')
@@ -16,6 +17,13 @@ beforeAll(async () => {
   selectorsDiff = getSelectorDiff()
   variablesDiff = getVariableDiff()
   version = getCurrentVersion()
+})
+
+describe('css', () => {
+  it('The support.css file contains no compiled css', () => {
+    const supportStats = getPackageStats('support')
+    expect(supportStats.size).toEqual(0)
+  })
 })
 
 describe('deprecations', () => {

--- a/__tests__/utils/css.js
+++ b/__tests__/utils/css.js
@@ -42,6 +42,11 @@ function getDeprecatedVariables(version) {
   return deprecations.reduce((list, deprecation) => list.concat(deprecation.variables), []).filter(v => v)
 }
 
+function getPackageStats(packageName) {
+  const stats = require(join(currentPath, './dist', `./stats/${packageName}.json`))
+  return stats
+}
+
 function currentVersionSelectors() {
   return getSelectors(join(currentPath, './dist'))
 }
@@ -70,6 +75,7 @@ module.exports = {
   getCurrentVersion,
   getDeprecatedSelectors,
   getDeprecatedVariables,
+  getPackageStats,
   getSelectorDiff,
   getVariableDiff
 }


### PR DESCRIPTION
This adds a test to make sure that `primer/css/support` always compiles to `0`. This is to save us from accidentally including something in there that would be imported to a lot of places.