### PR TITLE
Loosening the primer/primitives dependency to any minor.patch version

### DIFF
--- a/.changeset/friendly-squids-grin.md
+++ b/.changeset/friendly-squids-grin.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Loosening the primer/primitives dependency to any minor.patch version

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "release": "changeset publish"
   },
   "dependencies": {
-    "@primer/primitives": "4.7.1"
+    "@primer/primitives": "^4.7.1"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,7 +880,7 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@primer/primitives@4.7.1":
+"@primer/primitives@^4.7.1":
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-4.7.1.tgz#2510ca37dd83d1e9cacda7637f2a594edff0391d"
   integrity sha512-kttAUcP3QgT5UbYLeMTKDxPvnAVzywX0xnKPcLkmEVQyhmEBlTO4LSlYIzL5YcKyklHcFRf1426UcGOY9wdWDQ==


### PR DESCRIPTION
I had tightened this dependency back up recently but we lost the ability to update primitives in dotcom and skip the update here. So I'm bringing back the `^` which will use any ^ version greater than what's in package.json as long as it's not a major release.

/cc @primer/css-reviewers
