### PR TITLE
Revert "Added light & dark colorblind themes"

### DIFF
--- a/.changeset/afraid-pugs-whisper.md
+++ b/.changeset/afraid-pugs-whisper.md
@@ -1,5 +1,0 @@
----
-"@primer/css": minor
----
-
-Add light & dark colorblind themes

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "release": "changeset publish"
   },
   "dependencies": {
-    "@primer/primitives": "^4.8.0"
+    "@primer/primitives": "^4.7.1"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.1",

--- a/src/base/modes.scss
+++ b/src/base/modes.scss
@@ -3,21 +3,15 @@
 @import "../support/mixins/color-modes.scss";
 
 @import "@primer/primitives/dist/scss/colors/_light.scss";
-@import "@primer/primitives/dist/scss/colors/_light_protanopia.scss";
 @import "@primer/primitives/dist/scss/colors/_dark.scss";
 @import "@primer/primitives/dist/scss/colors/_dark_dimmed.scss";
 @import "@primer/primitives/dist/scss/colors/_dark_high_contrast.scss";
-@import "@primer/primitives/dist/scss/colors/_dark_protanopia.scss";
 
 // Outputs the CSS variables
 // Use :root (html element) to define a default
 
 @include color-mode-theme(light, true) {
   @include primer-colors-light;
-}
-
-@include color-mode-theme(light_protanopia) {
-  @include primer-colors-light-protanopia;
 }
 
 @include color-mode-theme(dark) {
@@ -30,10 +24,6 @@
 
 @include color-mode-theme(dark_high_contrast) {
   @include primer-colors-dark_high_contrast;
-}
-
-@include color-mode-theme(dark_protanopia) {
-  @include primer-colors-dark_protanopia;
 }
 
 // Color mode boundaries

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,10 +880,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@primer/primitives@^4.8.0":
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-4.8.0.tgz#674d4958d9b2256cc8226d4e6e328686a84b8564"
-  integrity sha512-et4Kwt5LRy5YskHYHFJBoqWoqTHsdQHAOV5YvqQco2P7fQ3Xnus6tMQDuoD2cR03S86qKAjNYO9E6grDxVJWZA==
+"@primer/primitives@^4.7.1":
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-4.7.1.tgz#2510ca37dd83d1e9cacda7637f2a594edff0391d"
+  integrity sha512-kttAUcP3QgT5UbYLeMTKDxPvnAVzywX0xnKPcLkmEVQyhmEBlTO4LSlYIzL5YcKyklHcFRf1426UcGOY9wdWDQ==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"


### PR DESCRIPTION
Reverts primer/css#1596

Reverting this because of the +30kb gzipped increase in the bundle size. I think we need to ship this in https://github.com/primer/css/pull/1402 when we have the ability to separate the color themes.