### PR TITLE
Set details overlay z-index to 111

### DIFF
--- a/.changeset/shy-peas-study.md
+++ b/.changeset/shy-peas-study.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Increase the z-index value for the details dialog overlay.

--- a/src/utilities/details.scss
+++ b/src/utilities/details.scss
@@ -14,7 +14,7 @@
 }
 
 .details-overlay-dark[open] > summary::before {
-  z-index: 99;
+  z-index: 111;
   background: var(--color-primer-canvas-backdrop);
 }
 


### PR DESCRIPTION
The sticky header in `github/github` is set to `z-index: 110` and we want the overlay to be above that so I've set the `z-index` of it to 111.

See https://github.com/github/github/pull/195575.

/cc @primer/css-reviewers
