### PR TITLE
Remove V1 color utilities

### DIFF
--- a/.changeset/nice-terms-juggle.md
+++ b/.changeset/nice-terms-juggle.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": major
+---
+
+Remove V1 color utilities

--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -72,58 +72,6 @@
 
 // Misc
 
-.text-inherit, // deprecated
 .color-fg-inherit {
   color: inherit !important;
 }
-
-// ----------------------- Deprecated --------------------------------------
-// The following V1 utilities will be removed in the next major release
-// -------------------------------------------------------------------------
-
-// Text colors
-.color-text-primary   { color: var(--color-fg-default) !important; }
-.color-text-secondary { color: var(--color-fg-muted) !important; }
-.color-text-tertiary  { color: var(--color-fg-muted) !important; }
-.color-text-link      { color: var(--color-accent-fg) !important; }
-.color-text-success   { color: var(--color-success-fg) !important; }
-.color-text-warning   { color: var(--color-attention-fg) !important; }
-.color-text-danger    { color: var(--color-danger-fg) !important; }
-.color-text-inverse   { color: var(--color-fg-on-emphasis) !important; }
-.color-text-white     { color: var(--color-scale-white) !important; }
-
-// Icon colors
-.color-icon-primary   { color: var(--color-fg-default) !important; }
-.color-icon-secondary { color: var(--color-fg-muted) !important; }
-.color-icon-tertiary  { color: var(--color-fg-muted) !important; }
-.color-icon-info      { color: var(--color-accent-fg) !important; }
-.color-icon-danger    { color: var(--color-danger-fg) !important; }
-.color-icon-success   { color: var(--color-success-fg) !important; }
-.color-icon-warning   { color: var(--color-attention-fg) !important; }
-
-// Border colors
-.color-border-primary   { border-color: var(--color-border-default) !important; }
-.color-border-secondary { border-color: var(--color-border-muted) !important; }
-.color-border-tertiary  { border-color: var(--color-neutral-muted) !important; }
-.color-border-inverse   { border-color: var(--color-fg-on-emphasis) !important; }
-.color-border-info      { border-color: var(--color-accent-emphasis) !important; }
-// .color-border-success   { border-color: var(--color-success-emphasis) !important; }
-// .color-border-danger    { border-color: var(--color-danger-emphasis) !important; }
-.color-border-warning   { border-color: var(--color-attention-emphasis) !important; }
-
-// Background colors
-.color-bg-canvas          { background-color: var(--color-canvas-default) !important; }
-.color-bg-canvas-inverse  { background-color: var(--color-neutral-emphasis) !important; }
-.color-bg-canvas-inset    { background-color: var(--color-canvas-inset) !important; }
-.color-bg-primary         { background-color: var(--color-canvas-default) !important; }
-.color-bg-secondary       { background-color: var(--color-canvas-subtle) !important; }
-.color-bg-tertiary        { background-color: var(--color-canvas-subtle) !important; }
-// .color-bg-overlay         { background-color: var(--color-canvas-overlay) !important; }
-.color-bg-info            { background-color: var(--color-accent-subtle) !important; }
-.color-bg-info-inverse    { background-color: var(--color-accent-emphasis) !important; }
-.color-bg-danger          { background-color: var(--color-danger-subtle) !important; }
-.color-bg-danger-inverse  { background-color: var(--color-danger-emphasis) !important; }
-.color-bg-success         { background-color: var(--color-success-subtle) !important; }
-.color-bg-success-inverse { background-color: var(--color-success-emphasis) !important; }
-.color-bg-warning         { background-color: var(--color-attention-subtle) !important; }
-.color-bg-warning-inverse { background-color: var(--color-attention-emphasis) !important; }


### PR DESCRIPTION
This removes all the V1 color utilities.

Note: We still have to update the docs, but I'll make a separate PR for that.