### PR TITLE
Use REM values for font sizes

### DIFF
--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -1,30 +1,27 @@
 // Typography variables
 
-@function font-size-to-rem($px, $baseFontSize) {
-  @return ($px / $baseFontSize) * 1rem;
-}
-
-$baseFontSize: 16 !default;
+// Calculating rem: (?px / 16px) * 1rem
+// Example: (24px / 16px) * 1rem = 1.5rem
 
 // Heading sizes - mobile
 // h4-h6 remain the same size on both mobile & desktop
-$h00-size-mobile: font-size-to-rem(40, $baseFontSize) !default;
-$h0-size-mobile: font-size-to-rem(32, $baseFontSize) !default;
-$h1-size-mobile: font-size-to-rem(26, $baseFontSize) !default;
-$h2-size-mobile: font-size-to-rem(22, $baseFontSize) !default;
-$h3-size-mobile: font-size-to-rem(18, $baseFontSize) !default;
+$h00-size-mobile: 2.5rem !default; // 40px
+$h0-size-mobile: 2rem !default; // 32px
+$h1-size-mobile: 1.625rem !default; // 26px
+$h2-size-mobile: 1.375rem !default; // 22px
+$h3-size-mobile: 1.125rem !default; // 18px
 
 // Heading sizes - desktop
-$h00-size: font-size-to-rem(48, $baseFontSize) !default;
-$h0-size: font-size-to-rem(40, $baseFontSize) !default;
-$h1-size: font-size-to-rem(32, $baseFontSize) !default;
-$h2-size: font-size-to-rem(24, $baseFontSize) !default;
-$h3-size: font-size-to-rem(20, $baseFontSize) !default;
-$h4-size: font-size-to-rem(16, $baseFontSize) !default;
-$h5-size: font-size-to-rem(14, $baseFontSize) !default;
-$h6-size: font-size-to-rem(12, $baseFontSize) !default;
+$h00-size: 3rem !default; // 48px
+$h0-size: 2.5rem !default; // 40px
+$h1-size: 2rem !default; // 32px
+$h2-size: 1.5rem !default; // 24px
+$h3-size: 1.25rem !default; // 20px
+$h4-size: 1rem !default; // 16px
+$h5-size: 0.875rem !default; // 14px
+$h6-size: 0.75rem !default; // 12px
 
-$font-size-small: font-size-to-rem(12, $baseFontSize) !default;
+$font-size-small: 0.75rem !default; // 12px
 
 // Font weights
 $font-weight-bold: 600 !default;
@@ -45,5 +42,5 @@ $body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, san
 $mono-font: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace !default;
 
 // The base body size
-$body-font-size: font-size-to-rem(14, $baseFontSize) !default;
+$body-font-size: 0.875rem !default; // 14px
 $body-line-height: $lh-default !default;


### PR DESCRIPTION
This is the same as #1527 but the values already calculated as `rem`s, see https://github.com/primer/css/pull/1527/files#r689755316.
