### PR TITLE
Fix TimelineItem--condensed background

### DIFF
--- a/.changeset/silver-items-talk.md
+++ b/.changeset/silver-items-talk.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fix TimelineItem--condensed background

--- a/src/timeline/timeline-item.scss
+++ b/src/timeline/timeline-item.scss
@@ -93,6 +93,7 @@
     // stylelint-disable-next-line primer/colors
     color: var(--color-icon-secondary);
     background-color: var(--color-bg-canvas);
+    background-image: none;
     border: 0;
   }
 }


### PR DESCRIPTION
This removes the "condensed" `TimelineItem` background:

Before | After
--- | ---
<img width="199" alt="Screen Shot 2021-08-30 at 12 11 58" src="https://user-images.githubusercontent.com/378023/131280383-b280c1e9-a684-41a1-9272-a3acfbb04afa.png"> | <img width="145" alt="Screen Shot 2021-08-30 at 12 12 44" src="https://user-images.githubusercontent.com/378023/131280388-ea3bdbf1-33d8-407e-9bde-b11915dc8ed5.png">

