### PR TITLE
[Docs] theming improvements

### DIFF
--- a/docs/content/getting-started/theming.md
+++ b/docs/content/getting-started/theming.md
@@ -173,4 +173,4 @@ In general,
 
 1. use [functional variables](/support/color-system) as much as possible.
 2. create new [custom color variables](/getting-started/theming#custom-color-variables) if there is no functional variable that fits the use case.
-3. as an alternaitve to custom color variables, use [`auto` variables](/getting-started/theming#auto-variables) if the results give enough constrast.
+3. as an alternative to custom color variables, use [`auto` variables](/getting-started/theming#auto-variables) if the results give enough contrast.

--- a/docs/content/getting-started/theming.md
+++ b/docs/content/getting-started/theming.md
@@ -9,18 +9,19 @@ Currently there are 3 themes (`light`, `dark`, `dark_dimmed`) to choose from. Wh
 
 ## Set a theme
 
-Configure Primer CSS to use a certain theme by adding the following attributes:
+Configure Primer CSS to use a certain theme by setting HTML attributes.
 
-- `data-color-mode` with a value of either `light` or `dark`
-- either `data-light-theme` or `data-dark-theme` with a value of either `light`, `dark`, `dark_dimmed`
+- **Light** theme: `data-color-mode="light" data-dark-theme="light"`
+- **Dark** theme: `data-color-mode="dark" data-dark-theme="dark"`
+- **Dark Dimmed** theme: `data-color-mode="dark" data-dark-theme="dark_dimmed"`
 
-The attributes can be added to any element, but ideally it should be added to the document root (`<html>`). Below an example to use the `dark_dimmed` theme:
+Typically these attributes are added to the document root (`<html>`) to use on the entire page:
 
 ```html
 <html data-color-mode="dark" data-dark-theme="dark_dimmed">
 ```
 
-More examples:
+Below an example of all themes to compare:
 
 ```html live
 <div data-color-mode="light" data-light-theme="light" class="p-3">

--- a/docs/content/getting-started/theming.md
+++ b/docs/content/getting-started/theming.md
@@ -161,7 +161,7 @@ The benefit of `auto` over the `scale` variables is that `auto` variables automa
 
 **Note**: If you use `stylelint`, the [`primer/no-scale-colors`](https://github.com/primer/stylelint-config-primer/tree/main/plugins#primerno-scale-colors) will fail with "[variable] is a non-functional scale color and cannot be used without being wrapped in the color-variables mixin". You can disable stylelint for this case by adding `// stylelint-disable-line`:
 
-```scss
+```css
 .my-class {
   color: var(--color-auto-gray-7); // stylelint-disable-line
 }


### PR DESCRIPTION
This PR closes https://github.com/primer/css/issues/1485 by fixing typos, formatting issues and other improvements for [theming](https://primer.style/css/getting-started/theming).
