### PR TITLE
render `code` at 100% font size irregardless of direct descension

### DIFF
--- a/.changeset/famous-planes-dress.md
+++ b/.changeset/famous-planes-dress.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Render `code` at 100% font size irregardless of direct descension from `pre`.

--- a/src/markdown/code.scss
+++ b/src/markdown/code.scss
@@ -19,12 +19,15 @@
   pre {
     word-wrap: normal;
 
+    code {
+      // stylelint-disable-next-line primer/typography
+      font-size: 100%;
+    }
+
     // Code tags within code blocks (<pre>s)
     > code {
       padding: 0;
       margin: 0;
-      // stylelint-disable-next-line primer/typography
-      font-size: 100%;
       word-break: normal;
       white-space: pre;
       background: transparent;


### PR DESCRIPTION
This change fixes a bug when rendering markdown and there are outputs where `<code>` tags get rendered at 85% font-size when not a direct descendant of a `<pre>`. 

Before:

<img width="512" alt="127915129-54e72d4d-495d-4f4c-aee5-962fecc9205d" src="https://user-images.githubusercontent.com/16991201/128200578-965d6c1a-e8c6-41b5-a9c4-c5f608a63eb8.png">

After:

<img width="660" alt="Screen Shot 2021-08-04 at 11 17 05 AM" src="https://user-images.githubusercontent.com/16991201/128207260-6788932f-2bc4-455a-a93f-947678c8d751.png">


/cc @primer/ds-core
