### PR TITLE
Fix slash-div deprecation warning

### DIFF
--- a/src/marketing/support/mixins.scss
+++ b/src/marketing/support/mixins.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @mixin btn-solid-mktg($color, $bg, $bg2, $bg3, $bg4) {
   color: $color;
   background-color: $bg2;
@@ -76,5 +78,5 @@ $browser-context: 16 !default;
     $context: $context * 1px;
   }
 
-  @return $pixels / $context * 1rem;
+  @return math.div($pixels, $context) * 1rem;
 }


### PR DESCRIPTION
When I use primer with [dart-sass 1.39.2](https://github.com/sass/dart-sass/releases/tag/1.39.2), it prints a Deprecation Warning for [slash-div](https://sass-lang.com/d/slash-div).

```
Deprecation Warning: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($pixels, $context)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
79 │   @return $pixels / $context * 1rem;
   │           ^^^^^^^^^^^^^^^^^^
   ╵
    src/marketing/support/mixins.scss 79:11  rem()
    src/marketing/support/index.scss 6:14    root stylesheet
```

As [Sass document](https://sass-lang.com/documentation/breaking-changes/slash-div), it is a breaking change and they don't use slash(`/`) as division anymore. So, the Dart Sass will not support it in 2.0.0.

In my local tests, `math.div` works fine.

/cc @primer/ds-core
