### PR TITLE
Changing to @primer/stylelint-config and upgrading @primer/primitives to 5.0 rc

### DIFF
--- a/.changeset/early-insects-share.md
+++ b/.changeset/early-insects-share.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Changing to @primer/stylelint-config and upgrading @primer/primitives to 5.0 rc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1527,7 +1527,7 @@
 
 - Storybook. We've added a storybook prototyping environment for testing components in seclusion. To start the server run `npm start`
 - Adding yeoman generator for creating a primer module. `generator-primer-module`
-- Importing `stylelint-config-primer` from https://github.com/primer/stylelint-config-primer/ into monorepo.
+- Importing `stylelint-config-primer` from https://github.com/primer/stylelint-config/ into monorepo.
 - Importing `stylelint-selector-no-utility` from https://github.com/primer/stylelint-selector-no-utility into monorepo.
 
 ### Changes
@@ -1617,7 +1617,7 @@ This release updates primer modules to use variables for spacing units instead o
 
 # 9.1.0
 
-This release updates our [stylelint config](/primer/stylelint-config-primer) to [v2.0.0](https://github.com/primer/stylelint-config-primer/releases/tag/v2.0.0), and to stylelint v7.13.0. Each module also now has a `lint` npm script, and there are top-level `test` and `lint` scripts that you can use to lint and test all modules in one go.
+This release updates our [stylelint config](/primer/stylelint-config-primer) to [v2.0.0](https://github.com/primer/stylelint-config/releases/tag/v2.0.0), and to stylelint v7.13.0. Each module also now has a `lint` npm script, and there are top-level `test` and `lint` scripts that you can use to lint and test all modules in one go.
 
 This release also includes major improvements to our Travis build scripts to automatically publish PR builds, release candidates, and the "final" versions to npm.
 

--- a/docs/content/tools/linting.md
+++ b/docs/content/tools/linting.md
@@ -23,23 +23,23 @@ Whether you work on `github/github` or not, it's useful to see lint errors local
 bin/stylelint "app/assets/stylesheets/**/*.scss" --syntax scss
 ```
 
-For more advanced usage, we recommend reading the [stylelint user guide](http://stylelint.io/user-guide/) and checking out our [primer stylelint configuration](https://github.com/primer/stylelint-config-primer).
+For more advanced usage, we recommend reading the [stylelint user guide](http://stylelint.io/user-guide/) and checking out our [primer stylelint configuration](https://github.com/primer/stylelint-config).
 
 ### Configuration
 
 Stylelint is [configured by a JSON file](http://stylelint.io/user-guide/configuration/) that specifies which linter rules we enforce. If you are working on `github/github`, you don't need to do any setup because the configuration is included within the repository bundle.
 
-We have extracted out our configuration file into a separate repository [primer/stylelint-config-primer](https://github.com/primer/stylelint-config-primer). This gives us a central source where we can keep the configuration up-to-date and distribute easily across all our projects.
+We have extracted out our configuration file into a separate repository [primer/stylelint-config](https://github.com/primer/stylelint-config). This gives us a central source where we can keep the configuration up-to-date and distribute easily across all our projects.
 
-To [use the configuration](https://github.com/primer/stylelint-config-primer#usage) in your project, install the config `npm install --save stylelint-config-primer` via npm, and extend the config in your `.stylelintrc` file. Put the file in the root directory of your project.
+To [use the configuration](https://github.com/primer/stylelint-config#usage) in your project, install the config `npm install --save @primer/stylelint-config` via npm, and extend the config in your `.stylelintrc` file. Put the file in the root directory of your project.
 
 ```json
 {
-  "extends": "stylelint-config-primer"
+  "extends": "@primer/stylelint-config"
 }
 ```
 
-A list of all the specific rules we have enabled are documented in [the package README](https://github.com/primer/stylelint-config-primer#documentation).
+A list of all the specific rules we have enabled are documented in [the package README](https://github.com/primer/stylelint-config#documentation).
 
 ### Disabling
 

--- a/package.json
+++ b/package.json
@@ -34,13 +34,14 @@
     "release": "changeset publish"
   },
   "dependencies": {
-    "@primer/primitives": "^4.8.0"
+    "@primer/primitives": "^5.0.0-rc.8de08c0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.1",
     "@changesets/cli": "2.17.0",
     "@github/prettier-config": "0.0.4",
     "@koddsson/postcss-sass": "5.0.0",
+    "@primer/stylelint-config": "12.0.0",
     "autoprefixer": "10.3.6",
     "cssstats": "4.0.2",
     "eslint": "7.32.0",
@@ -62,7 +63,6 @@
     "prettier": "2.4.1",
     "semver": "7.3.5",
     "stylelint": "13.13.1",
-    "stylelint-config-primer": "11.1.1",
     "stylelint-scss": "3.21.0",
     "table": "6.7.1"
   },

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -6,6 +6,11 @@ module.exports = {
   rules: {
     'scss/dollar-variable-default': [true, {ignore: 'local'}],
     'primer/no-override': false,
+    'primer/colors': true,
+    'primer/borders': true,
+    'primer/spacing': true,
+    'primer/typography': true,
+    'primer/box-shadow': true,
     'primer/no-undefined-vars': [true, {files: 'node_modules/@primer/primitives/dist/scss/colors*/*.scss'}]
   }
 }

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -1,18 +1,11 @@
-const currentVersion = process.env.PRIMER_VERSION || require('./package.json').version
-
 module.exports = {
-  extends: ['stylelint-config-primer'],
+  extends: ['@primer/stylelint-config'],
   plugins: ['stylelint-scss'],
   syntax: 'scss',
   ignoreFiles: ['src/fonts/**/*'],
   rules: {
     'scss/dollar-variable-default': [true, {ignore: 'local'}],
     'primer/no-override': false,
-    'primer/colors': true,
-    'primer/borders': true,
-    'primer/spacing': true,
-    'primer/typography': true,
-    'primer/box-shadow': true,
     'primer/no-undefined-vars': [true, {files: 'node_modules/@primer/primitives/dist/scss/colors*/*.scss'}]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -968,10 +968,25 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@primer/primitives@^4.8.0":
-  version "4.8.1"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-4.8.1.tgz#05f76e47f67018514fd54b35ca615b9d27ef2a46"
-  integrity sha512-mgr6+EKpn4DixuhLt3drk7QmNQO8M7RYONWovg1nkV7p56jklhDLfZmp1luLUee37eQGAxx3ToStL6gqINFjnQ==
+"@primer/primitives@^5.0.0-rc.8de08c0":
+  version "5.0.0-rc.8de08c0"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-5.0.0-rc.8de08c0.tgz#b85825eb55d8b364ca31cb573e66e2caae63137a"
+  integrity sha512-4qjGx4ec3FuAU/7sKjsVzDXMM8ZbFW/VstxmCwaraN6hXfgruZrGY0HlEuhzor0xenhdbxMZllsPoz6FxFIxNQ==
+
+"@primer/stylelint-config@12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@primer/stylelint-config/-/stylelint-config-12.0.0.tgz#33648ca2d630e9f93744fb3a311e245cd4d5b666"
+  integrity sha512-BnuyuE3kkJYQhCUUFF3iotODB6l2/79zdTjLhkypYN2ctbTCnpdZs2JJiyLo2WGt/VPj6tQy+n8db+wcvq+w8w==
+  dependencies:
+    anymatch "^3.1.1"
+    globby "^11.0.1"
+    lodash.kebabcase "^4.1.1"
+    postcss-value-parser "^4.0.2"
+    string.prototype.matchall "^4.0.2"
+    stylelint-no-unsupported-browser-features "^5.0.1"
+    stylelint-order "^4.1.0"
+    stylelint-scss "^3.19.0"
+    tap-map "^1.0.0"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"
@@ -5511,21 +5526,6 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
-
-stylelint-config-primer@11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/stylelint-config-primer/-/stylelint-config-primer-11.1.1.tgz#5a5bdafb679547b0089eac9c5c9a11b520707d0e"
-  integrity sha512-tmwi1DVuXg0G52v9vDiN7Vhyz3wVQ86FjARuozhO8lXJd8aIfyA5hLRLxxuelZMEqGyMGGKaMLU6OZSVoVwEIw==
-  dependencies:
-    anymatch "^3.1.1"
-    globby "^11.0.1"
-    lodash.kebabcase "^4.1.1"
-    postcss-value-parser "^4.0.2"
-    string.prototype.matchall "^4.0.2"
-    stylelint-no-unsupported-browser-features "^5.0.1"
-    stylelint-order "^4.1.0"
-    stylelint-scss "^3.19.0"
-    tap-map "^1.0.0"
 
 stylelint-no-unsupported-browser-features@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
For this PR, I'm upgrading

- `@primer/primitives` to the latest rc version for 5.0
- Updating stylelint-config-primer (now renamed to `@primer/stylelint-config`)
- Changing all `stylelint-config-primer` references

/cc @primer/css-reviewers
