### PR TITLE
Use variable for the active border of the UnderlineNav

### DIFF
--- a/.changeset/rude-rockets-flow.md
+++ b/.changeset/rude-rockets-flow.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Use variable for the active border of the UnderlineNav

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -39,8 +39,7 @@
   &[aria-current]:not([aria-current=false]) {
     font-weight: $font-weight-bold;
     color: var(--color-underlinenav-text-active);
-    // stylelint-disable-next-line primer/borders
-    border-bottom-color: #f9826c; // custom coral
+    border-bottom-color: var(--color-underlinenav-border-active);
     outline: 1px dotted transparent; // Support Firefox custom colors
     outline-offset: -1px;
 


### PR DESCRIPTION
This replaces the custom coral hex value `` with the `--color-underlinenav-border-active` from Primitives.
