### PR TITLE
Remove input-dark from the docs

### DIFF
--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -140,15 +140,6 @@ Add the `disabled` attribute to make a `.form-control` appear disabled.
 </form>
 ```
 
-### Dark
-
-```html live
-<div class="bg-gray-dark p-3 mt-n3 ml-n3 mr-n3">
-  <input class="form-control input-dark" type="text" placeholder="Dark input" aria-label="Dark input">
-  <input class="form-control input-dark input-sm" type="text" placeholder="Dark input small" aria-label="Dark input">
-</div>
-```
-
 ### Hide WebKit's contact info autofill icon
 
 WebKit sometimes gets confused and tries to add an icon/dropdown to autofill contact information on fields that may not be appropriate (such as input for number of users). Use this class to override the display of this icon.


### PR DESCRIPTION
The `input-dark` modifier got removed in the last major release. But we forgot to remove [the example](https://primer.style/css/components/forms#dark) from the docs.


Reported in [Slack](https://github.slack.com/archives/C0ZCGGGJ2/p1624562487369100) by @cpruitt.