### PR TITLE
Remove background from .note

### DIFF
--- a/.changeset/khaki-lobsters-marry.md
+++ b/.changeset/khaki-lobsters-marry.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Remove background from .note

--- a/src/forms/form-group.scss
+++ b/src/forms/form-group.scss
@@ -191,6 +191,7 @@
   &.successed {
     .success {
       color: var(--color-input-tooltip-success-text);
+      background-color: var(--color-bg-canvas); // Makes sure the background is opaque to cover any content underneath
       background-image: linear-gradient(var(--color-input-tooltip-success-bg), var(--color-input-tooltip-success-bg));
       border-color: var(--color-input-tooltip-success-border);
 
@@ -206,6 +207,7 @@
 
     .warning {
       color: var(--color-input-tooltip-warning-text);
+      background-color: var(--color-bg-canvas); // Makes sure the background is opaque to cover any content underneath
       background-image: linear-gradient(var(--color-input-tooltip-warning-bg), var(--color-input-tooltip-warning-bg));
       border-color: var(--color-input-tooltip-warning-border);
 
@@ -225,6 +227,7 @@
 
     .error {
       color: var(--color-input-tooltip-error-text);
+      background-color: var(--color-bg-canvas); // Makes sure the background is opaque to cover any content underneath
       background-image: linear-gradient(var(--color-input-tooltip-error-bg), var(--color-input-tooltip-error-bg));
       border-color: var(--color-input-tooltip-error-border);
 
@@ -240,7 +243,6 @@
   margin: $spacer-1 0 2px;
   font-size: $font-size-small;
   color: var(--color-text-secondary);
-  background-color: var(--color-bg-canvas); // Makes sure the background is opaque to cover any content underneath
 
   .spinner {
     // stylelint-disable-next-line primer/spacing


### PR DESCRIPTION
This partially reverts https://github.com/primer/css/pull/1507 and moves the opaque background from `.note` to the "state" classes. This should fix the notifications:

![image (2)](https://user-images.githubusercontent.com/378023/127417260-3d0870f3-402b-4a28-abb6-6764e024a3b8.png)

As well as the form tooltips:

![Screen Shot 2021-07-20 at 15 23 55](https://user-images.githubusercontent.com/378023/127417290-95524bfd-aa80-4df1-9e04-ec96fb559024.png)

Initially I thought that the `.note` class is only used for these form tooltips, but turns out it a more commonly used class.. I guess to make text smaller?
