### PR TITLE
use standard lifecyle milestones for statuses

### DIFF
--- a/.changeset/neat-laws-matter.md
+++ b/.changeset/neat-laws-matter.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Use standard lifecyle milestones for statuses.

--- a/docs/content/components/box-overlay.md
+++ b/docs/content/components/box-overlay.md
@@ -1,7 +1,7 @@
 ---
 title: Box overlay
 path: components/box-overlay
-status: Experimental
+status: Alpha
 status_issue: 'https://github.com/github/design-systems/issues/374'
 source: 'https://github.com/github/github/tree/master/app/assets/stylesheets/components/box-overlay.scss'
 symbols: [Box--overlay, Box-header, Box-overlay--narrow, Box-overlay--wide]

--- a/docs/content/components/dropdown.md
+++ b/docs/content/components/dropdown.md
@@ -1,6 +1,6 @@
 ---
 title: Dropdown
-status: New
+status: Beta
 ---
 
 <Note>

--- a/docs/content/components/layout.md
+++ b/docs/content/components/layout.md
@@ -1,7 +1,7 @@
 ---
 title: Layout
 path: components/layout
-status: Experimental
+status: Alpha
 source: 'https://github.com/primer/css/tree/main/src/layout/layout.scss'
 bundle: layout
 ---

--- a/docs/content/components/links.md
+++ b/docs/content/components/links.md
@@ -1,7 +1,7 @@
 ---
 title: Links
 path: components/links
-status: New
+status: Beta
 source: 'https://github.com/primer/css/tree/main/src/links'
 bundle: links
 ---

--- a/docs/content/components/loaders.md
+++ b/docs/content/components/loaders.md
@@ -1,7 +1,7 @@
 ---
 title: Loaders
 path: components/loaders
-status: New
+status: Beta
 source: 'https://github.com/primer/css/tree/main/src/loaders'
 bundle: loaders
 ---

--- a/docs/content/components/marketing-buttons.md
+++ b/docs/content/components/marketing-buttons.md
@@ -1,7 +1,7 @@
 ---
 title: Marketing buttons
 path: components/marketing-buttons
-status: New
+status: Beta
 source: 'https://github.com/primer/css/tree/main/src/marketing/buttons'
 bundle: marketing-buttons
 ---

--- a/docs/content/components/pagination.md
+++ b/docs/content/components/pagination.md
@@ -1,7 +1,7 @@
 ---
 title: Pagination
 path: components/pagination
-status: New
+status: Beta
 source: 'https://github.com/primer/css/tree/main/src/pagination'
 bundle: pagination
 ---

--- a/docs/content/components/popover.md
+++ b/docs/content/components/popover.md
@@ -1,7 +1,7 @@
 ---
 title: Popover
 path: components/popover
-status: Experimental
+status: Alpha
 source: 'https://github.com/primer/css/tree/main/src/popover'
 bundle: popover
 ---

--- a/docs/content/components/progress.md
+++ b/docs/content/components/progress.md
@@ -1,7 +1,7 @@
 ---
 title: Progress
 path: components/progress
-status: New
+status: Beta
 source: 'https://github.com/primer/css/tree/main/src/progress'
 bundle: progress
 ---

--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -1,6 +1,6 @@
 ---
 title: Select menu
-status: New
+status: Beta
 source: 'https://github.com/primer/css/tree/main/src/select-menu'
 bundle: select-menu
 ---

--- a/docs/content/components/timeline.md
+++ b/docs/content/components/timeline.md
@@ -1,7 +1,7 @@
 ---
 title: Timeline
 path: components/timeline
-status: Experimental
+status: Alpha
 status_issue: 'https://github.com/github/design-systems/issues/101'
 source: ''
 bundle: timeline

--- a/docs/content/components/toasts.md
+++ b/docs/content/components/toasts.md
@@ -1,7 +1,7 @@
 ---
 title: Toasts
 path: components/toasts
-status: Experimental
+status: Alpha
 status_issue: 'https://github.com/github/design-systems/issues/101'
 source: ''
 bundle: toasts

--- a/docs/content/components/truncate.md
+++ b/docs/content/components/truncate.md
@@ -1,7 +1,7 @@
 ---
 title: Truncate
 path: components/truncate
-status: Experimental
+status: Alpha
 source: 'https://github.com/primer/css/tree/main/src/truncate'
 bundle: truncate
 ---

--- a/docs/content/support/color-system.mdx
+++ b/docs/content/support/color-system.mdx
@@ -1,7 +1,7 @@
 ---
 title: Color system
 description: 'Sass variables, mixins, and functions for use in our components.'
-status: New
+status: Beta
 source: 'https://github.com/primer/css/blob/main/src/support/variables/color-system.scss'
 bundle: support
 ---

--- a/docs/content/utilities/colors.mdx
+++ b/docs/content/utilities/colors.mdx
@@ -1,7 +1,7 @@
 ---
 title: Colors
 description: 'Immutable, atomic CSS classes to rapidly build product'
-status: New
+status: Beta
 status_issue: 'https://github.com/github/design-systems/issues/97'
 ---
 

--- a/docs/content/utilities/marketing-type.md
+++ b/docs/content/utilities/marketing-type.md
@@ -1,7 +1,7 @@
 ---
 title: Marketing typography
 path: utilities/marketing-type
-status: New
+status: Beta
 source: 'https://github.com/primer/css/tree/main/src/marketing/type'
 bundle: marketing-type
 ---


### PR DESCRIPTION
This PR standardizes our use of the `status` field to reflect the lifecycle milestones defined in https://github.com/primer/design/pull/174.

/cc @primer/rails-reviewers
