### PR TITLE
Prevent content to increase main's size

### DIFF
--- a/.changeset/happy-ways-suffer.md
+++ b/.changeset/happy-ways-suffer.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Prevents main content to blowout and cause an horizontal scroll

--- a/src/layout/layout.scss
+++ b/src/layout/layout.scss
@@ -152,6 +152,7 @@
 }
 
 .Layout-main {
+  min-width: 0;
 
   // Centered main column
   // FIXME: right-aligned sidebar


### PR DESCRIPTION
Based on https://css-tricks.com/preventing-a-grid-blowout/

If main's content was large enough, it would cause `main` to grow more than it should and push `sidebar` to the side, causing an horizontal scroll on pages.

| Before | After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/11280312/124145356-56996900-da52-11eb-954d-8b6a44d85cea.png) | ![image](https://user-images.githubusercontent.com/11280312/124145395-5e590d80-da52-11eb-9024-175c2de360ad.png) | 
