### PR TITLE
Make `TimelineItem-badge--success` ready for V2

### DIFF
--- a/.changeset/silent-cycles-camp.md
+++ b/.changeset/silent-cycles-camp.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Make `TimelineItem-badge--success` ready for Color Modes V2

--- a/src/timeline/timeline-item.scss
+++ b/src/timeline/timeline-item.scss
@@ -42,7 +42,7 @@
   flex-shrink: 0;
 
   &--success {
-    color: var(--color-text-white);
+    color: var(--color-btn-primary-text);
     background-color: var(--color-btn-primary-bg);
     border: $border-width $border-style var(--color-timeline-badge-success-border);
   }

--- a/src/timeline/timeline-item.scss
+++ b/src/timeline/timeline-item.scss
@@ -42,8 +42,8 @@
   flex-shrink: 0;
 
   &--success {
-    color: var(--color-btn-primary-text);
-    background-color: var(--color-btn-primary-bg);
+    color: var(--color-fg-on-emphasis, var(--color-btn-primary-text)); // TODO remove V1 fallback
+    background-color: var(--color-success-emphasis, var(--color-btn-primary-bg)); // TODO remove V1 fallback
     border: $border-width $border-style var(--color-timeline-badge-success-border);
   }
 }


### PR DESCRIPTION
Currently `--color-text-white` is dark in HC, but that causes other regressions.. so we decided to not have a replacement in Primer and deprecate `--color-text-white` and just add a hack to dotcom. See [Slack](https://github.slack.com/archives/C016WHYJJAW/p1624525266196000).

![image](https://user-images.githubusercontent.com/378023/123389942-5d008e80-d5d5-11eb-93e4-db7ec9413785.png)

This PR replaces `--color-text-white` with `--color-fg-on-emphasis` for `TimelineItem-badge--success`. As a fallback for V1  `--color-btn-primary-text` is used.