### PR TITLE
Updating stylint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "prettier": "2.3.2",
     "semver": "7.3.5",
     "stylelint": "13.13.1",
-    "stylelint-config-primer": "11.1.0",
+    "stylelint-config-primer": "11.1.1",
     "stylelint-scss": "3.20.1",
     "table": "6.7.1"
   },

--- a/script/remove-needless-disables
+++ b/script/remove-needless-disables
@@ -1,59 +1,11 @@
-#!/usr/bin/env node
-const stylelint = require('stylelint')
-const {readFileSync, writeFileSync} = require('fs')
+#!/bin/bash
+set -e
 
-const files = process.argv.slice(2)
-if (files.length === 0) {
-  files.push('src/**/*.scss')
-}
+disables=$(stylelint src --quiet --report-needless-disables -f unix | grep '^/')
 
-// we use an empty "marker" to delineate removed lines
-const REMOVED = `===REMOVED@${Date.now()}===`
-
-stylelint.lint({files, reportNeedlessDisables: true}).then(({needlessDisables}) => {
-  for (const {source, ranges} of needlessDisables) {
-    const lines = readFileSync(source, 'utf8').split(/\n/)
-    let offset = 0
-    for (const {start, unusedRule} of ranges) {
-      let index = start - 1
-      let line = lines[index]
-      let disable = parseDisableComment(line)
-      if (!disable) {
-        console.warn(`unable to parse disable on line ${start}: ${lines[start - 1]}; trying previous line...`)
-        index--
-        line = lines[index]
-        disable = parseDisableComment(line)
-        if (!disable) {
-          console.warn(`unable to parse disable on line ${index + 1}: ${lines}`)
-          continue
-        }
-      }
-
-      const rules = new Set(disable.rules)
-      rules.delete(unusedRule)
-
-      if (rules.size === 0) {
-        console.log(`- ${line}`)
-        lines[index] = REMOVED
-      } else {
-        const replacement = line.replace(disable.content, `${disable.type} ${Array.from(rules).join(', ')}`)
-        lines[index] = replacement
-        console.log(`- ${line}`)
-        console.log(`+ ${replacement}`)
-      }
-    }
-    const output = lines.filter(line => line !== REMOVED).join('\n')
-    writeFileSync(source, output, 'utf8')
-  }
-})
-
-function parseDisableComment(str) {
-  const match = str.match(/(stylelint-disable((-next)?-line)?)\s+(.+)$/)
-  return match
-    ? {
-        content: match[0],
-        type: match[1],
-        rules: match[4].split(/,\s+/)
-      }
-    : false
-}
+while IFS= read -r line; do
+  case $line in
+    (*:*:*:*) file=${line%:*}
+  esac
+  echo $file
+done < <(echo "$disables")

--- a/src/alerts/flash.scss
+++ b/src/alerts/flash.scss
@@ -69,7 +69,6 @@
   border-color: var(--color-alert-info-border);
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-alert-info-icon);
   }
 }
@@ -80,7 +79,6 @@
   border-color: var(--color-alert-warn-border);
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-alert-warn-icon);
   }
 }
@@ -91,7 +89,6 @@
   border-color: var(--color-alert-error-border);
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-alert-error-icon);
   }
 }
@@ -102,7 +99,6 @@
   border-color: var(--color-alert-success-border);
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-alert-success-icon);
   }
 }

--- a/src/avatars/avatar-stack.scss
+++ b/src/avatars/avatar-stack.scss
@@ -33,7 +33,7 @@
     // stylelint-disable-next-line primer/spacing
     margin-right: -11px;
     background-color: var(--color-bg-canvas);
-    border-right: $border-width $border-style var(--color-bg-canvas); // stylelint-disable-line primer/borders
+    border-right: $border-width $border-style var(--color-bg-canvas);
     // stylelint-disable-next-line primer/borders
     border-radius: $border-radius-1;
     transition: margin 0.1s ease-in-out;
@@ -97,13 +97,11 @@
 
   &::before {
     width: 17px;
-    // stylelint-disable-next-line primer/colors
     background: var(--color-avatar-stack-fade-more);
   }
 
   &::after {
     width: 14px;
-    // stylelint-disable-next-line primer/colors
     background: var(--color-avatar-stack-fade);
   }
 }
@@ -123,7 +121,6 @@
   }
 
   .avatar.avatar-more {
-    // stylelint-disable-next-line primer/colors
     background: var(--color-avatar-stack-fade);
 
     &::before {
@@ -141,6 +138,6 @@
     // stylelint-disable-next-line primer/spacing
     margin-left: -11px;
     border-right: 0;
-    border-left: $border-width $border-style var(--color-bg-canvas); // stylelint-disable-line primer/borders
+    border-left: $border-width $border-style var(--color-bg-canvas);
   }
 }

--- a/src/blankslate/blankslate.scss
+++ b/src/blankslate/blankslate.scss
@@ -27,7 +27,6 @@
   margin-right: $spacer-1;
   margin-bottom: $spacer-2;
   margin-left: $spacer-1;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-icon-secondary);
 }
 

--- a/src/branch-name/branch-name.scss
+++ b/src/branch-name/branch-name.scss
@@ -14,7 +14,6 @@
   .octicon {
     // stylelint-disable-next-line primer/spacing
     margin: 1px -2px 0 0;
-    // stylelint-disable-next-line primer/colors
     color: var(--color-branch-name-icon);
   }
 }
@@ -26,7 +25,6 @@ a.branch-name {
   background-color: var(--color-branch-name-link-bg);
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-branch-name-link-icon);
   }
 }

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -28,7 +28,6 @@
     cursor: default;
 
     .octicon {
-      // stylelint-disable-next-line primer/colors
       color: var(--color-icon-tertiary);
     }
   }
@@ -158,7 +157,6 @@
   }
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-btn-primary-icon);
   }
 }
@@ -223,7 +221,6 @@
   color: var(--color-btn-danger-text);
 
   .octicon {
-    // stylelint-disable-next-line primer/colors
     color: var(--color-btn-danger-icon);
   }
 
@@ -239,7 +236,6 @@
     }
 
     .octicon {
-      // stylelint-disable-next-line primer/colors
       color: var(--color-btn-danger-hover-icon);
     }
   }

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -54,7 +54,6 @@
   &::after {
     // stylelint-disable-next-line primer/borders
     border: 7px $border-style transparent;
-    // stylelint-disable-next-line primer/borders
     border-bottom-color: var(--color-bg-overlay);
   }
 
@@ -161,7 +160,6 @@
     right: -14px;
     left: auto;
     border-color: transparent;
-    // stylelint-disable-next-line primer/borders
     border-left-color: var(--color-bg-overlay);
   }
 }
@@ -184,7 +182,6 @@
     top: 11px;
     left: -14px;
     border-color: transparent;
-    // stylelint-disable-next-line primer/borders
     border-right-color: var(--color-bg-overlay);
   }
 }

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -130,7 +130,6 @@ textarea.form-control {
       // stylelint-disable-next-line primer/spacing
       padding: 2px $spacer-1;
       font-style: normal;
-      // stylelint-disable-next-line primer/colors
       background: var(--color-attention-subtle, var(--color-auto-yellow-1));
       border-radius: $border-radius;
     }

--- a/src/forms/form-group.scss
+++ b/src/forms/form-group.scss
@@ -195,7 +195,7 @@
       background-image: linear-gradient(var(--color-input-tooltip-success-bg), var(--color-input-tooltip-success-bg));
       border-color: var(--color-input-tooltip-success-border);
 
-      &::after { border-bottom-color: var(--color-input-tooltip-success-bg); } // stylelint-disable-line primer/borders
+      &::after { border-bottom-color: var(--color-input-tooltip-success-bg); }
       &::before { border-bottom-color: var(--color-input-tooltip-success-border); }
     }
   }
@@ -211,7 +211,7 @@
       background-image: linear-gradient(var(--color-input-tooltip-warning-bg), var(--color-input-tooltip-warning-bg));
       border-color: var(--color-input-tooltip-warning-border);
 
-      &::after { border-bottom-color: var(--color-input-tooltip-warning-bg); } // stylelint-disable-line primer/borders
+      &::after { border-bottom-color: var(--color-input-tooltip-warning-bg); }
       &::before { border-bottom-color: var(--color-input-tooltip-warning-border); }
     }
   }
@@ -231,7 +231,7 @@
       background-image: linear-gradient(var(--color-input-tooltip-error-bg), var(--color-input-tooltip-error-bg));
       border-color: var(--color-input-tooltip-error-border);
 
-      &::after { border-bottom-color: var(--color-input-tooltip-error-bg); } // stylelint-disable-line primer/borders
+      &::after { border-bottom-color: var(--color-input-tooltip-error-bg); }
       &::before { border-bottom-color: var(--color-input-tooltip-error-border); }
     }
   }

--- a/src/forms/form-validation.scss
+++ b/src/forms/form-validation.scss
@@ -345,7 +345,6 @@ p.explain {
   .octicon {
     // stylelint-disable-next-line primer/spacing
     margin-right: 5px;
-    // stylelint-disable-next-line primer/colors
     color: var(--color-icon-tertiary);
   }
 

--- a/src/header/header.scss
+++ b/src/header/header.scss
@@ -24,7 +24,6 @@
 
 .Header-link {
   font-weight: $font-weight-bold;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-header-logo);
   white-space: nowrap;
 

--- a/src/layout/layout.scss
+++ b/src/layout/layout.scss
@@ -121,7 +121,6 @@
       width: 1px;
       // stylelint-disable-next-line primer/spacing
       margin-right: -1px;
-      // stylelint-disable-next-line primer/colors
       background: var(--color-border-primary);
     }
 

--- a/src/markdown/markdown-body.scss
+++ b/src/markdown/markdown-body.scss
@@ -76,7 +76,6 @@
     height: $em-spacer-3;
     padding: 0;
     margin: $spacer-4 0;
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-border-primary);
     border: 0;
   }

--- a/src/navigation/menu.scss
+++ b/src/navigation/menu.scss
@@ -61,7 +61,6 @@
       left: 0;
       width: 2px;
       content: "";
-      // stylelint-disable-next-line primer/colors
       background-color: var(--color-menu-border-active);
     }
   }
@@ -69,7 +68,6 @@
   .octicon {
     width: 16px;
     margin-right: $spacer-2;
-    // stylelint-disable-next-line primer/colors
     color: var(--color-icon-tertiary);
     text-align: center;
   }
@@ -81,7 +79,6 @@
 
   .menu-warning {
     float: right;
-    // stylelint-disable-next-line primer/colors
     color: var(--color-icon-warning);
   }
 

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -65,7 +65,6 @@
 
   // Bar on the left
   &::before {
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-sidenav-border-active);
   }
 }

--- a/src/navigation/subnav.scss
+++ b/src/navigation/subnav.scss
@@ -80,7 +80,6 @@
   top: 9px;
   left: 8px;
   display: block;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-icon-tertiary);
   text-align: center;
   pointer-events: none;

--- a/src/navigation/tabnav.scss
+++ b/src/navigation/tabnav.scss
@@ -53,7 +53,6 @@
 
   .octicon {
     margin-right: $spacer-1;
-    // stylelint-disable-next-line primer/colors
     color: var(--color-icon-tertiary);
   }
 

--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -67,7 +67,6 @@
 
 .UnderlineNav-octicon {
   margin-right: $spacer-1;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-underlinenav-icon);
 }
 

--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -32,7 +32,6 @@
     margin-left: -$spacer-2;
     // stylelint-disable-next-line primer/borders
     border: 7px $border-style transparent;
-    // stylelint-disable-next-line primer/borders
     border-bottom-color: var(--color-bg-overlay);
   }
 
@@ -59,7 +58,6 @@
 
   &::after {
     bottom: -14px;
-    // stylelint-disable-next-line primer/borders
     border-top-color: var(--color-bg-overlay);
   }
 }
@@ -138,7 +136,6 @@
 
   &::after {
     right: -14px;
-    // stylelint-disable-next-line primer/borders
     border-left-color: var(--color-bg-overlay);
   }
 }
@@ -154,7 +151,6 @@
 
   &::after {
     left: -14px;
-    // stylelint-disable-next-line primer/borders
     border-right-color: var(--color-bg-overlay);
   }
 }

--- a/src/progress/progress.scss
+++ b/src/progress/progress.scss
@@ -4,7 +4,6 @@
   display: flex;
   height: 8px;
   overflow: hidden;
-  // stylelint-disable-next-line primer/colors
   background-color: var(--color-neutral-muted, var(--color-auto-gray-2));
   border-radius: $border-radius;
   outline: 1px solid transparent; // Support Firefox custom colors

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -126,7 +126,6 @@ $SelectMenu-max-height: 480px !default;
   padding: $spacer-3;
   margin: -$spacer-3;
   line-height: 1;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-icon-tertiary);
   background-color: transparent;
   border: 0;

--- a/src/timeline/timeline-item.scss
+++ b/src/timeline/timeline-item.scss
@@ -13,7 +13,6 @@
     display: block;
     width: 2px;
     content: "";
-    // stylelint-disable-next-line primer/colors
     background-color: var(--color-border-secondary);
   }
 
@@ -31,7 +30,6 @@
   height: $spacer-5;
   margin-right: $spacer-2;
   margin-left: -$spacer-3 + 1;
-  // stylelint-disable-next-line primer/colors
   color: var(--color-icon-secondary);
   align-items: center;
   background-color: var(--color-timeline-badge-bg);
@@ -89,7 +87,6 @@
     height: $spacer-3;
     margin-top: $spacer-2;
     margin-bottom: $spacer-2;
-    // stylelint-disable-next-line primer/colors
     color: var(--color-icon-secondary);
     background-color: var(--color-bg-canvas);
     border: 0;

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -21,7 +21,7 @@
   justify-content: center;
   width: $spacer-3 * 3;
   flex-shrink: 0;
-  color: var(--color-toast-icon); // stylelint-disable-line primer/colors
+  color: var(--color-toast-icon);
   background-color: var(--color-toast-icon-bg);
   border: $border-width $border-style var(--color-toast-icon-border);
   border-right: 0;
@@ -58,7 +58,7 @@
   box-shadow: inset 0 0 0 1px var(--color-toast-loading-border), var(--color-toast-shadow);
 
   .Toast-icon {
-    color: var(--color-toast-loading-icon); // stylelint-disable-line primer/colors
+    color: var(--color-toast-loading-icon);
     background-color: var(--color-toast-loading-icon-bg);
     border-color: var(--color-toast-loading-icon-border);
   }
@@ -69,7 +69,7 @@
   box-shadow: inset 0 0 0 1px var(--color-toast-danger-border), var(--color-toast-shadow);
 
   .Toast-icon {
-    color: var(--color-toast-danger-icon); // stylelint-disable-line primer/colors
+    color: var(--color-toast-danger-icon);
     background-color: var(--color-toast-danger-icon-bg);
     border-color: var(--color-toast-danger-icon-border);
   }
@@ -80,7 +80,7 @@
   box-shadow: inset 0 0 0 1px var(--color-toast-warning-border), var(--color-toast-shadow);
 
   .Toast-icon {
-    color: var(--color-toast-warning-icon); // stylelint-disable-line primer/colors
+    color: var(--color-toast-warning-icon);
     background-color: var(--color-toast-warning-icon-bg);
     border-color: var(--color-toast-warning-icon-border);
   }
@@ -91,7 +91,7 @@
   box-shadow: inset 0 0 0 1px var(--color-toast-success-border), var(--color-toast-shadow);
 
   .Toast-icon {
-    color: var(--color-toast-success-icon); // stylelint-disable-line primer/colors
+    color: var(--color-toast-success-icon);
     background-color: var(--color-toast-success-icon-bg);
     border-color: var(--color-toast-success-icon-border);
   }

--- a/src/tooltips/tooltips.scss
+++ b/src/tooltips/tooltips.scss
@@ -32,7 +32,7 @@
   display: none;
   width: 0;
   height: 0;
-  color: var(--color-tooltip-bg); // stylelint-disable-line primer/colors
+  color: var(--color-tooltip-bg);
   pointer-events: none;
   content: "";
   // stylelint-disable-next-line primer/borders
@@ -101,7 +101,6 @@
     bottom: -7px;
     // stylelint-disable-next-line primer/spacing
     margin-right: -6px;
-    // stylelint-disable-next-line primer/borders
     border-bottom-color: var(--color-tooltip-bg);
   }
 }
@@ -135,7 +134,6 @@
     bottom: auto;
     // stylelint-disable-next-line primer/spacing
     margin-right: -6px;
-    // stylelint-disable-next-line primer/borders
     border-top-color: var(--color-tooltip-bg);
   }
 }
@@ -174,7 +172,6 @@
     left: -7px;
     // stylelint-disable-next-line primer/spacing
     margin-top: -6px;
-    // stylelint-disable-next-line primer/borders
     border-left-color: var(--color-tooltip-bg);
   }
 }
@@ -195,7 +192,6 @@
     bottom: 50%;
     // stylelint-disable-next-line primer/spacing
     margin-top: -6px;
-    // stylelint-disable-next-line primer/borders
     border-right-color: var(--color-tooltip-bg);
   }
 }

--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -12,13 +12,13 @@
 .color-text-white     { color: var(--color-text-white) !important; }
 
 // Icon colors
-.color-icon-primary   { color: var(--color-icon-primary) !important; } // stylelint-disable-line primer/colors
-.color-icon-secondary { color: var(--color-icon-secondary) !important; } // stylelint-disable-line primer/colors
-.color-icon-tertiary  { color: var(--color-icon-tertiary) !important; } // stylelint-disable-line primer/colors
-.color-icon-info      { color: var(--color-icon-info) !important; } // stylelint-disable-line primer/colors
-.color-icon-danger    { color: var(--color-icon-danger) !important; } // stylelint-disable-line primer/colors
-.color-icon-success   { color: var(--color-icon-success) !important; } // stylelint-disable-line primer/colors
-.color-icon-warning   { color: var(--color-icon-warning) !important; } // stylelint-disable-line primer/colors
+.color-icon-primary   { color: var(--color-icon-primary) !important; }
+.color-icon-secondary { color: var(--color-icon-secondary) !important; }
+.color-icon-tertiary  { color: var(--color-icon-tertiary) !important; }
+.color-icon-info      { color: var(--color-icon-info) !important; }
+.color-icon-danger    { color: var(--color-icon-danger) !important; }
+.color-icon-success   { color: var(--color-icon-success) !important; }
+.color-icon-warning   { color: var(--color-icon-warning) !important; }
 
 // Border colors
 .color-border-primary   { border-color: var(--color-border-primary) !important; }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,7 +2129,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-doiuse@^4.3.1:
+doiuse@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/doiuse/-/doiuse-4.4.1.tgz#efea4ecb6b04ed3228de28f5c6ad704f2c578c80"
   integrity sha512-TUpr1/YNg20IB09tZmwGCTsTQoxj8jUld/hUZprZMj8vj0VpAJySXEWCr8WMvqvgzk0/kG/FxeSMGKode4UjPg==
@@ -6082,27 +6082,27 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
 
-stylelint-config-primer@11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-primer/-/stylelint-config-primer-11.1.0.tgz#c8a7f35e271122d452b6c0ce8396d02e48a2448e"
-  integrity sha512-K4sqmzjgHTbhhpXjWQ3R8wzvKJZsVH6eSU5CbRB3pXWLkUIs07n6HEwRu2B4yPdPoa6gkoJwsUdHQV8gDxW8cg==
+stylelint-config-primer@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/stylelint-config-primer/-/stylelint-config-primer-11.1.1.tgz#5a5bdafb679547b0089eac9c5c9a11b520707d0e"
+  integrity sha512-tmwi1DVuXg0G52v9vDiN7Vhyz3wVQ86FjARuozhO8lXJd8aIfyA5hLRLxxuelZMEqGyMGGKaMLU6OZSVoVwEIw==
   dependencies:
     anymatch "^3.1.1"
     globby "^11.0.1"
     lodash.kebabcase "^4.1.1"
     postcss-value-parser "^4.0.2"
     string.prototype.matchall "^4.0.2"
-    stylelint-no-unsupported-browser-features "^4.1.4"
+    stylelint-no-unsupported-browser-features "^5.0.1"
     stylelint-order "^4.1.0"
     stylelint-scss "^3.19.0"
     tap-map "^1.0.0"
 
-stylelint-no-unsupported-browser-features@^4.1.4:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-4.1.4.tgz#14c58167ba101ab5f1d26b98dd1a0d75c9e0a423"
-  integrity sha512-GORR+/z4KkWP9SWO4fLmC5WAIjDClShSfwCYTuAB9cT8GE+rtOXeAqw5RyXuN9BLIBAPjeO2W7LFIrWUH8x7FA==
+stylelint-no-unsupported-browser-features@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-5.0.1.tgz#a72460f3e537a4eb88ee4232924d5a17e4ee15bd"
+  integrity sha512-eI/MPD/DSJrSGufhEZe46iIhNn0W1bHVZjFFMvkbEqTz8wwkPA5UwghuUtqzjMypYyGQw3U47eruv+AeXjP54A==
   dependencies:
-    doiuse "^4.3.1"
+    doiuse "^4.4.1"
     lodash "^4.17.15"
     postcss "^8.1.4"
 


### PR DESCRIPTION
This updates primer stylelint config to latest with primer/colors and primer/borders fix. This is an alternative fix to https://github.com/primer/css/pull/1576

Because the rules were loosened a bit, I had to remove some needless disables