### PR TITLE
Added light & dark colorblind themes

### DIFF
--- a/.changeset/afraid-pugs-whisper.md
+++ b/.changeset/afraid-pugs-whisper.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Add light & dark colorblind themes

--- a/.changeset/slimy-chefs-notice.md
+++ b/.changeset/slimy-chefs-notice.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+-  Added light & dark colorblind themes

--- a/.changeset/slimy-chefs-notice.md
+++ b/.changeset/slimy-chefs-notice.md
@@ -1,5 +1,0 @@
----
-"@primer/css": patch
----
-
--  Added light & dark colorblind themes

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "release": "changeset publish"
   },
   "dependencies": {
-    "@primer/primitives": "^4.7.1"
+    "@primer/primitives": "^4.8.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.1",

--- a/src/base/modes.scss
+++ b/src/base/modes.scss
@@ -9,7 +9,6 @@
 @import "@primer/primitives/dist/scss/colors/_dark_high_contrast.scss";
 @import "@primer/primitives/dist/scss/colors/_dark_protanopia.scss";
 
-
 // Outputs the CSS variables
 // Use :root (html element) to define a default
 

--- a/src/base/modes.scss
+++ b/src/base/modes.scss
@@ -3,15 +3,22 @@
 @import "../support/mixins/color-modes.scss";
 
 @import "@primer/primitives/dist/scss/colors/_light.scss";
+@import "@primer/primitives/dist/scss/colors/_light_protanopia.scss";
 @import "@primer/primitives/dist/scss/colors/_dark.scss";
 @import "@primer/primitives/dist/scss/colors/_dark_dimmed.scss";
 @import "@primer/primitives/dist/scss/colors/_dark_high_contrast.scss";
+@import "@primer/primitives/dist/scss/colors/_dark_protanopia.scss";
+
 
 // Outputs the CSS variables
 // Use :root (html element) to define a default
 
 @include color-mode-theme(light, true) {
   @include primer-colors-light;
+}
+
+@include color-mode-theme(light_protanopia) {
+  @include primer-colors-light-protanopia;
 }
 
 @include color-mode-theme(dark) {
@@ -24,6 +31,10 @@
 
 @include color-mode-theme(dark_high_contrast) {
   @include primer-colors-dark_high_contrast;
+}
+
+@include color-mode-theme(dark_protanopia) {
+  @include primer-colors-dark_protanopia;
 }
 
 // Color mode boundaries

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,10 +880,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@primer/primitives@^4.7.1":
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-4.7.1.tgz#2510ca37dd83d1e9cacda7637f2a594edff0391d"
-  integrity sha512-kttAUcP3QgT5UbYLeMTKDxPvnAVzywX0xnKPcLkmEVQyhmEBlTO4LSlYIzL5YcKyklHcFRf1426UcGOY9wdWDQ==
+"@primer/primitives@^4.8.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-4.8.0.tgz#674d4958d9b2256cc8226d4e6e328686a84b8564"
+  integrity sha512-et4Kwt5LRy5YskHYHFJBoqWoqTHsdQHAOV5YvqQco2P7fQ3Xnus6tMQDuoD2cR03S86qKAjNYO9E6grDxVJWZA==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"


### PR DESCRIPTION
Just adding the new colorblind themes to `src/base/modes.scss`

Related to 
- https://github.com/primer/primitives/pull/236
- https://github.com/github/github/pull/193173

/cc @primer/css-reviewers
