### PR TITLE
V2 last minute tweaks

### DIFF
--- a/.changeset/healthy-rings-suffer.md
+++ b/.changeset/healthy-rings-suffer.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": major
+---
+
+Update v1 deprecations

--- a/docs/content/support/v18-migration.mdx
+++ b/docs/content/support/v18-migration.mdx
@@ -47,7 +47,7 @@ See [color utility classes](/utilities/colors) for a list of all the functional 
 | ------------------------- | ------------------------- |
 | `.color-border-primary`   | `.color-border-default`   |
 | `.color-border-secondary` | `.color-border-muted`     |
-| `.color-border-tertiary`  | n/a                       |
+| `.color-border-tertiary`  | `.color-border-default`                       |
 | `.color-border-inverse`   | n/a                       |
 | `.color-border-info`      | `.color-border-accent`    |
 | `.color-border-warning`   | `.color-border-attention` |

--- a/docs/content/support/v18-migration.mdx
+++ b/docs/content/support/v18-migration.mdx
@@ -19,7 +19,7 @@ See [color utility classes](/utilities/colors) for a list of all the functional 
 | ----------------------- | ------------------------|
 | `.color-text-primary`   | `.color-fg-default`     |
 | `.color-text-secondary` | `.color-fg-muted`       |
-| `.color-text-tertiary`  | `.color-fg-subtle`      |
+| `.color-text-tertiary`  | `.color-fg-muted`      |
 | `.color-text-link`      | `.color-fg-accent`      |
 | `.color-text-success`   | `.color-fg-success`     |
 | `.color-text-warning`   | `.color-fg-attention`   |
@@ -47,7 +47,7 @@ See [color utility classes](/utilities/colors) for a list of all the functional 
 | ------------------------- | ------------------------- |
 | `.color-border-primary`   | `.color-border-default`   |
 | `.color-border-secondary` | `.color-border-muted`     |
-| `.color-border-tertiary`  | `.color-border-muted`     |
+| `.color-border-tertiary`  | n/a                       |
 | `.color-border-inverse`   | n/a                       |
 | `.color-border-info`      | `.color-border-accent`    |
 | `.color-border-warning`   | `.color-border-attention` |
@@ -62,7 +62,6 @@ See [color utility classes](/utilities/colors) for a list of all the functional 
 | `.color-bg-primary`         | `.color-bg-default`            |
 | `.color-bg-secondary`       | `.color-bg-subtle`             |
 | `.color-bg-tertiary`        | `.color-bg-subtle`             |
-| `.color-bg-overlay`         | `.color-bg-overlay`            |
 | `.color-bg-info`            | `.color-bg-accent-subtle`      |
 | `.color-bg-info-inverse`    | `.color-bg-accent-emphasis`    |
 | `.color-bg-danger`          | `.color-bg-danger-subtle`      |

--- a/docs/content/support/v18-migration.mdx
+++ b/docs/content/support/v18-migration.mdx
@@ -47,7 +47,7 @@ See [color utility classes](/utilities/colors) for a list of all the functional 
 | ------------------------- | ------------------------- |
 | `.color-border-primary`   | `.color-border-default`   |
 | `.color-border-secondary` | `.color-border-muted`     |
-| `.color-border-tertiary`  | `.color-border-default`                       |
+| `.color-border-tertiary`  | `.color-border-default`   |
 | `.color-border-inverse`   | n/a                       |
 | `.color-border-info`      | `.color-border-accent`    |
 | `.color-border-warning`   | `.color-border-attention` |

--- a/src/deprecations.json
+++ b/src/deprecations.json
@@ -2,7 +2,7 @@
   "selectors": {
     "color-text-primary": "color-fg-default",
     "color-text-secondary": "color-fg-muted",
-    "color-text-tertiary": "color-fg-subtle",
+    "color-text-tertiary": "color-fg-muted",
     "color-text-link": "color-fg-accent",
     "color-text-success": "color-fg-success",
     "color-text-warning": "color-fg-attention",
@@ -18,7 +18,7 @@
     "color-icon-warning": "color-fg-attention",
     "color-border-primary": "color-border-default",
     "color-border-secondary": "color-border-muted",
-    "color-border-tertiary": "color-border-muted",
+    "color-border-tertiary": null,
     "color-border-inverse": null,
     "color-border-info": "color-border-accent",
     "color-border-warning": "color-border-attention",

--- a/src/deprecations.json
+++ b/src/deprecations.json
@@ -18,7 +18,7 @@
     "color-icon-warning": "color-fg-attention",
     "color-border-primary": "color-border-default",
     "color-border-secondary": "color-border-muted",
-    "color-border-tertiary": null,
+    "color-border-tertiary": "color-border-default",
     "color-border-inverse": null,
     "color-border-info": "color-border-accent",
     "color-border-warning": "color-border-attention",


### PR DESCRIPTION
This makes the following changes to the deprecated/migration guide:

## Replace `.color-border-tertiary`

```diff
- `.color-border-tertiary`  | `.color-border-muted`
+ `.color-border-tertiary`  | `.color-border-default`
```

Depends a bit on https://github.com/primer/primitives/pull/242.

## Replace `.color-text-tertiary`

```diff
- `.color-text-tertiary`  | `.color-fg-subtle`
+ `.color-text-tertiary`  | `.color-fg-muted`
```

Can't remember if that was intentional or just an oversight. But it seems that Primitives uses [`"text.tertiary": "fg.muted",`](https://github.com/primer/primitives/blob/016e904b746059dbcc4dcdafaf96b627603714c1/data/colors/deprecations.json#L86). So maybe better to keep it the same for the utilities.