### PR TITLE
Fix unreadable secondary text in dropdown-item on hover/focus

### DIFF
--- a/.changeset/moody-apes-study.md
+++ b/.changeset/moody-apes-study.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fix unreadable text when utility is used in dropdown item.

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -94,6 +94,11 @@
       color: inherit;
       opacity: 1;
     }
+    
+    .color-text-secondary,
+    .color-text-secondary {
+      color: var(--color-state-hover-primary-text) !important;
+    }
   }
 
   &.btn-link {

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -94,7 +94,7 @@
       color: inherit;
       opacity: 1;
     }
-    
+
     [class*="color-text-"] {
       color: inherit !important;
     }

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -95,9 +95,8 @@
       opacity: 1;
     }
     
-    .color-text-secondary,
-    .color-text-secondary {
-      color: var(--color-state-hover-primary-text) !important;
+    [class*="color-text-"] {
+      color: inherit !important;
     }
   }
 


### PR DESCRIPTION
This makes a change to how `.color-text-*` elements within a `.dropdown-item` in the hover or focus state appear. Before, the text would appear as dark gray, and thus unreadable on the blue hover background of the dropdown item. With this change, they appear as white, like unstyled text in the dropdown item is on hover.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/82317/124312093-64271f80-db34-11eb-9312-c04d3f9d0672.png)|![image](https://user-images.githubusercontent.com/82317/124312050-51144f80-db34-11eb-9c3e-1ab8341c6502.png)|

/cc @koddsson
