### PR TITLE
Add font-weight-medium to marketing styles, and use it in the type scale

### DIFF
--- a/.changeset/heavy-rings-sip.md
+++ b/.changeset/heavy-rings-sip.md
@@ -1,5 +1,5 @@
 ---
-'@primer/css': patch
+'@primer/css': minor
 ---
 
 Move Menlo before Consolas in monospace font stack

--- a/src/marketing/support/variables.scss
+++ b/src/marketing/support/variables.scss
@@ -3,6 +3,8 @@
 $marketing-font-path: "/fonts/" !default;
 
 $font-mktg: $body-font !default;
+$font-weight-medium: 450 !default;
+
 $mktg-font-feature-settings: 'ss02' on, 'ss01' on !default;
 $mktg-header-spacing-large: -0.03em !default;
 $mktg-header-spacing-default: -0.01em !default;

--- a/src/marketing/support/variables.scss
+++ b/src/marketing/support/variables.scss
@@ -9,7 +9,7 @@ $mktg-font-feature-settings: 'ss02' on, 'ss01' on !default;
 $mktg-header-spacing-large: -0.03em !default;
 $mktg-header-spacing-default: -0.01em !default;
 $mktg-header-spacing-threshold: 48px !default;
-$mktg-header-weight-large: 800 !default;
+$mktg-header-weight-large: $font-weight-extrabold !default;
 $mktg-header-weight-default: $font-weight-bold !default;
 $mktg-header-weight-threshold: 24px !default;
 

--- a/src/marketing/support/variables.scss
+++ b/src/marketing/support/variables.scss
@@ -4,6 +4,7 @@ $marketing-font-path: "/fonts/" !default;
 
 $font-mktg: $body-font !default;
 $font-weight-medium: 450 !default;
+$font-weight-extrabold: 700 !default;
 
 $mktg-font-feature-settings: 'ss02' on, 'ss01' on !default;
 $mktg-header-spacing-large: -0.03em !default;

--- a/src/marketing/support/variables.scss
+++ b/src/marketing/support/variables.scss
@@ -4,7 +4,7 @@ $marketing-font-path: "/fonts/" !default;
 
 $font-mktg: $body-font !default;
 $font-weight-medium: 450 !default;
-$font-weight-extrabold: 700 !default;
+$font-weight-extrabold: 800 !default;
 
 $mktg-font-feature-settings: 'ss02' on, 'ss01' on !default;
 $mktg-header-spacing-large: -0.03em !default;

--- a/src/marketing/type/typography.scss
+++ b/src/marketing/type/typography.scss
@@ -27,9 +27,11 @@
       @include breakpoint(md) {
         font-size: map-get($pairing-md, "size") !important;
         line-height: map-get($pairing-md, "lh") !important;
+
         @if (map-get($pairing-md, "size") >= $mktg-header-spacing-threshold and map-get($pairing, "size") < $mktg-header-spacing-threshold) {
           letter-spacing: $mktg-header-spacing-large !important;
         }
+
         @if (map-get($pairing-md, "size") >= $mktg-header-weight-threshold and map-get($pairing, "size") < $mktg-header-weight-threshold) {
           font-weight: $mktg-header-weight-large !important;
         }
@@ -40,9 +42,11 @@
       @include breakpoint(lg) {
         font-size: map-get($pairing-lg, "size") !important;
         line-height: map-get($pairing-lg, "lh") !important;
+
         @if (map-get($pairing-lg, "size") >= $mktg-header-spacing-threshold and map-get($pairing-md, "size") < $mktg-header-spacing-threshold) {
           letter-spacing: $mktg-header-spacing-large !important;
         }
+
         @if (map-get($pairing-lg, "size") >= $mktg-header-weight-threshold and map-get($pairing-md, "size") < $mktg-header-weight-threshold) {
           font-weight: $mktg-header-weight-large !important;
         }
@@ -78,9 +82,11 @@
       @include breakpoint(md) {
         font-size: map-get($pairing-md, "size") !important;
         line-height: map-get($pairing-md, "lh") !important;
+
         @if (map-get($pairing-md, "size") >= $mktg-body-spacing-threshold and map-get($pairing, "size") < $mktg-body-spacing-threshold) {
           letter-spacing: $mktg-body-spacing-large !important;
         }
+
         @if (map-get($pairing-md, "size") >= $mktg-body-weight-threshold and map-get($pairing, "size") < $mktg-body-weight-threshold) {
           font-weight: $font-weight-medium;
         }
@@ -91,9 +97,11 @@
       @include breakpoint(lg) {
         font-size: map-get($pairing-lg, "size") !important;
         line-height: map-get($pairing-lg, "lh") !important;
+
         @if (map-get($pairing-lg, "size") >= $mktg-body-spacing-threshold and map-get($pairing-md, "size") < $mktg-body-spacing-threshold) {
           letter-spacing: $mktg-body-spacing-large !important;
         }
+
         @if (map-get($pairing-lg, "size") >= $mktg-body-weight-threshold and map-get($pairing-md, "size") < $mktg-body-weight-threshold) {
           font-weight: $font-weight-medium;
         }

--- a/src/marketing/type/typography.scss
+++ b/src/marketing/type/typography.scss
@@ -110,6 +110,10 @@
   }
 }
 
+.text-medium {
+  font-weight: $font-weight-medium !important;
+}
+
 // Pullquote
 
 @mixin pullquote {

--- a/src/marketing/type/typography.scss
+++ b/src/marketing/type/typography.scss
@@ -82,7 +82,7 @@
           letter-spacing: $mktg-body-spacing-large !important;
         }
         @if (map-get($pairing-md, "size") >= $mktg-body-weight-threshold and map-get($pairing, "size") < $mktg-body-weight-threshold) {
-          font-weight: $font-weight-semibold;
+          font-weight: $font-weight-medium;
         }
       }
     }
@@ -95,7 +95,7 @@
           letter-spacing: $mktg-body-spacing-large !important;
         }
         @if (map-get($pairing-lg, "size") >= $mktg-body-weight-threshold and map-get($pairing-md, "size") < $mktg-body-weight-threshold) {
-          font-weight: $font-weight-semibold;
+          font-weight: $font-weight-medium;
         }
       }
     }


### PR DESCRIPTION
The `medium` weight of a font usually maps to `500`, but this weight is taken in Primer by `semibold`. In order to add the ability to use `medium` weights on marketing pages, this PR adds `medium` at weight `450` and `extrabold` at `800`, and adds a `.text-medium` utility to use this font-weight. It also changes the marketing type scale to use `medium` rather than `semibold` for all `fX-mktg` utilities.

This produces the full weight scale as follows:
```
$font-weight-extrabold: 800 !default;
$font-weight-bold: 600 !default;
$font-weight-semibold: 500 !default;
$font-weight-medium: 450 !default;
$font-weight-normal: 400 !default;
$font-weight-light: 300 !default;
```