### PR TITLE
Change the old primer/colors and primer/borders stylelint plugins severity to warning

### DIFF
--- a/src/alerts/flash.scss
+++ b/src/alerts/flash.scss
@@ -69,7 +69,6 @@
   border-color: var(--color-alert-info-border);
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-alert-info-icon);
   }
 }
@@ -80,7 +79,6 @@
   border-color: var(--color-alert-warn-border);
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-alert-warn-icon);
   }
 }
@@ -91,7 +89,6 @@
   border-color: var(--color-alert-error-border);
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-alert-error-icon);
   }
 }
@@ -102,7 +99,6 @@
   border-color: var(--color-alert-success-border);
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-alert-success-icon);
   }
 }

--- a/src/avatars/avatar-parent-child.scss
+++ b/src/avatars/avatar-parent-child.scss
@@ -11,7 +11,6 @@
   right: -15%;
   bottom: -9%;
   background-color: var(--color-bg-canvas); // For transparent backgrounds
-  // stylelint-disable-next-line primer/borders
   border-radius: $border-radius-1;
   box-shadow: var(--color-avatar-child-shadow);
 }

--- a/src/avatars/avatar-stack.scss
+++ b/src/avatars/avatar-stack.scss
@@ -34,7 +34,6 @@
     margin-right: -11px;
     background-color: var(--color-bg-canvas);
     border-right: $border-width $border-style var(--color-bg-canvas); // stylelint-disable-line primer/borders
-    // stylelint-disable-next-line primer/borders
     border-radius: $border-radius-1;
     transition: margin 0.1s ease-in-out;
 
@@ -49,7 +48,6 @@
 
     // stylelint-disable selector-max-type
     img {
-      // stylelint-disable-next-line primer/borders
       border-radius: $border-radius-1;
     }
     // stylelint-enable selector-max-type
@@ -90,20 +88,17 @@
     display: block;
     height: 20px;
     content: "";
-    // stylelint-disable-next-line primer/borders
     border-radius: 2px;
     outline: $border-width $border-style var(--color-bg-canvas);
   }
 
   &::before {
     width: 17px;
-    // stylelint-disable-next-line primer/colors
     background: var(--color-avatar-stack-fade-more);
   }
 
   &::after {
     width: 14px;
-    // stylelint-disable-next-line primer/colors
     background: var(--color-avatar-stack-fade);
   }
 }
@@ -123,7 +118,6 @@
   }
 
   .avatar.avatar-more {
-    // stylelint-disable-next-line primer/colors
     background: var(--color-avatar-stack-fade);
 
     &::before {

--- a/src/avatars/avatar-stack.scss
+++ b/src/avatars/avatar-stack.scss
@@ -33,7 +33,7 @@
     // stylelint-disable-next-line primer/spacing
     margin-right: -11px;
     background-color: var(--color-bg-canvas);
-    border-right: $border-width $border-style var(--color-bg-canvas); // stylelint-disable-line primer/borders
+    border-right: $border-width $border-style var(--color-bg-canvas);
     border-radius: $border-radius-1;
     transition: margin 0.1s ease-in-out;
 
@@ -135,6 +135,6 @@
     // stylelint-disable-next-line primer/spacing
     margin-left: -11px;
     border-right: 0;
-    border-left: $border-width $border-style var(--color-bg-canvas); // stylelint-disable-line primer/borders
+    border-left: $border-width $border-style var(--color-bg-canvas);
   }
 }

--- a/src/avatars/avatar.scss
+++ b/src/avatars/avatar.scss
@@ -27,7 +27,6 @@
 .avatar-1,
 .avatar-2,
 .avatar-small {
-  // stylelint-disable-next-line primer/borders
   border-radius: $border-radius-1;
 }
 

--- a/src/avatars/circle-badge.scss
+++ b/src/avatars/circle-badge.scss
@@ -45,7 +45,6 @@
     left: 0;
     width: 100%;
     content: "";
-    // stylelint-disable-next-line primer/borders
     border-bottom: 2px dashed var(--color-border-primary);
   }
 

--- a/src/base/kbd.scss
+++ b/src/base/kbd.scss
@@ -11,7 +11,6 @@ kbd {
   color: var(--color-text-primary);
   vertical-align: middle;
   background-color: var(--color-bg-secondary);
-  // stylelint-disable-next-line primer/borders
   border: $border-style $border-width var(--color-border-tertiary);
   border-bottom-color: var(--color-border-tertiary);
   border-radius: $border-radius;

--- a/src/blankslate/blankslate.scss
+++ b/src/blankslate/blankslate.scss
@@ -27,7 +27,6 @@
   margin-right: $spacer-1;
   margin-bottom: $spacer-2;
   margin-left: $spacer-1;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-icon-secondary);
 }
 

--- a/src/branch-name/branch-name.scss
+++ b/src/branch-name/branch-name.scss
@@ -14,7 +14,6 @@
   .octicon {
     // stylelint-disable-next-line primer/spacing
     margin: 1px -2px 0 0;
-    // stylelint-disable-next-line primer/colors
     color: var(--color-branch-name-icon);
   }
 }
@@ -26,7 +25,6 @@ a.branch-name {
   background-color: var(--color-branch-name-link-bg);
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-branch-name-link-icon);
   }
 }

--- a/src/breadcrumb/breadcrumb.scss
+++ b/src/breadcrumb/breadcrumb.scss
@@ -10,7 +10,6 @@
     height: 0.8em;
     margin: 0 $em-spacer-5;
     content: '';
-    // stylelint-disable-next-line primer/borders
     border-right: 0.1em $border-style var(--color-text-disabled);
     transform: rotate(15deg);
   }

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -28,7 +28,6 @@
     cursor: default;
 
     .octicon {
-      // stylelint-disable-next-line primer/colors
       color: var(--color-icon-tertiary);
     }
   }
@@ -158,7 +157,6 @@
   }
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-btn-primary-icon);
   }
 }
@@ -223,7 +221,6 @@
   color: var(--color-btn-danger-text);
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-btn-danger-icon);
   }
 
@@ -239,7 +236,6 @@
     }
 
     .octicon {
-      // stylelint-disable-next-line primer/colors
       color: var(--color-btn-danger-hover-icon);
     }
   }
@@ -301,8 +297,6 @@
   padding: $em-spacer-6 1.5em;
   font-size: inherit;
   line-height: $lh-default;
-
-  // stylelint-disable-next-line primer/borders
   border-radius: 0.5em;
 }
 

--- a/src/buttons/misc.scss
+++ b/src/buttons/misc.scss
@@ -154,7 +154,6 @@
   vertical-align: middle;
   background: var(--color-hidden-text-expander-bg);
   border: 0;
-  // stylelint-disable-next-line primer/borders
   border-radius: 1px;
 
   &:hover {

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -9,7 +9,6 @@
   vertical-align: middle;
   content: "";
   border-style: $border-style;
-  // stylelint-disable-next-line primer/borders
   border-width: $spacer-1 $spacer-1 0;
   border-right-color: transparent;
   border-bottom-color: transparent;
@@ -45,15 +44,12 @@
 
   // caret border
   &::before {
-    // stylelint-disable-next-line primer/borders
     border: $spacer-2 $border-style transparent;
     border-bottom-color: var(--color-border-primary);
   }
 
   // caret background (should match dropdown background)
   &::after {
-    // stylelint-disable-next-line primer/borders
-    border: 7px $border-style transparent;
     // stylelint-disable-next-line primer/borders
     border-bottom-color: var(--color-bg-overlay);
   }
@@ -161,7 +157,6 @@
     right: -14px;
     left: auto;
     border-color: transparent;
-    // stylelint-disable-next-line primer/borders
     border-left-color: var(--color-bg-overlay);
   }
 }
@@ -184,7 +179,6 @@
     top: 11px;
     left: -14px;
     border-color: transparent;
-    // stylelint-disable-next-line primer/borders
     border-right-color: var(--color-bg-overlay);
   }
 }
@@ -204,25 +198,19 @@
 
   &::before {
     bottom: -$spacer-2;
-    left: 9px;
-    // stylelint-disable-next-line primer/borders
-    border-top: $spacer-2 $border-style var(--color-border-primary);
+    left: 9px;or-border-primary);
     // stylelint-disable-next-line primer/borders
     border-right: $spacer-2 $border-style transparent;
     border-bottom: 0;
-    // stylelint-disable-next-line primer/borders
     border-left: $spacer-2 $border-style transparent;
   }
 
   &::after {
     bottom: -7px;
-    left: 10px;
-    // stylelint-disable-next-line primer/borders
-    border-top: 7px $border-style var(--color-bg-overlay);
+    left: 10px;overlay);
     // stylelint-disable-next-line primer/borders
     border-right: 7px $border-style transparent;
     border-bottom: 0;
-    // stylelint-disable-next-line primer/borders
     border-left: 7px $border-style transparent;
   }
 }

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -50,7 +50,7 @@
 
   // caret background (should match dropdown background)
   &::after {
-    // stylelint-disable-next-line primer/borders
+    border: 7px $border-style transparent;
     border-bottom-color: var(--color-bg-overlay);
   }
 
@@ -198,8 +198,8 @@
 
   &::before {
     bottom: -$spacer-2;
-    left: 9px;or-border-primary);
-    // stylelint-disable-next-line primer/borders
+    left: 9px;
+    border-top: $spacer-2 $border-style var(--color-border-primary);
     border-right: $spacer-2 $border-style transparent;
     border-bottom: 0;
     border-left: $spacer-2 $border-style transparent;
@@ -207,8 +207,8 @@
 
   &::after {
     bottom: -7px;
-    left: 10px;overlay);
-    // stylelint-disable-next-line primer/borders
+    left: 10px;
+    border-top: 7px $border-style var(--color-bg-overlay);
     border-right: 7px $border-style transparent;
     border-bottom: 0;
     border-left: 7px $border-style transparent;

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -130,7 +130,6 @@ textarea.form-control {
       // stylelint-disable-next-line primer/spacing
       padding: 2px $spacer-1;
       font-style: normal;
-      // stylelint-disable-next-line primer/colors
       background: var(--color-attention-subtle, var(--color-auto-yellow-1));
       border-radius: $border-radius;
     }

--- a/src/forms/form-group.scss
+++ b/src/forms/form-group.scss
@@ -170,19 +170,16 @@
         height: 0;
         pointer-events: none;
         content: " ";
-        // stylelint-disable-next-line primer/borders
         border: $border-style transparent;
       }
 
       &::after {
-        // stylelint-disable-next-line primer/borders
         border-width: 5px;
       }
 
       &::before {
         // stylelint-disable-next-line primer/spacing
         margin-left: -1px;
-        // stylelint-disable-next-line primer/borders
         border-width: 6px;
       }
     }

--- a/src/forms/form-group.scss
+++ b/src/forms/form-group.scss
@@ -192,7 +192,7 @@
       background-image: linear-gradient(var(--color-input-tooltip-success-bg), var(--color-input-tooltip-success-bg));
       border-color: var(--color-input-tooltip-success-border);
 
-      &::after { border-bottom-color: var(--color-input-tooltip-success-bg); } // stylelint-disable-line primer/borders
+      &::after { border-bottom-color: var(--color-input-tooltip-success-bg); }
       &::before { border-bottom-color: var(--color-input-tooltip-success-border); }
     }
   }
@@ -208,7 +208,7 @@
       background-image: linear-gradient(var(--color-input-tooltip-warning-bg), var(--color-input-tooltip-warning-bg));
       border-color: var(--color-input-tooltip-warning-border);
 
-      &::after { border-bottom-color: var(--color-input-tooltip-warning-bg); } // stylelint-disable-line primer/borders
+      &::after { border-bottom-color: var(--color-input-tooltip-warning-bg); }
       &::before { border-bottom-color: var(--color-input-tooltip-warning-border); }
     }
   }
@@ -228,7 +228,7 @@
       background-image: linear-gradient(var(--color-input-tooltip-error-bg), var(--color-input-tooltip-error-bg));
       border-color: var(--color-input-tooltip-error-border);
 
-      &::after { border-bottom-color: var(--color-input-tooltip-error-bg); } // stylelint-disable-line primer/borders
+      &::after { border-bottom-color: var(--color-input-tooltip-error-bg); }
       &::before { border-bottom-color: var(--color-input-tooltip-error-border); }
     }
   }

--- a/src/forms/form-validation.scss
+++ b/src/forms/form-validation.scss
@@ -228,7 +228,6 @@ dl.form-group > dd, // TODO: Deprecate
 .upload-enabled {
   textarea {
     display: block;
-    // stylelint-disable-next-line primer/borders
     border-bottom: $border-width dashed var(--color-upload-enabled-border);
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
@@ -345,7 +344,6 @@ p.explain {
   .octicon {
     // stylelint-disable-next-line primer/spacing
     margin-right: 5px;
-    // stylelint-disable-next-line primer/colors
     color: var(--color-icon-tertiary);
   }
 

--- a/src/header/header.scss
+++ b/src/header/header.scss
@@ -24,7 +24,6 @@
 
 .Header-link {
   font-weight: $font-weight-bold;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-header-logo);
   white-space: nowrap;
 
@@ -42,7 +41,6 @@
   box-shadow: none;
 
   &::placeholder {
-    // stylelint-disable-next-line primer/colors
     color: rgba(255, 255, 255, 0.75);
   }
 }

--- a/src/labels/counters.scss
+++ b/src/labels/counters.scss
@@ -12,7 +12,6 @@
   text-align: center;
   background-color: var(--color-counter-bg);
   border: $border-width $border-style transparent; // Support Firefox custom colors
-  // stylelint-disable-next-line primer/borders
   border-radius: 2em;
 
   &:empty {

--- a/src/labels/states.scss
+++ b/src/labels/states.scss
@@ -14,7 +14,6 @@
   line-height: 20px;
   text-align: center;
   white-space: nowrap;
-  // stylelint-disable-next-line primer/borders
   border-radius: 2em;
 }
 

--- a/src/layout/layout.scss
+++ b/src/layout/layout.scss
@@ -121,7 +121,6 @@
       width: 1px;
       // stylelint-disable-next-line primer/spacing
       margin-right: -1px;
-      // stylelint-disable-next-line primer/colors
       background: var(--color-border-primary);
     }
 

--- a/src/markdown/markdown-body.scss
+++ b/src/markdown/markdown-body.scss
@@ -76,7 +76,6 @@
     height: $em-spacer-3;
     padding: 0;
     margin: $spacer-4 0;
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-border-primary);
     border: 0;
   }
@@ -85,7 +84,6 @@
     // stylelint-disable-next-line primer/spacing
     padding: 0 1em;
     color: var(--color-text-tertiary);
-    // stylelint-disable-next-line primer/borders
     border-left: 0.25em $border-style var(--color-markdown-blockquote-border);
 
     > :first-child {

--- a/src/marketing/buttons/button.scss
+++ b/src/marketing/buttons/button.scss
@@ -13,7 +13,6 @@
   vertical-align: middle;
   user-select: none;
   border: 0;
-  // stylelint-disable-next-line primer/borders
   border-radius: rem(6px);
 
   @include btn-solid-mktg(
@@ -33,7 +32,6 @@
     left: 0;
     z-index: -1;
     content: "";
-    // stylelint-disable-next-line primer/borders
     border-radius: rem(6px);
     opacity: 0;
     transition: opacity 0.4s;

--- a/src/navigation/menu.scss
+++ b/src/navigation/menu.scss
@@ -61,7 +61,6 @@
       left: 0;
       width: 2px;
       content: "";
-      // stylelint-disable-next-line primer/colors
       background-color: var(--color-menu-border-active);
     }
   }
@@ -69,7 +68,6 @@
   .octicon {
     width: 16px;
     margin-right: $spacer-2;
-    // stylelint-disable-next-line primer/colors
     color: var(--color-icon-tertiary);
     text-align: center;
   }
@@ -81,7 +79,6 @@
 
   .menu-warning {
     float: right;
-    // stylelint-disable-next-line primer/colors
     color: var(--color-icon-warning);
   }
 

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -65,7 +65,6 @@
 
   // Bar on the left
   &::before {
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-sidenav-border-active);
   }
 }

--- a/src/navigation/subnav.scss
+++ b/src/navigation/subnav.scss
@@ -80,7 +80,6 @@
   top: 9px;
   left: 8px;
   display: block;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-icon-tertiary);
   text-align: center;
   pointer-events: none;

--- a/src/navigation/tabnav.scss
+++ b/src/navigation/tabnav.scss
@@ -53,7 +53,6 @@
 
   .octicon {
     margin-right: $spacer-1;
-    // stylelint-disable-next-line primer/colors
     color: var(--color-icon-tertiary);
   }
 

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -21,7 +21,6 @@
   white-space: nowrap;
   background-color: transparent;
   border: 0;
-  // stylelint-disable-next-line primer/borders
   border-bottom: 2px $border-style transparent;
 
   &:hover,
@@ -67,7 +66,6 @@
 
 .UnderlineNav-octicon {
   margin-right: $spacer-1;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-underlinenav-icon);
 }
 

--- a/src/pagination/pagination.scss
+++ b/src/pagination/pagination.scss
@@ -68,7 +68,6 @@
       height: 16px;
       vertical-align: text-bottom;
       content: "";
-      // stylelint-disable-next-line primer/colors
       background-color: currentColor;
     }
 

--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -29,7 +29,7 @@
   &::after {
     top: -14px;
     margin-left: -$spacer-2;
-    // stylelint-disable-next-line primer/borders
+    border: 7px $border-style transparent;
     border-bottom-color: var(--color-bg-overlay);
   }
 

--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -22,7 +22,6 @@
     top: -$spacer-3;
     // stylelint-disable-next-line primer/spacing
     margin-left: -9px;
-    // stylelint-disable-next-line primer/borders
     border: $spacer-2 $border-style transparent;
     border-bottom-color: var(--color-border-primary);
   }
@@ -30,8 +29,6 @@
   &::after {
     top: -14px;
     margin-left: -$spacer-2;
-    // stylelint-disable-next-line primer/borders
-    border: 7px $border-style transparent;
     // stylelint-disable-next-line primer/borders
     border-bottom-color: var(--color-bg-overlay);
   }
@@ -59,7 +56,6 @@
 
   &::after {
     bottom: -14px;
-    // stylelint-disable-next-line primer/borders
     border-top-color: var(--color-bg-overlay);
   }
 }
@@ -138,7 +134,6 @@
 
   &::after {
     right: -14px;
-    // stylelint-disable-next-line primer/borders
     border-left-color: var(--color-bg-overlay);
   }
 }
@@ -154,7 +149,6 @@
 
   &::after {
     left: -14px;
-    // stylelint-disable-next-line primer/borders
     border-right-color: var(--color-bg-overlay);
   }
 }

--- a/src/progress/progress.scss
+++ b/src/progress/progress.scss
@@ -4,7 +4,6 @@
   display: flex;
   height: 8px;
   overflow: hidden;
-  // stylelint-disable-next-line primer/colors
   background-color: var(--color-neutral-muted, var(--color-auto-gray-2));
   border-radius: $border-radius;
   outline: 1px solid transparent; // Support Firefox custom colors

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -63,7 +63,6 @@ $SelectMenu-max-height: 480px !default;
   flex-direction: column;
   background-color: var(--color-bg-overlay);
   border: $border-width $border-style var(--color-select-menu-backdrop-border);
-  // stylelint-disable-next-line primer/borders
   border-radius: $border-radius * 2;
   box-shadow: var(--color-select-menu-shadow);
   animation: SelectMenu-modal-animation 0.12s cubic-bezier(0, 0.1, 0.1, 1) backwards;
@@ -126,7 +125,6 @@ $SelectMenu-max-height: 480px !default;
   padding: $spacer-3;
   margin: -$spacer-3;
   line-height: 1;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-icon-tertiary);
   background-color: transparent;
   border: 0;

--- a/src/timeline/timeline-item.scss
+++ b/src/timeline/timeline-item.scss
@@ -13,7 +13,6 @@
     display: block;
     width: 2px;
     content: "";
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-border-secondary);
   }
 
@@ -31,11 +30,9 @@
   height: $spacer-5;
   margin-right: $spacer-2;
   margin-left: -$spacer-3 + 1;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-icon-secondary);
   align-items: center;
   background-color: var(--color-timeline-badge-bg);
-  // stylelint-disable-next-line primer/borders
   border: 2px $border-style var(--color-bg-canvas);
   border-radius: 50%;
   justify-content: center;
@@ -72,7 +69,6 @@
   margin-left: -($spacer-6 + $spacer-3);
   background-color: var(--color-bg-canvas);
   border: 0;
-  // stylelint-disable-next-line primer/borders
   border-top: 4px $border-style var(--color-border-primary);
 }
 
@@ -89,7 +85,6 @@
     height: $spacer-3;
     margin-top: $spacer-2;
     margin-bottom: $spacer-2;
-    // stylelint-disable-next-line primer/colors
     color: var(--color-icon-secondary);
     background-color: var(--color-bg-canvas);
     border: 0;

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -21,7 +21,7 @@
   justify-content: center;
   width: $spacer-3 * 3;
   flex-shrink: 0;
-  color: var(--color-toast-icon); // stylelint-disable-line primer/colors
+  color: var(--color-toast-icon);
   background-color: var(--color-toast-icon-bg);
   border: $border-width $border-style var(--color-toast-icon-border);
   border-right: 0;
@@ -58,7 +58,7 @@
   box-shadow: inset 0 0 0 1px var(--color-toast-loading-border), var(--color-toast-shadow);
 
   .Toast-icon {
-    color: var(--color-toast-loading-icon); // stylelint-disable-line primer/colors
+    color: var(--color-toast-loading-icon);
     background-color: var(--color-toast-loading-icon-bg);
     border-color: var(--color-toast-loading-icon-border);
   }
@@ -69,7 +69,7 @@
   box-shadow: inset 0 0 0 1px var(--color-toast-danger-border), var(--color-toast-shadow);
 
   .Toast-icon {
-    color: var(--color-toast-danger-icon); // stylelint-disable-line primer/colors
+    color: var(--color-toast-danger-icon);
     background-color: var(--color-toast-danger-icon-bg);
     border-color: var(--color-toast-danger-icon-border);
   }
@@ -80,7 +80,7 @@
   box-shadow: inset 0 0 0 1px var(--color-toast-warning-border), var(--color-toast-shadow);
 
   .Toast-icon {
-    color: var(--color-toast-warning-icon); // stylelint-disable-line primer/colors
+    color: var(--color-toast-warning-icon);
     background-color: var(--color-toast-warning-icon-bg);
     border-color: var(--color-toast-warning-icon-border);
   }
@@ -91,7 +91,7 @@
   box-shadow: inset 0 0 0 1px var(--color-toast-success-border), var(--color-toast-shadow);
 
   .Toast-icon {
-    color: var(--color-toast-success-icon); // stylelint-disable-line primer/colors
+    color: var(--color-toast-success-icon);
     background-color: var(--color-toast-success-icon-bg);
     border-color: var(--color-toast-success-icon-border);
   }

--- a/src/tooltips/tooltips.scss
+++ b/src/tooltips/tooltips.scss
@@ -32,7 +32,7 @@
   display: none;
   width: 0;
   height: 0;
-  color: var(--color-tooltip-bg); // stylelint-disable-line primer/colors
+  color: var(--color-tooltip-bg);
   pointer-events: none;
   content: "";
   border: 6px $border-style transparent;

--- a/src/tooltips/tooltips.scss
+++ b/src/tooltips/tooltips.scss
@@ -35,7 +35,6 @@
   color: var(--color-tooltip-bg); // stylelint-disable-line primer/colors
   pointer-events: none;
   content: "";
-  // stylelint-disable-next-line primer/borders
   border: 6px $border-style transparent;
   opacity: 0;
 }
@@ -101,7 +100,6 @@
     bottom: -7px;
     // stylelint-disable-next-line primer/spacing
     margin-right: -6px;
-    // stylelint-disable-next-line primer/borders
     border-bottom-color: var(--color-tooltip-bg);
   }
 }
@@ -135,7 +133,6 @@
     bottom: auto;
     // stylelint-disable-next-line primer/spacing
     margin-right: -6px;
-    // stylelint-disable-next-line primer/borders
     border-top-color: var(--color-tooltip-bg);
   }
 }
@@ -174,7 +171,6 @@
     left: -7px;
     // stylelint-disable-next-line primer/spacing
     margin-top: -6px;
-    // stylelint-disable-next-line primer/borders
     border-left-color: var(--color-tooltip-bg);
   }
 }
@@ -195,7 +191,6 @@
     bottom: 50%;
     // stylelint-disable-next-line primer/spacing
     margin-top: -6px;
-    // stylelint-disable-next-line primer/borders
     border-right-color: var(--color-tooltip-bg);
   }
 }

--- a/src/utilities/borders.scss
+++ b/src/utilities/borders.scss
@@ -70,6 +70,5 @@
 
 /* Change the border style to dashed, in conjunction with another utility */
 .border-dashed {
-  // stylelint-disable-next-line primer/borders
   border-style: dashed !important;
 }

--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -12,13 +12,13 @@
 .color-text-white     { color: var(--color-text-white) !important; }
 
 // Icon colors
-.color-icon-primary   { color: var(--color-icon-primary) !important; } // stylelint-disable-line primer/colors
-.color-icon-secondary { color: var(--color-icon-secondary) !important; } // stylelint-disable-line primer/colors
-.color-icon-tertiary  { color: var(--color-icon-tertiary) !important; } // stylelint-disable-line primer/colors
-.color-icon-info      { color: var(--color-icon-info) !important; } // stylelint-disable-line primer/colors
-.color-icon-danger    { color: var(--color-icon-danger) !important; } // stylelint-disable-line primer/colors
-.color-icon-success   { color: var(--color-icon-success) !important; } // stylelint-disable-line primer/colors
-.color-icon-warning   { color: var(--color-icon-warning) !important; } // stylelint-disable-line primer/colors
+.color-icon-primary   { color: var(--color-icon-primary) !important; }
+.color-icon-secondary { color: var(--color-icon-secondary) !important; }
+.color-icon-tertiary  { color: var(--color-icon-tertiary) !important; }
+.color-icon-info      { color: var(--color-icon-info) !important; }
+.color-icon-danger    { color: var(--color-icon-danger) !important; }
+.color-icon-success   { color: var(--color-icon-success) !important; }
+.color-icon-warning   { color: var(--color-icon-warning) !important; }
 
 // Border colors
 .color-border-primary   { border-color: var(--color-border-primary) !important; }

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -8,7 +8,7 @@ module.exports = {
   rules: {
     'scss/dollar-variable-default': [true, {ignore: 'local'}],
     'primer/no-override': false,
-    'primer/colors': true,
+    'primer/colors': false,
     'primer/borders': true,
     'primer/spacing': true,
     'primer/typography': true,

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -8,8 +8,8 @@ module.exports = {
   rules: {
     'scss/dollar-variable-default': [true, {ignore: 'local'}],
     'primer/no-override': false,
-    'primer/colors': false,
-    'primer/borders': false,
+    'primer/colors': [true, {severity: 'warning'}],
+    'primer/borders': [true, {severity: 'warning'}],
     'primer/spacing': true,
     'primer/typography': true,
     'primer/box-shadow': true,

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -9,7 +9,7 @@ module.exports = {
     'scss/dollar-variable-default': [true, {ignore: 'local'}],
     'primer/no-override': false,
     'primer/colors': false,
-    'primer/borders': true,
+    'primer/borders': false,
     'primer/spacing': true,
     'primer/typography': true,
     'primer/box-shadow': true,


### PR DESCRIPTION
These old plugins looked for `fg` and `bg` in color var names and matched them up with `color:` and `background-color:` this is a problem with the new color system. Breaking the build on https://github.com/primer/css/pull/1575 and https://github.com/primer/css/pull/1574

I propose we start by making them warnings, and maybe rebuild them in stylelint-config-primer with the new color modes in mind.


