### PR TITLE
Removing v2 color mode css variable fallbacks

### DIFF
--- a/.changeset/shaggy-shirts-camp.md
+++ b/.changeset/shaggy-shirts-camp.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Removing v2 color mode fallbacks

--- a/.changeset/shaggy-shirts-camp.md
+++ b/.changeset/shaggy-shirts-camp.md
@@ -2,4 +2,4 @@
 "@primer/css": minor
 ---
 
-Removing v2 color mode fallbacks
+Removing v2 color mode css var fallbacks. `var(--color-v2, var(--color-v1))` becomes `var(--color-v2)`

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -130,7 +130,7 @@ textarea.form-control {
       // stylelint-disable-next-line primer/spacing
       padding: 2px $spacer-1;
       font-style: normal;
-      background: var(--color-attention-subtle, var(--color-auto-yellow-1));
+      background: var(--color-attention-subtle);
       border-radius: $border-radius;
     }
   }

--- a/src/progress/progress.scss
+++ b/src/progress/progress.scss
@@ -4,7 +4,7 @@
   display: flex;
   height: 8px;
   overflow: hidden;
-  background-color: var(--color-neutral-muted, var(--color-auto-gray-2));
+  background-color: var(--color-neutral-muted);
   border-radius: $border-radius;
   outline: 1px solid transparent; // Support Firefox custom colors
 }

--- a/src/timeline/timeline-item.scss
+++ b/src/timeline/timeline-item.scss
@@ -41,8 +41,8 @@
   flex-shrink: 0;
 
   &--success {
-    color: var(--color-fg-on-emphasis, var(--color-btn-primary-text)); // TODO remove V1 fallback
-    background-color: var(--color-success-emphasis, var(--color-btn-primary-bg)); // TODO remove V1 fallback
+    color: var(--color-fg-on-emphasis);
+    background-color: var(--color-success-emphasis);
     border: $border-width $border-style transparent;
   }
 }


### PR DESCRIPTION
There weren't many, this removes the couple of v1 css variable fallbacks we had in the code.

`var(--color-v2, var(--color-v1))` ➡️ `var(--color-v2)`
