### PR TITLE
Move Menlo before Consolas in monospace font stack

### DIFF
--- a/.changeset/heavy-rings-sip.md
+++ b/.changeset/heavy-rings-sip.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Move Menlo before Consolas in monospace font stack

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -36,7 +36,7 @@ $body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, san
 
 // Monospace font stack
 // Note: SFMono-Regular needs to come before SF Mono to fix an older version of the font in Chrome
-$mono-font: ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace !default;
+$mono-font: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace !default;
 
 // The base body size
 $body-font-size: 14px !default;


### PR DESCRIPTION
Microsoft Office for Mac products install a number of Microsoft fonts, including Consolas. This means that people who:

- are using a Mac and
- haven’t manually installed SF Mono and
- are using a browser that does not automatically pull in SF Mono from the OS (e.g. Chrome) and
- have Consolas on their system

are getting all monospace text in Consolas instead of Menlo, which is the next-best choice after SF Mono for macOS.

This does mean people on Windows who have manually installed Menlo will get that instead of Consolas, but the number of people this affects is far less than Macs with Office and Chrome.

/cc @primer/ds-core
