### PR TITLE
Update `Layout`'s sidebar width values

### DIFF
--- a/.changeset/clean-books-act.md
+++ b/.changeset/clean-books-act.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Update `Layout`'s sidebar width values.

--- a/docs/content/components/layout.md
+++ b/docs/content/components/layout.md
@@ -109,8 +109,8 @@ Flowing as row:
 
 ### Sidebar sizing
 
-- Default: [md: 256px, lg: 296px, xl: 320px]
-- `Layout--sidebar-narrow` [md: 240px, lg: 256px, xl: 296px]
+- Default: [md: 256px, lg: 296px]
+- `Layout--sidebar-narrow` [md: 240px, lg: 256px]
 - `Layout--sidebar-wide` [md: 296px, lg: 320px, xl: 344px]
 
 ```html live

--- a/src/support/variables/layout.scss
+++ b/src/support/variables/layout.scss
@@ -169,14 +169,12 @@ $responsive-positions: (
 $sidebar-width: (
   sm: 220px,
   md: 256px,
-  lg: 296px,
-  xl: 320px
+  lg: 296px
 ) !default;
 
 $sidebar-narrow-width: (
   md: 240px,
-  lg: 256px,
-  xl: 296px
+  lg: 256px
 ) !default;
 
 $sidebar-wide-width: (


### PR DESCRIPTION
This update addresses some previous feedback on the `Layout` component's sidebar widths.

With the new values, the default sidebar width is more compact by default, being closer to its previous value. Originally a `col-3` on a `xl` would render as ~280px. With the `Layout` component introduction it incorrectly increased to `320px`. This PR dials it back to 296px.

On a desktop computer (`xl` breakpoint), these are the new options:

| `sidebarWidth` | Size |
|--------|--------|
| `default` | 296px |
| `narrow` | 256px | 
| `wide` | 344px | 

:v:

/cc @primer/css-reviewers @camertron @jonrohan 
