### PR TITLE
Convert header and body font sizes to rem

### DIFF
--- a/.changeset/red-snakes-stare.md
+++ b/.changeset/red-snakes-stare.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Output headings & body font-size as rem units

--- a/.changeset/red-snakes-stare.md
+++ b/.changeset/red-snakes-stare.md
@@ -1,5 +1,5 @@
 ---
-'@primer/css': patch
+'@primer/css': minor
 ---
 
 Output headings & body font-size as rem units

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -8,23 +8,23 @@ $baseFontSize: 16;
 
 // Heading sizes - mobile
 // h4-h6 remain the same size on both mobile & desktop
-$h00-size-mobile: 40px !default;
-$h0-size-mobile: 32px !default;
-$h1-size-mobile: 26px !default;
-$h2-size-mobile: 22px !default;
-$h3-size-mobile: 18px !default;
+$h00-size-mobile: font-size-to-rem(40, $baseFontSize) !default;
+$h0-size-mobile: font-size-to-rem(32, $baseFontSize) !default;
+$h1-size-mobile: font-size-to-rem(26, $baseFontSize) !default;
+$h2-size-mobile: font-size-to-rem(22, $baseFontSize) !default;
+$h3-size-mobile: font-size-to-rem(18, $baseFontSize) !default;
 
 // Heading sizes - desktop
-$h00-size: 48px !default;
-$h0-size: 40px !default;
-$h1-size: 32px !default;
-$h2-size: 24px !default;
-$h3-size: 20px !default;
-$h4-size: 16px !default;
-$h5-size: 14px !default;
-$h6-size: 12px !default;
+$h00-size: font-size-to-rem(48, $baseFontSize) !default;
+$h0-size: font-size-to-rem(40, $baseFontSize) !default;
+$h1-size: font-size-to-rem(32, $baseFontSize) !default;
+$h2-size: font-size-to-rem(24, $baseFontSize) !default;
+$h3-size: font-size-to-rem(20, $baseFontSize) !default;
+$h4-size: font-size-to-rem(16, $baseFontSize) !default;
+$h5-size: font-size-to-rem(14, $baseFontSize) !default;
+$h6-size: font-size-to-rem(12, $baseFontSize) !default;
 
-$font-size-small: 12px !default;
+$font-size-small: font-size-to-rem(12, $baseFontSize) !default;
 
 // Font weights
 $font-weight-bold: 600 !default;
@@ -45,5 +45,5 @@ $body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, san
 $mono-font: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace !default;
 
 // The base body size
-$body-font-size: 14px !default;
+$body-font-size: font-size-to-rem(14, $baseFontSize) !default;
 $body-line-height: $lh-default !default;

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -4,7 +4,7 @@
   @return ($px / $baseFontSize) * 1rem;
 }
 
-$baseFontSize: 16;
+$baseFontSize: 16 !default;
 
 // Heading sizes - mobile
 // h4-h6 remain the same size on both mobile & desktop

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -1,5 +1,11 @@
 // Typography variables
 
+@function font-size-to-rem($px, $baseFontSize) {
+  @return ($px / $baseFontSize) * 1rem;
+}
+
+$baseFontSize: 16;
+
 // Heading sizes - mobile
 // h4-h6 remain the same size on both mobile & desktop
 $h00-size-mobile: 40px !default;


### PR DESCRIPTION
From https://github.com/github/accessibility/issues/147:

>The [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/) does not specify a minimum font size for the web.
>
>The Dotcom is using `px` as absolute units for `font-size`. The WCAG recommends to use relative units like `em` and `rem` for font sizes. All major browsers have a default font size of 16px, so we can set that size as the base `font-size` and calculate the rest proportionately with rem units. 
>
>`em` units are relative to the font size of their own element, and `rem` units are relative to the root element.

From WAI:

> The font size should be defined in relative units, such as percentages, em or rem. 

This pull request creates a `px` to `rem` converter and uses that function to ensure that the body font size and the header variables output `rem` units.

The concrete benefit here is that users who change their font size in their browser will see text larger or smaller after their changes to the settings. Right now, github.com will not resize its fonts even when a user changes this setting.

### References 
- https://www.w3.org/WAI/tutorials/page-structure/styling/
- https://css-tricks.com/accessible-font-sizing-explained/
- https://www.sitepoint.com/understanding-and-using-rem-units-in-css/

/cc @primer/ds-core
