### PR TITLE
Testing on dotcom - Visual design updates to button styles

### DIFF
--- a/docs/content/components/buttons.md
+++ b/docs/content/components/buttons.md
@@ -135,7 +135,7 @@ When you want a link, but you want it padded and line heightened like a button b
 
 ```html live
 <button class="btn btn-invisible" type="button">Cancel</button>
-<button class="btn" type="button">Submit</button>
+<button class="btn ml-2" type="button">Submit</button>
 ```
 
 ### Hidden text button

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "release": "changeset publish"
   },
   "dependencies": {
-    "@primer/primitives": "0.0.0-202183195617"
+    "@primer/primitives": "0.0.0-20218320450"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "release": "changeset publish"
   },
   "dependencies": {
-    "@primer/primitives": "0.0.0-2021726201530"
+    "@primer/primitives": "0.0.0-202183195617"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "release": "changeset publish"
   },
   "dependencies": {
-    "@primer/primitives": "^4.3.5"
+    "@primer/primitives": "0.0.0-2021726201530"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.0",

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -169,12 +169,16 @@
 // Outline button
 
 .btn-outline {
-  background-color: transparent;
+  background-color: var(--color-btn-outline-bg);
   box-shadow: none;
+  color: var(--color-btn-outline-text);
 
   &:hover,
   [open] > & {
+    color: var(--color-btn-outline-hover-text);
+    background-color: var(--color-btn-outline-hover-bg);
     border-color: var(--color-btn-outline-hover-border);
+    box-shadow: var(--color-btn-outline-hover-shadow), var(--color-btn-outline-hover-inset-shadow);
 
     .Counter {
       background-color: var(--color-btn-outline-hover-counter-bg);
@@ -188,20 +192,28 @@
   &:active,
   &.selected,
   &[aria-selected=true] {
+    color: var(--color-btn-outline-selected-text);
+    background-color: var(--color-btn-outline-selected-bg);
     border-color: var(--color-btn-outline-selected-border);
-    box-shadow: none;
+    box-shadow: var(--color-btn-outline-selected-shadow);
   }
 
   &:disabled,
   &.disabled,
   &[aria-disabled=true] {
-    color: var(--color-text-disabled);
+    color: var(--color-btn-outline-disabled-text);
+    background-color: var(--color-btn-outline-disabled-bg);
     border-color: var(--color-btn-border);
     box-shadow: none;
 
     .Counter {
       background-color: var(--color-btn-outline-disabled-counter-bg);
     }
+  }
+
+  &:focus {
+    border-color: var(--color-btn-outline-focus-border);
+    box-shadow: var(--color-btn-outline-focus-shadow);
   }
 
   .Counter {

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -82,12 +82,6 @@
     transition-duration: 0.1s;
   }
 
-  &:active {
-    background-color: var(--color-btn-active-bg);
-    border-color: var(--color-btn-active-border);
-    transition: none;
-  }
-
   &.selected,
   &[aria-selected=true] {
     background-color: var(--color-btn-selected-bg);
@@ -108,6 +102,14 @@
     border-color: var(--color-btn-focus-border);
     outline: none;
     box-shadow: var(--color-btn-focus-shadow);
+  }
+
+  // Keep :active after :focus. Allows to see the inset shadow when the button is pressed
+  &:active {
+    background-color: var(--color-btn-active-bg);
+    border-color: var(--color-btn-active-border);
+    box-shadow: var(--color-btn-shadow-active);
+    transition: none;
   }
 }
 
@@ -166,14 +168,11 @@
 // Outline button
 
 .btn-outline {
-  color: var(--color-btn-outline-text);
+  background-color: transparent;
 
   &:hover,
   [open] > & {
-    color: var(--color-btn-outline-hover-text);
-    background-color: var(--color-btn-outline-hover-bg);
     border-color: var(--color-btn-outline-hover-border);
-    box-shadow: var(--color-btn-outline-hover-shadow), var(--color-btn-outline-hover-inset-shadow);
 
     .Counter {
       background-color: var(--color-btn-outline-hover-counter-bg);
@@ -187,28 +186,20 @@
   &:active,
   &.selected,
   &[aria-selected=true] {
-    color: var(--color-btn-outline-selected-text);
-    background-color: var(--color-btn-outline-selected-bg);
     border-color: var(--color-btn-outline-selected-border);
-    box-shadow: var(--color-btn-outline-selected-shadow);
+    box-shadow: none;
   }
 
   &:disabled,
   &.disabled,
   &[aria-disabled=true] {
-    color: var(--color-btn-outline-disabled-text);
-    background-color: var(--color-btn-outline-disabled-bg);
+    color: var(--color-text-disabled);
     border-color: var(--color-btn-border);
     box-shadow: none;
 
     .Counter {
       background-color: var(--color-btn-outline-disabled-counter-bg);
     }
-  }
-
-  &:focus {
-    border-color: var(--color-btn-outline-focus-border);
-    box-shadow: var(--color-btn-outline-focus-shadow);
   }
 
   .Counter {

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -17,6 +17,7 @@
   border: $border-width $border-style;
   border-radius: $border-radius;
   appearance: none; // Corrects inability to style clickable `input` types in iOS.
+  outline-offset: 1 + $border-width * 2;
 
   &:hover {
     text-decoration: none;
@@ -169,6 +170,7 @@
 
 .btn-outline {
   background-color: transparent;
+  box-shadow: none;
 
   &:hover,
   [open] > & {

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -96,12 +96,10 @@
     border-color: var(--color-btn-border);
   }
 
-  // Keep :focus after :disabled. Allows to see the focus ring even on disabled buttons
+  // Keep :focus after :disabled. Allows to see the border focus color even on disabled buttons
   &:focus,
   &.focus {
     border-color: var(--color-btn-focus-border);
-    outline: none;
-    box-shadow: var(--color-btn-focus-shadow);
   }
 
   // Keep :active after :focus. Allows to see the inset shadow when the button is pressed
@@ -151,7 +149,6 @@
   &.focus {
     background-color: var(--color-btn-primary-focus-bg);
     border-color: var(--color-btn-primary-focus-border);
-    box-shadow: var(--color-btn-primary-focus-shadow);
   }
 
   .Counter {
@@ -263,7 +260,6 @@
 
   &:focus {
     border-color: var(--color-btn-danger-focus-border);
-    box-shadow: var(--color-btn-danger-focus-shadow);
   }
 
   .Counter {

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -94,6 +94,7 @@
     color: var(--color-text-disabled);
     background-color: var(--color-btn-bg);
     border-color: var(--color-btn-border);
+    box-shadow: none;
   }
 
   // Keep :focus after :disabled. Allows to see the border focus color even on disabled buttons
@@ -139,6 +140,7 @@
     color: var(--color-btn-primary-disabled-text);
     background-color: var(--color-btn-primary-disabled-bg);
     border-color: var(--color-btn-primary-disabled-border);
+    box-shadow: none;
 
     .octicon {
       color: var(--color-btn-primary-disabled-text);

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -132,6 +132,7 @@
   &[aria-selected=true] {
     background-color: var(--color-btn-primary-selected-bg);
     box-shadow: var(--color-btn-primary-selected-shadow);
+    border-color: var(--color-btn-primary-border);
   }
 
   &:disabled,

--- a/src/buttons/misc.scss
+++ b/src/buttons/misc.scss
@@ -34,7 +34,7 @@
 //
 // Typically used as a "cancel" button next to a .btn
 .btn-invisible {
-  color: var(--color-btn-text);
+  color: var(--color-text-link);
   background-color: transparent; // Reset default gradient backgrounds and colors
   border: 0;
   box-shadow: none;

--- a/src/buttons/misc.scss
+++ b/src/buttons/misc.scss
@@ -43,7 +43,6 @@
   &:focus,
   &.zeroclipboard-is-hover {
     background-color: var(--color-btn-hover-bg);
-    outline: none;
     box-shadow: none;
   }
 
@@ -104,7 +103,6 @@
   color: var(--color-text-secondary);
   background: transparent;
   border: 0;
-  outline: none;
 
   &:hover {
     color: var(--color-text-primary);
@@ -114,8 +112,6 @@
   &:focus {
     color: var(--color-text-tertiary);
     border-color: var(--color-btn-active-border);
-    outline: none;
-    box-shadow: var(--color-btn-focus-shadow);
   }
 }
 
@@ -198,6 +194,7 @@
   border-top-right-radius: $border-radius;
   border-bottom-right-radius: $border-radius;
   box-shadow: var(--color-shadow-small), var(--color-shadow-highlight);
+  outline-offset: 1 + $border-width * 2;
 
   &:hover,
   &:active {
@@ -211,7 +208,5 @@
 
   &:focus {
     z-index: 1;
-    outline: 0;
-    box-shadow: var(--color-state-focus-shadow);
   }
 }

--- a/src/buttons/misc.scss
+++ b/src/buttons/misc.scss
@@ -34,30 +34,26 @@
 //
 // Typically used as a "cancel" button next to a .btn
 .btn-invisible {
-  color: var(--color-text-link);
+  color: var(--color-btn-text);
   background-color: transparent; // Reset default gradient backgrounds and colors
   border: 0;
-  border-radius: 0;
   box-shadow: none;
 
   &:hover,
+  &:focus,
   &.zeroclipboard-is-hover {
-    color: var(--color-text-link);
-    background: none;
+    background-color: var(--color-btn-hover-bg);
     outline: none;
     box-shadow: none;
   }
 
   &:active,
-  &:focus,
   &.selected,
   &[aria-selected=true],
   &.zeroclipboard-is-active {
-    color: var(--color-text-link);
-    background: none;
-    border-color: var(--color-btn-active-border);
+    background-color: var(--color-btn-active-bg);
+    box-shadow: none;
     outline: none;
-    box-shadow: var(--color-btn-focus-shadow);
   }
 
   &:disabled,

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,10 +880,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@primer/primitives@^4.3.5":
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-4.6.4.tgz#d31c37ee0e143cfbea47838fc02d33d95903c1f1"
-  integrity sha512-KKlP7m+94pbuFl3BYycQrmtNhX5+0gK3ftAh5L4a73Ov4FHbgMyVto3Cr0C5tlpvg0760Nisu+e/4T+/uvx8tA==
+"@primer/primitives@0.0.0-2021726201530":
+  version "0.0.0-2021726201530"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-0.0.0-2021726201530.tgz#f2c2d2fc8985e945b94bf1aed868aedc6c85b089"
+  integrity sha512-R54IUgCxoOS/tikKZwJoC28Y9nVul4IR73cdA/nU0t6u9eI/F8tiNjUTQ4FpN9hxEUs7rRSVCqA3Jo1JlPv65A==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,10 +880,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@primer/primitives@0.0.0-2021726201530":
-  version "0.0.0-2021726201530"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-0.0.0-2021726201530.tgz#f2c2d2fc8985e945b94bf1aed868aedc6c85b089"
-  integrity sha512-R54IUgCxoOS/tikKZwJoC28Y9nVul4IR73cdA/nU0t6u9eI/F8tiNjUTQ4FpN9hxEUs7rRSVCqA3Jo1JlPv65A==
+"@primer/primitives@0.0.0-202183195617":
+  version "0.0.0-202183195617"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-0.0.0-202183195617.tgz#c511e15b56f330bed1521607cee7e4b4903a9dd3"
+  integrity sha512-UgY794M0C2Tof0kSVQnj39LfKbQVGs/o7GZ1SS4JZatT2loJWU1CvPNAZHL2DpOtgONH80T1l3QtzToCStnJdg==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,10 +880,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@primer/primitives@0.0.0-202183195617":
-  version "0.0.0-202183195617"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-0.0.0-202183195617.tgz#c511e15b56f330bed1521607cee7e4b4903a9dd3"
-  integrity sha512-UgY794M0C2Tof0kSVQnj39LfKbQVGs/o7GZ1SS4JZatT2loJWU1CvPNAZHL2DpOtgONH80T1l3QtzToCStnJdg==
+"@primer/primitives@0.0.0-20218320450":
+  version "0.0.0-20218320450"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-0.0.0-20218320450.tgz#d87c31c0df171c4f2ed33c25e1b9bad735d19962"
+  integrity sha512-Gg2rx/F1rXwQstrfJDvSzwFb6MV0M/eyN27rwBw52UtKkY5AbkApRHlnS2uyYBAKZpZ9of+nKt977dRIu0jCUA==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"


### PR DESCRIPTION
Issue: https://github.com/github/primer/issues/263

Related PRs:
https://github.com/primer/react/pull/1408
https://github.com/primer/primitives/pull/219

These changes help us make the following design changes in Primer CSS and Primer React components:
* Focus style update
    * Uses native focus outline style to improve visibility. The custom styles had a very subtle focus ring
    * The focus ring has a small offset to improve contrast against the green background of the Primary button
* Show inner shadow for button `:active` states
    * Gives a sense of depth
* Add background color changes for the Invisible button
    * Makes it more obvious when an Invisible button is being hovered or pressed

### Screenshots

#### Native focus ring style for all buttons

##### Before
https://user-images.githubusercontent.com/2313998/131442571-a3f92bbf-93e9-44c4-bd42-9c733e53e168.mp4

##### After
https://user-images.githubusercontent.com/2313998/131442656-3b72f3c1-06fe-420b-9ce0-ef40623e9948.mp4

#### Show inner shadow for button `:active` states
##### Before
https://user-images.githubusercontent.com/2313998/131442693-e02199bb-4a62-4ac5-9fb7-c0215ec0b377.mp4

##### After
https://user-images.githubusercontent.com/2313998/131442746-7db89472-7893-40ea-85d9-a03137cb08a4.mp4


#### Add background color changes for the Invisible button

##### Before
https://user-images.githubusercontent.com/2313998/131442795-0b4d9020-bedd-44d3-992d-47705d049b88.mp4

##### After
https://user-images.githubusercontent.com/2313998/131442809-f9332fca-9115-47f4-a813-a0d46cbb19f0.mp4
