### PR TITLE
Fix bug where outline was showing up on hover

### DIFF
--- a/.changeset/breezy-ads-eat.md
+++ b/.changeset/breezy-ads-eat.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fix bug where outline was showing up on hover

--- a/src/buttons/misc.scss
+++ b/src/buttons/misc.scss
@@ -41,12 +41,18 @@
   box-shadow: none;
 
   &:hover,
+  &.zeroclipboard-is-hover {
+    color: var(--color-text-link);
+    background: none;
+    outline: none;
+    box-shadow: none;
+  }
+
   &:active,
   &:focus,
   &.selected,
   &[aria-selected=true],
-  &.zeroclipboard-is-hover,
-  &.zeroclipboard-is-active {
+  &.zeroclipboard-is-hover {
     color: var(--color-text-link);
     background: none;
     border-color: var(--color-btn-active-border);

--- a/src/buttons/misc.scss
+++ b/src/buttons/misc.scss
@@ -52,7 +52,7 @@
   &:focus,
   &.selected,
   &[aria-selected=true],
-  &.zeroclipboard-is-hover {
+  &.zeroclipboard-is-active {
     color: var(--color-text-link);
     background: none;
     border-color: var(--color-btn-active-border);


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/primer/css/pull/1510 where when hovering on a `btn-invisible` it would style it the same as `:focus` state.


https://user-images.githubusercontent.com/54012/127531391-fbce9ced-81d8-433f-afc7-120818dcbdf2.mov

