### PR TITLE
Revert `TimelineItem-badge` fix

### DIFF
--- a/.changeset/thirty-tips-help.md
+++ b/.changeset/thirty-tips-help.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Revert `TimelineItem-badge` fix

--- a/src/timeline/timeline-item.scss
+++ b/src/timeline/timeline-item.scss
@@ -34,8 +34,7 @@
   // stylelint-disable-next-line primer/colors
   color: var(--color-icon-secondary);
   align-items: center;
-  background-color: var(--color-bg-canvas); // covers the "line"
-  background-image: linear-gradient(0deg, var(--color-timeline-badge-bg), var(--color-timeline-badge-bg));
+  background-color: var(--color-timeline-badge-bg);
   // stylelint-disable-next-line primer/borders
   border: 2px $border-style var(--color-bg-canvas);
   border-radius: 50%;
@@ -93,7 +92,6 @@
     // stylelint-disable-next-line primer/colors
     color: var(--color-icon-secondary);
     background-color: var(--color-bg-canvas);
-    background-image: none;
     border: 0;
   }
 }


### PR DESCRIPTION
This reverts:

- https://github.com/primer/css/pull/1550
- https://github.com/primer/css/pull/1556

The "gradient hack" causes too many regressions and doesn't allow utilities like `color-bg-danger-inverse` to be used. So fix the "transparency" problem, I'll add a custom "component" variable for the `TimelineItem-badge` background to Primitives.

I tried using a `::after` pseudo element, but that still renders "above" the background color of the element and doesn't help in this situation.

In the future we might can offer different "states" for the `TimelineItem-badge`, but that needs some refactoring on dotcom first.
