### PR TITLE
Style footnotes

### DIFF
--- a/.changeset/gold-games-tickle.md
+++ b/.changeset/gold-games-tickle.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Adding footnote styles to markdown-body.

--- a/docs/content/components/markdown.md
+++ b/docs/content/components/markdown.md
@@ -276,6 +276,25 @@ bundle: markdown
 
   <p><img src="http://placekitten.com/g/1200/800/"></p>
 
+  <p>
+    Here's a simple footnote,<sup><a href="#user-content-fn-1-12345" id="user-content-fnref-1-12345" data-footnote-ref="" aria-describedby="footnote-label">1</a></sup> and here's a longer one.<sup><a href="#user-content-fn-bignote-12345" id="user-content-fnref-bignote-12345" data-footnote-ref="" aria-describedby="footnote-label">2</a></sup>
+  </p>
+
+  <section data-footnotes="" class="footnotes">
+    <h2 id="footnote-label" class="sr-only">Footnotes</h2>
+    <ol>
+      <li id="user-content-fn-1-12345">
+        <p>This is the first footnote. <a href="#user-content-fnref-1-12345" data-footnote-backref="" class="data-footnote-backref" aria-label="Back to content"><g-emoji class="g-emoji" alias="leftwards_arrow_with_hook" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/21a9.png">↩</g-emoji></a></p>
+      </li>
+      <li id="user-content-fn-bignote-12345">
+        <p>Here's one with multiple paragraphs and code.</p>
+        <p>Indent paragraphs to include them in the footnote.</p>
+        <p><code>{ my code }</code></p>
+        <p>Add as many paragraphs as you like. <a href="#user-content-fnref-bignote-12345" data-footnote-backref="" class="data-footnote-backref" aria-label="Back to content"><g-emoji class="g-emoji" alias="leftwards_arrow_with_hook" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/21a9.png">↩</g-emoji></a></p>
+      </li>
+    </ol>
+  </section>
+
   <pre><code>This is the final element on the page and there should be no margin below this.</code></pre>
 </div>
 ```
@@ -446,6 +465,18 @@ Small images should be shown at their actual size.
 Large images should always scale down and fit in the content container.
 
 ![](http://placekitten.com/g/1200/800/)
+
+Here's a simple footnote,[^1] and here's a longer one.[^bignote]
+
+[^1]: This is the first footnote.
+
+[^bignote]: Here's one with multiple paragraphs and code.
+
+  Indent paragraphs to include them in the footnote.
+
+  `{ my code }`
+
+  Add as many paragraphs as you like.
 
 ```
 This is the final element on the page and there should be no margin below this.

--- a/src/markdown/footnotes.scss
+++ b/src/markdown/footnotes.scss
@@ -1,5 +1,4 @@
 // stylelint-disable selector-max-type
-// stylelint-disable selector-no-qualifying-type
 // stylelint-disable selector-max-compound-selectors
 
 .markdown-body .footnotes {

--- a/src/markdown/footnotes.scss
+++ b/src/markdown/footnotes.scss
@@ -1,0 +1,23 @@
+.footnotes {
+  font-size: $h6-size;
+  color: var(--color-fg-muted);
+  border-top: $border;
+
+  ol {
+    padding-left: $spacer-3;
+    margin-bottom: $spacer-3;
+  }
+
+  p {
+    margin-top: $spacer-3;
+  }
+
+  a.data-footnote-backref g-emoji {
+    font-family: monospace;
+  }
+
+  :target {
+    border: $border-width $border-style var(--color-accent-emphasis);
+    box-shadow: 0 0 0.2em var(--color-accent-muted);
+  }
+}

--- a/src/markdown/footnotes.scss
+++ b/src/markdown/footnotes.scss
@@ -1,5 +1,7 @@
 // stylelint-disable selector-max-type
 // stylelint-disable selector-no-qualifying-type
+// stylelint-disable selector-max-compound-selectors
+
 .markdown-body .footnotes {
   font-size: $h6-size;
   color: var(--color-fg-muted);
@@ -7,20 +9,26 @@
 
   ol {
     padding-left: $spacer-3;
-    margin-bottom: $spacer-3;
   }
 
-  p {
-    margin-top: $spacer-3;
+  li {
+    position: relative;
   }
 
-  a.data-footnote-backref g-emoji {
+  li:target::before {
+    position: absolute;
+    top: -$spacer-2;
+    right: 0;
+    bottom: -$spacer-2;
+    left: -$spacer-4;
+    pointer-events: none;
+    content: "";
+    // stylelint-disable-next-line primer/borders
+    border: 2px $border-style var(--color-accent-emphasis);
+    border-radius: $border-radius;
+  }
+
+  .data-footnote-backref g-emoji {
     font-family: monospace;
-  }
-
-  :target {
-    border: $border-width $border-style var(--color-accent-emphasis);
-    // stylelint-disable-next-line primer/box-shadow
-    box-shadow: 0 0 0.2em var(--color-accent-muted);
   }
 }

--- a/src/markdown/footnotes.scss
+++ b/src/markdown/footnotes.scss
@@ -1,6 +1,6 @@
 // stylelint-disable selector-max-type
 // stylelint-disable selector-no-qualifying-type
-.footnotes {
+.markdown-body .footnotes {
   font-size: $h6-size;
   color: var(--color-fg-muted);
   border-top: $border;

--- a/src/markdown/footnotes.scss
+++ b/src/markdown/footnotes.scss
@@ -1,3 +1,5 @@
+// stylelint-disable selector-max-type
+// stylelint-disable selector-no-qualifying-type
 .footnotes {
   font-size: $h6-size;
   color: var(--color-fg-muted);
@@ -18,6 +20,7 @@
 
   :target {
     border: $border-width $border-style var(--color-accent-emphasis);
+    // stylelint-disable-next-line primer/box-shadow
     box-shadow: 0 0 0.2em var(--color-accent-muted);
   }
 }

--- a/src/markdown/index.scss
+++ b/src/markdown/index.scss
@@ -6,3 +6,4 @@
 @import "./images.scss";
 @import "./code.scss";
 @import "./blob-csv.scss";
+@import "./footnotes.scss";

--- a/src/markdown/markdown-body.scss
+++ b/src/markdown/markdown-body.scss
@@ -95,4 +95,12 @@
       margin-bottom: 0;
     }
   }
+
+  sup > a::before {
+    content: "[";
+  }
+
+  sup > a::after {
+    content: "]";
+  }
 }


### PR DESCRIPTION
This is on top of https://github.com/primer/css/pull/1616. But for some reason it can't find the `talum/css` fork to change the base branch? 🤔  @talum I can also push to your branch, or feel free to copy&paste it, if you think these changes are ok?

- [x] It restyles the targeted `li` to include the list item number:
    ![Screen Shot 2021-09-27 at 17 35 00](https://user-images.githubusercontent.com/378023/134874559-1cb33c94-996f-4529-8c21-0109839e19b3.png)
- [x] Adds an example to the docs. 👀  [Preview docs](https://primer-css-ow8s05edi-primer.vercel.app/css/components/markdown) (you have to scroll past the cat images). Also currently it shows the syles from dotcom. So it now has a double border. But that will go away when we delete the styles on dotcom.
    ![Screen Shot 2021-09-27 at 17 58 36](https://user-images.githubusercontent.com/378023/134877615-ce240463-d32a-4834-856a-f5e6cfee4a6a.png)
