### PR TITLE
[Storybook] Update Label stories

### DIFF
--- a/docs/src/stories/components/Label/Label.stories.jsx
+++ b/docs/src/stories/components/Label/Label.stories.jsx
@@ -13,19 +13,22 @@ export default {
       }
     },
     variant: {
-      options: [0, 1, 2, 3, 4, 5], // iterator
+      options: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], // iterator
       mapping: [
         '',
         'Label--primary',
         'Label--secondary',
-        'Label--info',
+        'Label--accent',
         'Label--success',
-        'Label--warning',
-        'Label--danger'
+        'Label--attention',
+        'Label--severe',
+        'Label--danger',
+        'Label--done',
+        'Label--sponsors'
       ], // values
       control: {
         type: 'select',
-        labels: ['default', 'primary', 'secondary', 'info', 'success', 'warning', 'danger']
+        labels: ['default', 'primary', 'secondary', 'accent', 'success', 'attention', 'severe', 'danger', 'done', 'sponsors']
       },
       description: 'Colors',
       table: {

--- a/docs/src/stories/components/Label/LabelFeatures.stories.jsx
+++ b/docs/src/stories/components/Label/LabelFeatures.stories.jsx
@@ -10,7 +10,7 @@ VariantDefault.storyName = '[Variant] Default'
 VariantDefault.args = {
   text: 'Label text',
   inline: false,
-  variant: 'Label--default'
+  variant: ''
 }
 
 export const VariantPrimary = LabelTemplate.bind({})
@@ -21,12 +21,20 @@ VariantPrimary.args = {
   variant: 'Label--primary'
 }
 
-export const VariantInfo = LabelTemplate.bind({})
-VariantInfo.storyName = '[Variant] Info'
-VariantInfo.args = {
+export const VariantSecondary = LabelTemplate.bind({})
+VariantSecondary.storyName = '[Variant] Secondary'
+VariantSecondary.args = {
   text: 'Label text',
   inline: false,
-  variant: 'Label--info'
+  variant: 'Label--secondary'
+}
+
+export const VariantAccent = LabelTemplate.bind({})
+VariantAccent.storyName = '[Variant] Accent'
+VariantAccent.args = {
+  text: 'Label text',
+  inline: false,
+  variant: 'Label--accent'
 }
 
 export const VariantSuccess = LabelTemplate.bind({})
@@ -37,12 +45,20 @@ VariantSuccess.args = {
   variant: 'Label--success'
 }
 
-export const VariantWarning = LabelTemplate.bind({})
-VariantWarning.storyName = '[Variant] Warning'
-VariantWarning.args = {
+export const VariantAttention = LabelTemplate.bind({})
+VariantAttention.storyName = '[Variant] Attention'
+VariantAttention.args = {
   text: 'Label text',
   inline: false,
-  variant: 'Label--warning'
+  variant: 'Label--attention'
+}
+
+export const VariantSevere = LabelTemplate.bind({})
+VariantSevere.storyName = '[Variant] Severe'
+VariantSevere.args = {
+  text: 'Label text',
+  inline: false,
+  variant: 'Label--severe'
 }
 
 export const VariantDanger = LabelTemplate.bind({})
@@ -53,14 +69,34 @@ VariantDanger.args = {
   variant: 'Label--danger'
 }
 
+export const VariantDone = LabelTemplate.bind({})
+VariantDone.storyName = '[Variant] Done'
+VariantDone.args = {
+  text: 'Label text',
+  inline: false,
+  variant: 'Label--done'
+}
+
+export const VariantSponsors = LabelTemplate.bind({})
+VariantSponsors.storyName = '[Variant] Sponsors'
+VariantSponsors.args = {
+  text: 'Label text',
+  inline: false,
+  variant: 'Label--sponsors'
+}
+
 export const AllVariants = ({}) => (
   <>
-    <LabelTemplate text="Default" variant="Label--default" />
+    <LabelTemplate text="Default" />
     <LabelTemplate text="Primary" variant="Label--primary" />
-    <LabelTemplate text="Info" variant="Label--info" />
+    <LabelTemplate text="Secondary" variant="Label--secondary" />
+    <LabelTemplate text="Accent" variant="Label--accent" />
     <LabelTemplate text="Success" variant="Label--success" />
-    <LabelTemplate text="Warning" variant="Label--warning" />
+    <LabelTemplate text="Attention" variant="Label--attention" />
+    <LabelTemplate text="Severe" variant="Label--severe" />
     <LabelTemplate text="Danger" variant="Label--danger" />
+    <LabelTemplate text="Done" variant="Label--done" />
+    <LabelTemplate text="Sponsors" variant="Label--sponsors" />
   </>
 )
 AllVariants.decorators = [


### PR DESCRIPTION
This is a follow-up to https://github.com/primer/css/pull/1708 and adds the new `Label`s (https://github.com/primer/css/pull/1711) also to Storybook.

### Before

![Screen Shot 2021-10-29 at 15 09 04](https://user-images.githubusercontent.com/378023/139387010-4ced7aee-8261-4874-84f6-eb06f237e6be.png)

### After

![Screen Shot 2021-10-29 at 15 10 29](https://user-images.githubusercontent.com/378023/139387016-75b13463-a738-473f-9a48-ef7d3b35abbd.png)

Here [Label docs](https://primer.style/css/components/labels#label-contrast) for reference.
