### PR TITLE
Adding outline to invisible buttons and close button

### DIFF
--- a/.changeset/slow-bobcats-sleep.md
+++ b/.changeset/slow-bobcats-sleep.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Adding focus outline to the invisible buttons `.btn-invisible` and `.close-button`.

--- a/src/buttons/misc.scss
+++ b/src/buttons/misc.scss
@@ -49,8 +49,9 @@
   &.zeroclipboard-is-active {
     color: var(--color-text-link);
     background: none;
+    border-color: var(--color-btn-active-border);
     outline: none;
-    box-shadow: none;
+    box-shadow: var(--color-btn-focus-shadow);
   }
 
   &:disabled,
@@ -107,8 +108,12 @@
     color: var(--color-text-primary);
   }
 
-  &:active {
+  &:active,
+  &:focus {
     color: var(--color-text-tertiary);
+    border-color: var(--color-btn-active-border);
+    outline: none;
+    box-shadow: var(--color-btn-focus-shadow);
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/primer/css/issues/1213

I'm adding focus outlines to the `.btn-invisible` and `.close-button` for better a11y. Currently there's no outline https://primer.style/css/components/buttons#close-button

<img width="195" alt="Screen Shot 2021-07-20 at 9 05 15 AM" src="https://user-images.githubusercontent.com/54012/126357977-a8af6995-0b3b-4023-bd72-0c268ee4d04d.png">

<img width="232" alt="Screen Shot 2021-07-20 at 9 05 29 AM" src="https://user-images.githubusercontent.com/54012/126357978-99e6d921-318b-4d27-ba29-e769836e789f.png">
