### PR TITLE
Fix form tooltip transparency

### DIFF
--- a/.changeset/lovely-rockets-heal.md
+++ b/.changeset/lovely-rockets-heal.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fix form tooltip transparency

--- a/src/forms/form-group.scss
+++ b/src/forms/form-group.scss
@@ -191,7 +191,7 @@
   &.successed {
     .success {
       color: var(--color-input-tooltip-success-text);
-      background-color: var(--color-input-tooltip-success-bg);
+      background-image: linear-gradient(var(--color-input-tooltip-success-bg), var(--color-input-tooltip-success-bg));
       border-color: var(--color-input-tooltip-success-border);
 
       &::after { border-bottom-color: var(--color-input-tooltip-success-bg); } // stylelint-disable-line primer/borders
@@ -206,7 +206,7 @@
 
     .warning {
       color: var(--color-input-tooltip-warning-text);
-      background-color: var(--color-input-tooltip-warning-bg);
+      background-image: linear-gradient(var(--color-input-tooltip-warning-bg), var(--color-input-tooltip-warning-bg));
       border-color: var(--color-input-tooltip-warning-border);
 
       &::after { border-bottom-color: var(--color-input-tooltip-warning-bg); } // stylelint-disable-line primer/borders
@@ -225,7 +225,7 @@
 
     .error {
       color: var(--color-input-tooltip-error-text);
-      background-color: var(--color-input-tooltip-error-bg);
+      background-image: linear-gradient(var(--color-input-tooltip-error-bg), var(--color-input-tooltip-error-bg));
       border-color: var(--color-input-tooltip-error-border);
 
       &::after { border-bottom-color: var(--color-input-tooltip-error-bg); } // stylelint-disable-line primer/borders
@@ -240,6 +240,7 @@
   margin: $spacer-1 0 2px;
   font-size: $font-size-small;
   color: var(--color-text-secondary);
+  background-color: var(--color-bg-canvas); // Makes sure the background is opaque to cover any content underneath
 
   .spinner {
     // stylelint-disable-next-line primer/spacing


### PR DESCRIPTION
This fixes the form tooltips in dark mode where the background is semi-transparent and could clash with the content underneath.

![Screen Shot 2021-07-20 at 15 23 55](https://user-images.githubusercontent.com/378023/126271981-a9110d9a-8dc3-491d-b2a0-fd729928a5c6.png)

It uses the same technique like the `.flash` alerts that have an opaque background with a colored gradient on top.

---

Fixes https://github.com/github/ui-frameworks/issues/86
