### PR TITLE
Add gradient hack to TimelineItem-badge

### DIFF
--- a/src/timeline/timeline-item.scss
+++ b/src/timeline/timeline-item.scss
@@ -34,7 +34,8 @@
   // stylelint-disable-next-line primer/colors
   color: var(--color-icon-secondary);
   align-items: center;
-  background-color: var(--color-timeline-badge-bg);
+  background-color: var(--color-bg-canvas); // covers the "line"
+  background-image: linear-gradient(0deg, var(--color-timeline-badge-bg), var(--color-timeline-badge-bg));
   // stylelint-disable-next-line primer/borders
   border: 2px $border-style var(--color-bg-canvas);
   border-radius: 50%;


### PR DESCRIPTION
This adds the "gradient hack" to `TimelineItem-badge`.

It is necessary because we would like to use `neutral.muted` but because that color is semi transparent, you would see the "line" underneath.

![Screen Shot 2021-08-25 at 17 31 44](https://user-images.githubusercontent.com/378023/130756621-84ec93e6-ad00-4e9a-8490-f8d316d06d7b.png)

Adding an additional `background-color: var(--color-bg-canvas)` makes sure there is an opaque color that covers the line.