### PR TITLE
Use min and max values in Storybook breakpoints

### DIFF
--- a/docs/.storybook/preview.js
+++ b/docs/.storybook/preview.js
@@ -4,31 +4,73 @@ import '../../src/base/index.scss'
 import renderToHTML from '../src/stories/helpers/code-snippet-html-helper'
 
 const customViewports = {
-  widthSM: {
-    name: 'width-sm',
+  minXS: {
+    name: 'XS (min)',
+    styles: {
+      width: '375px',
+      height: '100%'
+    }
+  },
+  maxXS: {
+    name: 'XS (max)',
+    styles: {
+      width: '543px',
+      height: '100%'
+    }
+  },
+  minSM: {
+    name: 'SM (min)',
     styles: {
       width: '544px',
       height: '100%'
     }
   },
-  widthMD: {
-    name: 'width-md',
+  maxSM: {
+    name: 'SM (max)',
+    styles: {
+      width: '767px',
+      height: '100%'
+    }
+  },
+  minMD: {
+    name: 'MD (min)',
     styles: {
       width: '768px',
       height: '100%'
     }
   },
-  widthLG: {
-    name: 'width-lg',
+  maxMD: {
+    name: 'MD (max)',
+    styles: {
+      width: '1011px',
+      height: '100%'
+    }
+  },
+  minLG: {
+    name: 'LG (min)',
     styles: {
       width: '1012px',
       height: '100%'
     }
   },
-  widthXL: {
-    name: 'width-xl',
+  maxLG: {
+    name: 'LG (max)',
+    styles: {
+      width: '1279px',
+      height: '100%'
+    }
+  },
+  minXL: {
+    name: 'XL (min)',
     styles: {
       width: '1280px',
+      height: '100%'
+    }
+  },
+  medXL: {
+    name: 'XL (med)',
+    styles: {
+      width: '1440px',
       height: '100%'
     }
   }


### PR DESCRIPTION
Instead of using single-value options in Storybook's viewport sizes, add support for minimum and maximum values for [each of Primer's breakpoints](https://primer.style/css/support/breakpoints), allowing for verifying exactly how the components and patterns behave in each breakpoint extreme (and whether it correctly adjusts as the breakpoint changes).

A few notes:

- I'm using `xs` to define anything smaller than `$width-sm`, as documented here:
  https://primer.style/css/support/breakpoints#breakpoint-variables

- I'm using `375px` as the minimum `xs` size as a reference to the minimum viewport size we should support.


/cc @langermank 
