### PR TITLE
Improve font stack on Windows

### DIFF
--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -43,6 +43,7 @@ $body-font:
   // See https://infinnie.github.io/blog/2017/systemui.html
   "Segoe UI Variable Text",
   "Segoe UI",
+  "Yu Gothic",
 
   // Linux-friendly system-level fonts + fallbacks
   system-ui,

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -37,20 +37,20 @@ $body-font:
   // Apple OSs
   -apple-system,
   BlinkMacSystemFont,
-  
+
   // Windows
   // Note this should be prioritized over `system-ui` to avoid legacy fonts.
   // See https://infinnie.github.io/blog/2017/systemui.html
-  "Segoe UI Variable",
+  "Segoe UI Variable Text",
   "Segoe UI",
-  
+
   // Linux-friendly system-level fonts + fallbacks
   system-ui,
   ui-sans-serif,
   Helvetica,
   Arial,
   sans-serif,
-  
+
   // Emojis
   "Apple Color Emoji",
   "Segoe UI Emoji" !default;


### PR DESCRIPTION
This is a follow up to https://github.com/primer/css/pull/1529 and further improves the font stack on Windows:

- `Segoe UI Variable` -> `Segoe UI Variable Text`.
    - "Segoe UI Variable Text" seems to be the better options for a lot of text (markdown). In the future we might can consider having a UI and a "text" font stack.
- Add `Yu Gothic` before `system-ui`.
    - This should have the effect that the browser will use `Yu Gothic` instead of `Yu Gothic UI` and should improve text (markdown).
