### PR TITLE
Removing the rem() mixin and usages. Placing the computed values in place.

### DIFF
--- a/.changeset/flat-shirts-lay.md
+++ b/.changeset/flat-shirts-lay.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": major
+---
+
+Removing the rem() mixin and usages. Placing the computed values in place.

--- a/src/marketing/buttons/button.scss
+++ b/src/marketing/buttons/button.scss
@@ -4,7 +4,7 @@
   display: inline-block;
   appearance: none !important;
   // stylelint-disable-next-line primer/spacing
-  padding: rem(($spacer-3) * 0.9) rem($spacer-4) rem(($spacer-3) * 1.1);
+  padding: .9rem 1.5rem 1.1rem;
   // stylelint-disable-next-line primer/typography
   font-size: 1rem;
   font-weight: $font-weight-bold;
@@ -14,7 +14,7 @@
   user-select: none;
   border: 0;
   // stylelint-disable-next-line primer/borders
-  border-radius: rem(6px);
+  border-radius: .375rem;
 
   @include btn-solid-mktg(
     var(--color-mktg-btn-text),
@@ -34,7 +34,7 @@
     z-index: -1;
     content: "";
     // stylelint-disable-next-line primer/borders
-    border-radius: rem(6px);
+    border-radius: .375rem;
     opacity: 0;
     transition: opacity 0.4s;
   }
@@ -97,7 +97,7 @@
 
 .btn-small-mktg {
   // stylelint-disable-next-line primer/spacing
-  padding: rem(10px) rem($spacer-3) rem(13px);
+  padding: .625rem 1rem .8125rem;
 }
 
 .btn-large-mktg {

--- a/src/marketing/support/mixins.scss
+++ b/src/marketing/support/mixins.scss
@@ -65,16 +65,3 @@
   }
 }
 
-$browser-context: 16 !default;
-
-@function rem($pixels, $context: $browser-context) {
-  @if (unitless($pixels)) {
-    $pixels: $pixels * 1px;
-  }
-
-  @if (unitless($context)) {
-    $context: $context * 1px;
-  }
-
-  @return $pixels / $context * 1rem;
-}


### PR DESCRIPTION
The `rem()` mixin is holding back the codebase from upgrading to `dart-sass`. https://github.com/primer/css/pull/1452#issuecomment-861478581

`node-sass` has reached end of life and is no longer supported by sass. But we can't migrate until we remove all `a / b` math from the codebase. There's issues migrating this mixin so we'd like to remove it.

I've searched for the places this mixin is used and replaced with the computed values for these marketing buttons. I'd like to put this in the next major release and then, if it's necessary, add to the dotcom codebase in case any code there uses the mixin.

@tobiasahlin @simurai do you see any problems with this plan?
