### PR TITLE
Rename protanopia themes to colorblind

### DIFF
--- a/src/color-modes/index.scss
+++ b/src/color-modes/index.scss
@@ -1,9 +1,9 @@
 // All themes
 
 @import "./themes/light.scss";
-@import "./themes/light_protanopia.scss";
+@import "./themes/light_colorblind.scss";
 @import "./themes/dark.scss";
 @import "./themes/dark_dimmed.scss";
 @import "./themes/dark_high_contrast.scss";
-@import "./themes/dark_protanopia.scss";
+@import "./themes/dark_colorblind.scss";
 @import "./native.scss";

--- a/src/color-modes/themes/dark_colorblind.scss
+++ b/src/color-modes/themes/dark_colorblind.scss
@@ -2,6 +2,6 @@
 
 @import "@primer/primitives/dist/scss/colors/_dark_protanopia.scss";
 
-@include color-mode-theme(dark_protanopia) {
+@include color-mode-theme(dark_colorblind) {
   @include primer-colors-dark_protanopia;
 }

--- a/src/color-modes/themes/light_colorblind.scss
+++ b/src/color-modes/themes/light_colorblind.scss
@@ -2,6 +2,6 @@
 
 @import "@primer/primitives/dist/scss/colors/_light_protanopia.scss";
 
-@include color-mode-theme(light_protanopia) {
+@include color-mode-theme(light_colorblind) {
   @include primer-colors-light_protanopia;
 }


### PR DESCRIPTION
This renames the protanopia themes to colorblind. I won't be able to change the imports until https://github.com/primer/primitives/pull/254 is shipped.
