### PR TITLE
Revert font stack changes

### DIFF
--- a/.changeset/thirty-pants-relate.md
+++ b/.changeset/thirty-pants-relate.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Revert font stack changes

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -32,28 +32,7 @@ $lh-condensed: 1.25 !default;
 $lh-default: 1.5 !default;
 
 // Font stacks
-$body-font:
-  // Apple OSs
-  -apple-system,
-  BlinkMacSystemFont,
-
-  // Windows
-  // Note this should be prioritized over `system-ui` to avoid legacy fonts.
-  // See https://infinnie.github.io/blog/2017/systemui.html
-  "Segoe UI Variable Text",
-  "Segoe UI",
-  "Meiryo", // Improves font rendering for Japanese, see https://github.com/primer/css/pull/1573.
-
-  // Linux-friendly system-level fonts + fallbacks
-  system-ui,
-  ui-sans-serif,
-  Helvetica,
-  Arial,
-  sans-serif,
-
-  // Emojis
-  "Apple Color Emoji",
-  "Segoe UI Emoji" !default;
+$body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji" !default;
 
 // Monospace font stack
 // Note: SFMono-Regular needs to come before SF Mono to fix an older version of the font in Chrome


### PR DESCRIPTION
This reverts the following PRs:

- https://github.com/primer/css/pull/1529
- https://github.com/primer/css/pull/1573

## Reasoning

We got a few reports that these changes had negative effects for certain users. We still would like to fix the initial issue https://github.com/primer/css/issues/1209, but it seems not that easy and needs some more careful testing.

## Next steps

An approach we might can try next is to put these font changes behind a feature flag and then enable it only for certain users that would like to beta test it (Linux, Windows, Japanese, Chinese etc.). Once we find a good font stack that works for most, we can ship it to production to all users.