### PR TITLE
Use `padded` as default storybook layout

### DIFF
--- a/docs/.storybook/preview-head.html
+++ b/docs/.storybook/preview-head.html
@@ -4,7 +4,7 @@
       Helvetica Neue, sans-serif;
     color: var(--color-fg-default);
     background-color: var(--color-canvas-default);
-    padding: 1rem;
+    padding: 0;
   }
 
   .theme-wrap {

--- a/docs/.storybook/preview.js
+++ b/docs/.storybook/preview.js
@@ -47,7 +47,7 @@ export const parameters = {
     expanded: true
   },
 
-  layout: 'fullscreen',
+  layout: 'padded',
   html: {
     root: '#story' // target id for html tab (should be direct parent of <Story /> for easy copy/paste)
   },


### PR DESCRIPTION
Instead of using a custom padding in the `fullscreen` layout parameter in Storybook, use `padded` as the default layout (which already comes with `padding: 1rem`), and reserve `fullscreen` for stories that want no padding at all (like split layouts 😇 ).

This should render no differences in existing stories, but should allow for proper use of the `fullscreen` layout parameter.

Reference: https://storybook.js.org/docs/react/configure/story-layout

✨ ✨ 

/cc @langermank 