### PR TITLE
Global focus styles

### DIFF
--- a/docs/src/stories/components/Button/Button.stories.jsx
+++ b/docs/src/stories/components/Button/Button.stories.jsx
@@ -7,31 +7,122 @@ export default {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=4371%3A7128'
-    }
+    },
+    layout: 'fullscreen'
   },
+
+  excludeStories: ['ButtonTemplate'],
   argTypes: {
     variant: {
-      options: [0, 1, 2, 3], // iterator
-      mapping: [null, 'btn-primary', 'btn-outline', 'btn-danger'], // values
+      options: [0, 1, 2, 3, 4, 5, 6, 7], // iterator
+      mapping: [
+        null,
+        'btn-primary',
+        'btn-outline',
+        'btn-danger',
+        'btn-link',
+        'btn-invisible',
+        'close-button',
+        'btn-with-count'
+      ], // values
       control: {
         type: 'select',
-        labels: ['default', 'primary', 'outline', 'danger']
+        labels: ['default', 'primary', 'outline', 'danger', 'link', 'invisible', 'close', 'with-count']
       },
-      defaultValue: ''
+      table: {
+        category: 'CSS'
+      }
+    },
+    size: {
+      options: [0, 1, 2], // iterator
+      mapping: [null, 'btn-sm', 'btn-large'], // values
+      control: {
+        type: 'select',
+        labels: ['default', 'small', 'large']
+      },
+      table: {
+        category: 'CSS'
+      }
     },
     label: {
       defaultValue: 'Button',
       type: 'string',
       name: 'label',
-      description: 'string'
+      description: 'string',
+      table: {
+        category: 'HTML'
+      }
+    },
+    disabled: {
+      defaultValue: false,
+      control: {type: 'boolean'},
+      table: {
+        category: 'Interactive'
+      }
+    },
+    fullWidth: {
+      defaultValue: false,
+      control: {type: 'boolean'},
+      table: {
+        category: 'CSS'
+      }
+    },
+    leadingVisual: {
+      name: 'leadingVisual',
+      type: 'string',
+      description: 'Paste [Octicon](https://primer.style/octicons/) in control field',
+      table: {
+        category: 'HTML'
+      }
+    },
+    trailingVisual: {
+      name: 'trailingVisual',
+      type: 'string',
+      description: 'Paste [Octicon](https://primer.style/octicons/) in control field',
+      table: {
+        category: 'HTML'
+      }
+    },
+    trailingAction: {
+      defaultValue: false,
+      control: {type: 'boolean'},
+      table: {
+        category: 'CSS'
+      }
+    },
+    selected: {
+      defaultValue: false,
+      control: {type: 'boolean'},
+      table: {
+        category: 'CSS'
+      }
     }
   }
 }
 
-const Template = ({label, variant}) => (
+export const ButtonTemplate = ({
+  label,
+  variant,
+  disabled,
+  size,
+  fullWidth,
+  leadingVisual,
+  trailingVisual,
+  trailingAction,
+  selected
+}) => (
   <>
-    <button className={clsx('btn', variant && `${variant}`)}>{label}</button>
+    <button
+      disabled={disabled}
+      className={clsx('btn', variant && `${variant}`, size && `${size}`, fullWidth && 'btn-block')}
+      aria-selected={selected}
+    >
+      {leadingVisual && <span className="" dangerouslySetInnerHTML={{__html: leadingVisual}} />}
+      <span>{label}</span>
+      {trailingVisual && <span className="" dangerouslySetInnerHTML={{__html: trailingVisual}} />}
+      {trailingAction && <span class="dropdown-caret"></span>}
+    </button>
   </>
 )
 
-export const Button = Template.bind({})
+export const Playground = ButtonTemplate.bind({})

--- a/docs/src/stories/components/Button/Button.stories.jsx
+++ b/docs/src/stories/components/Button/Button.stories.jsx
@@ -8,7 +8,7 @@ export default {
       type: 'figma',
       url: 'https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=4371%3A7128'
     },
-    layout: 'fullscreen'
+    layout: 'padded'
   },
 
   excludeStories: ['ButtonTemplate'],
@@ -22,12 +22,12 @@ export default {
         'btn-danger',
         'btn-link',
         'btn-invisible',
-        'close-button',
-        'btn-with-count'
+        'btn-with-count',
+        'btn-octicon'
       ], // values
       control: {
         type: 'select',
-        labels: ['default', 'primary', 'outline', 'danger', 'link', 'invisible', 'close', 'with-count']
+        labels: ['default', 'primary', 'outline', 'danger', 'link', 'invisible', 'close', 'with-count', 'icon-only']
       },
       table: {
         category: 'CSS'
@@ -62,6 +62,12 @@ export default {
     },
     fullWidth: {
       defaultValue: false,
+      control: {type: 'boolean'},
+      table: {
+        category: 'CSS'
+      }
+    },
+    closeBtn: {
       control: {type: 'boolean'},
       table: {
         category: 'CSS'
@@ -109,20 +115,38 @@ export const ButtonTemplate = ({
   leadingVisual,
   trailingVisual,
   trailingAction,
-  selected
+  selected,
+  closeBtn
 }) => (
   <>
     <button
       disabled={disabled}
-      className={clsx('btn', variant && `${variant}`, size && `${size}`, fullWidth && 'btn-block')}
+      className={clsx(
+        'btn',
+        variant && `${variant}`,
+        size && `${size}`,
+        fullWidth && 'btn-block',
+        closeBtn && 'close-button'
+      )}
       aria-selected={selected}
     >
       {leadingVisual && <span className="" dangerouslySetInnerHTML={{__html: leadingVisual}} />}
       <span>{label}</span>
       {trailingVisual && <span className="" dangerouslySetInnerHTML={{__html: trailingVisual}} />}
       {trailingAction && <span class="dropdown-caret"></span>}
+      {closeBtn && (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+          <path
+            fill-rule="evenodd"
+            d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"
+          ></path>
+        </svg>
+      )}
     </button>
   </>
 )
 
 export const Playground = ButtonTemplate.bind({})
+Playground.args = {
+  closeBtn: false
+}

--- a/docs/src/stories/components/Button/ButtonFeatures.stories.jsx
+++ b/docs/src/stories/components/Button/ButtonFeatures.stories.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import clsx from 'clsx'
+import {ButtonTemplate} from './Button.stories'
+
+export default {
+  title: 'Components/Button/Features'
+}
+
+export const LeadingVisual = ButtonTemplate.bind({})
+LeadingVisual.storyName = 'Leading icon'
+LeadingVisual.args = {
+  label: 'Open in Desktop',
+  leadingVisual:
+    '<svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.75 2.5h12.5a.25.25 0 01.25.25v7.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25v-7.5a.25.25 0 01.25-.25zM14.25 1H1.75A1.75 1.75 0 000 2.75v7.5C0 11.216.784 12 1.75 12h3.727c-.1 1.041-.52 1.872-1.292 2.757A.75.75 0 004.75 16h6.5a.75.75 0 00.565-1.243c-.772-.885-1.193-1.716-1.292-2.757h3.727A1.75 1.75 0 0016 10.25v-7.5A1.75 1.75 0 0014.25 1zM9.018 12H6.982a5.72 5.72 0 01-.765 2.5h3.566a5.72 5.72 0 01-.765-2.5z"></path></svg>'
+}
+
+export const TrailingVisual = ButtonTemplate.bind({})
+TrailingVisual.storyName = 'Trailing icon'
+TrailingVisual.args = {
+  label: 'Open in Desktop',
+  trailingVisual:
+    '<svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.75 2.5h12.5a.25.25 0 01.25.25v7.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25v-7.5a.25.25 0 01.25-.25zM14.25 1H1.75A1.75 1.75 0 000 2.75v7.5C0 11.216.784 12 1.75 12h3.727c-.1 1.041-.52 1.872-1.292 2.757A.75.75 0 004.75 16h6.5a.75.75 0 00.565-1.243c-.772-.885-1.193-1.716-1.292-2.757h3.727A1.75 1.75 0 0016 10.25v-7.5A1.75 1.75 0 0014.25 1zM9.018 12H6.982a5.72 5.72 0 01-.765 2.5h3.566a5.72 5.72 0 01-.765-2.5z"></path></svg>'
+}
+
+export const Disabled = ButtonTemplate.bind({})
+Disabled.storyName = 'Disabled'
+Disabled.args = {
+  label: 'Disabled',
+  disabled: true
+}
+
+export const DisabledWithLeadingVisual = ButtonTemplate.bind({})
+DisabledWithLeadingVisual.storyName = 'Disabled with leading visual'
+DisabledWithLeadingVisual.args = {
+  label: 'Disabled',
+  disabled: true,
+  leadingVisual:
+    '<svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.75 2.5h12.5a.25.25 0 01.25.25v7.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25v-7.5a.25.25 0 01.25-.25zM14.25 1H1.75A1.75 1.75 0 000 2.75v7.5C0 11.216.784 12 1.75 12h3.727c-.1 1.041-.52 1.872-1.292 2.757A.75.75 0 004.75 16h6.5a.75.75 0 00.565-1.243c-.772-.885-1.193-1.716-1.292-2.757h3.727A1.75 1.75 0 0016 10.25v-7.5A1.75 1.75 0 0014.25 1zM9.018 12H6.982a5.72 5.72 0 01-.765 2.5h3.566a5.72 5.72 0 01-.765-2.5z"></path></svg>'
+}
+
+export const Selected = ButtonTemplate.bind({})
+Selected.storyName = 'Selected'
+Selected.args = {
+  label: 'Selected',
+  selected: true
+}
+
+export const SelectedWithLeadingVisual = ButtonTemplate.bind({})
+SelectedWithLeadingVisual.storyName = 'Selected with leading visual'
+SelectedWithLeadingVisual.args = {
+  label: 'Selected',
+  selected: true,
+  leadingVisual:
+    '<svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.75 2.5h12.5a.25.25 0 01.25.25v7.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25v-7.5a.25.25 0 01.25-.25zM14.25 1H1.75A1.75 1.75 0 000 2.75v7.5C0 11.216.784 12 1.75 12h3.727c-.1 1.041-.52 1.872-1.292 2.757A.75.75 0 004.75 16h6.5a.75.75 0 00.565-1.243c-.772-.885-1.193-1.716-1.292-2.757h3.727A1.75 1.75 0 0016 10.25v-7.5A1.75 1.75 0 0014.25 1zM9.018 12H6.982a5.72 5.72 0 01-.765 2.5h3.566a5.72 5.72 0 01-.765-2.5z"></path></svg>'
+}

--- a/docs/src/stories/components/Forms/Input.stories.jsx
+++ b/docs/src/stories/components/Forms/Input.stories.jsx
@@ -1,0 +1,141 @@
+import React from 'react'
+import clsx from 'clsx'
+
+export default {
+  title: 'Components/Forms/Input',
+  parameters: {
+    layout: 'padded'
+  },
+  decorators: [
+    Story => (
+      <form>
+        <Story />
+      </form>
+    )
+  ],
+  excludeStories: ['InputTemplate'],
+  argTypes: {
+    size: {
+      options: [0, 1, 2], // iterator
+      mapping: [null, 'input-sm', 'input-lg'], // values
+      control: {
+        type: 'select',
+        labels: ['default', 'small', 'large']
+      },
+      table: {
+        category: 'CSS'
+      }
+    },
+    block: {
+      description: 'full width',
+      control: {type: 'boolean'},
+      table: {
+        category: 'Interactive'
+      }
+    },
+    monospace: {
+      description: 'monospace text',
+      control: {type: 'boolean'},
+      table: {
+        category: 'Interactive'
+      }
+    },
+    contrast: {
+      description: 'change input background to light gray',
+      control: {type: 'boolean'},
+      table: {
+        category: 'Interactive'
+      }
+    },
+    disabled: {
+      description: 'disabled field',
+      control: {type: 'boolean'},
+      table: {
+        category: 'Interactive'
+      }
+    },
+    hideWebKit: {
+      description: 'hide WebKit autofill icon',
+      control: {type: 'boolean'},
+      table: {
+        category: 'Interactive'
+      }
+    },
+    placeholder: {
+      type: 'string',
+      name: 'placeholder',
+      description: 'string',
+      table: {
+        category: 'HTML'
+      }
+    },
+    label: {
+      type: 'string',
+      name: 'label',
+      description: 'string',
+      table: {
+        category: 'HTML'
+      }
+    },
+    type: {
+      name: 'type',
+      type: 'string',
+      description: 'type',
+      table: {
+        category: 'HTML'
+      }
+    },
+    id: {
+      name: 'id',
+      type: 'string',
+      description: 'id',
+      table: {
+        category: 'HTML'
+      }
+    }
+  }
+}
+
+export const InputTemplate = ({
+  label,
+  type,
+  id,
+  size,
+  block,
+  placeholder,
+  contrast,
+  disabled,
+  hideWebKit,
+  monospace
+}) => (
+  <>
+    <label for={id}>{label}</label>
+    <input
+      className={clsx(
+        'form-control',
+        size && `${size}`,
+        block && 'input-block',
+        contrast && 'input-contrast',
+        hideWebKit && 'input-hide-webkit-autofill',
+        monospace && 'input-monospace'
+      )}
+      type={type}
+      id={id}
+      placeholder={placeholder}
+      disabled={disabled}
+    />
+  </>
+)
+
+export const Playground = InputTemplate.bind({})
+Playground.args = {
+  type: 'email',
+  id: 'some-id',
+  placeholder: 'Email address',
+  label: 'Enter email address',
+  block: false,
+  hideWebKit: false,
+  monospace: false,
+  contrast: false,
+  disabled: false
+}

--- a/docs/src/stories/components/Forms/Select.stories.jsx
+++ b/docs/src/stories/components/Forms/Select.stories.jsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import clsx from 'clsx'
+
+export default {
+  title: 'Components/Forms/Select',
+  parameters: {
+    layout: 'padded'
+  },
+  decorators: [
+    Story => (
+      <form>
+        <Story />
+      </form>
+    )
+  ],
+  excludeStories: ['SelectTemplate'],
+  argTypes: {
+    size: {
+      options: [0, 1], // iterator
+      mapping: [null, 'select-sm'], // values
+      control: {
+        type: 'select',
+        labels: ['default', 'small']
+      },
+      table: {
+        category: 'CSS'
+      }
+    },
+    disabled: {
+      description: 'disabled field',
+      control: {type: 'boolean'},
+      table: {
+        category: 'Interactive'
+      }
+    },
+    placeholder: {
+      type: 'string',
+      name: 'placeholder',
+      description: 'string',
+      table: {
+        category: 'HTML'
+      }
+    },
+    label: {
+      type: 'string',
+      name: 'label',
+      description: 'string',
+      table: {
+        category: 'HTML'
+      }
+    },
+    id: {
+      name: 'id',
+      type: 'string',
+      description: 'id',
+      table: {
+        category: 'HTML'
+      }
+    }
+  }
+}
+
+export const SelectTemplate = ({label, id, size, placeholder, disabled}) => (
+  <>
+    <label for={id}>{label}</label>
+    <select className={clsx('form-select', size && `${size}`)} id={id} placeholder={placeholder} disabled={disabled}>
+      <option>Choose an option</option>
+      <option>Git</option>
+      <option>Subversion</option>
+      <option>Social Coding</option>
+      <option>Beets</option>
+      <option>Bears</option>
+      <option>Battlestar Galactica</option>
+    </select>
+  </>
+)
+
+export const Playground = SelectTemplate.bind({})
+Playground.args = {
+  id: 'some-id',
+  placeholder: 'Select',
+  label: 'Select one'
+}

--- a/docs/src/stories/components/Forms/Textarea.stories.jsx
+++ b/docs/src/stories/components/Forms/Textarea.stories.jsx
@@ -1,0 +1,117 @@
+import React from 'react'
+import clsx from 'clsx'
+
+export default {
+  title: 'Components/Forms/Textarea',
+  parameters: {
+    layout: 'padded'
+  },
+  decorators: [
+    Story => (
+      <form>
+        <Story />
+      </form>
+    )
+  ],
+  excludeStories: ['TextareaTemplate'],
+  argTypes: {
+    size: {
+      options: [0, 1, 2], // iterator
+      mapping: [null, 'input-sm', 'input-lg'], // values
+      control: {
+        type: 'select',
+        labels: ['default', 'small', 'large']
+      },
+      table: {
+        category: 'CSS'
+      }
+    },
+    block: {
+      description: 'full width',
+      control: {type: 'boolean'},
+      table: {
+        category: 'Interactive'
+      }
+    },
+    contrast: {
+      description: 'change input background to light gray',
+      control: {type: 'boolean'},
+      table: {
+        category: 'Interactive'
+      }
+    },
+    disabled: {
+      description: 'disabled field',
+      control: {type: 'boolean'},
+      table: {
+        category: 'Interactive'
+      }
+    },
+    hideWebKit: {
+      description: 'hude WebKit autofill icon',
+      control: {type: 'boolean'},
+      table: {
+        category: 'Interactive'
+      }
+    },
+    placeholder: {
+      type: 'string',
+      name: 'placeholder',
+      description: 'string',
+      table: {
+        category: 'HTML'
+      }
+    },
+    label: {
+      type: 'string',
+      name: 'label',
+      description: 'string',
+      table: {
+        category: 'HTML'
+      }
+    },
+    type: {
+      name: 'type',
+      type: 'string',
+      description: 'type',
+      table: {
+        category: 'HTML'
+      }
+    },
+    id: {
+      name: 'id',
+      type: 'string',
+      description: 'id',
+      table: {
+        category: 'HTML'
+      }
+    }
+  }
+}
+
+export const TextareaTemplate = ({label, type, id, size, block, placeholder, contrast, disabled, hideWebKit}) => (
+  <>
+    <label for={id}>{label}</label>
+    <textarea
+      className={clsx(
+        'form-control',
+        size && `${size}`,
+        block && 'input-block',
+        contrast && 'input-contrast',
+        hideWebKit && 'input-hide-webkit-autofill'
+      )}
+      type={type}
+      id={id}
+      placeholder={placeholder}
+      disabled={disabled}
+    />
+  </>
+)
+
+export const Playground = TextareaTemplate.bind({})
+Playground.args = {
+  type: 'email',
+  id: 'some-id',
+  placeholder: 'Email address',
+  label: 'Enter email address'
+}

--- a/docs/src/stories/components/Link/Link.stories.jsx
+++ b/docs/src/stories/components/Link/Link.stories.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import clsx from 'clsx'
+
+export default {
+  title: 'Components/Link',
+  parameters: {
+    layout: 'padded'
+  },
+
+  excludeStories: ['LinkTemplate'],
+  argTypes: {
+    variant: {
+      options: [0, 1, 2, 3, 4], // iterator
+      mapping: [null, 'Link--primary', 'Link--secondary', 'Link--muted', 'Link--onHover'], // values
+      control: {
+        type: 'select',
+        labels: ['default', 'primary', 'secondar', 'muted', 'onHover', 'invisible', 'close', 'with-count']
+      },
+      table: {
+        category: 'CSS'
+      }
+    },
+    noUnderline: {
+      defaultValue: false,
+      control: {type: 'boolean'},
+      table: {
+        category: 'Interactive'
+      }
+    },
+    label: {
+      type: 'string',
+      name: 'label',
+      description: 'string',
+      table: {
+        category: 'HTML'
+      }
+    },
+    href: {
+      name: 'href',
+      type: 'string',
+      description: 'url',
+      table: {
+        category: 'HTML'
+      }
+    }
+  }
+}
+
+export const LinkTemplate = ({label, variant, href, noUnderline}) => (
+  <>
+    <a href={href} className={clsx(variant && `${variant}`, noUnderline && 'no-underline')}>
+      {label}
+    </a>
+  </>
+)
+
+export const Playground = LinkTemplate.bind({})
+Playground.args = {
+  label: 'Link label',
+  href: '/'
+}

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -297,7 +297,7 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
-"@babel/helper-validator-identifier@^7.15.7":
+"@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.15.7":
   version "7.15.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
@@ -1168,7 +1168,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.10.5", "@babel/types@^7.12.11", "@babel/types@^7.12.6", "@babel/types@^7.12.7", "@babel/types@^7.16.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
+"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.10.5", "@babel/types@^7.12.11", "@babel/types@^7.12.6", "@babel/types@^7.12.7", "@babel/types@^7.15.4", "@babel/types@^7.16.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.0.tgz#db3b313804f96aadd0b776c4823e127ad67289ba"
   integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -170,7 +170,8 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition:
+ visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -15,6 +15,12 @@
     }
   }
 
+  // li only: focus-visible, a href: focus-within on li
+  &:focus-visible,
+  &:focus-within {
+    @include focusOutline;
+  }
+
   // only hover li without list as children
   &:not(.ActionList-item--hasSubItem) {
     &:hover {
@@ -287,10 +293,6 @@
   // column-gap persists with empty grid-areas, margin applies only when children exist
   > :not(:last-child) {
     margin-right: $spacer-2;
-  }
-
-  &:focus-visible {
-    @include focusOutline;
   }
 
   // sizes

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -1,10 +1,3 @@
-@mixin focusOutline {
-  position: relative;
-  z-index: 1;
-  outline: none;
-  box-shadow: 0 0 0 2px var(--color-accent-fg); // this color breaks convention
-}
-
 // <li>
 .ActionList-item {
   position: relative;
@@ -171,8 +164,7 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition:
- visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -76,10 +76,31 @@ button {
 }
 
 details {
-  summary { cursor: pointer; }
+  summary {
+    cursor: pointer;
+  }
 
   &:not([open]) {
     // Set details content hidden by default for browsers that don't do this
-    > *:not(summary) { display: none !important; }
+    > *:not(summary) {
+      display: none !important;
+    }
   }
+}
+
+// global focus styles
+
+// fallback :focus state
+:focus:is(a, button, input, textarea) {
+  @include focusOutline;
+}
+
+// remove fallback :focus if :focus-visible is supported
+:focus:is(a, button, input, textarea):not(:focus-visible) {
+  outline: solid 1px transparent;
+}
+
+// default :focus-visibile state
+:focus-visible:is(a, button, input, textarea) {
+  @include focusOutline;
 }

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -90,6 +90,7 @@ details {
 
 // global focus styles
 
+// add .focus
 // fallback :focus state
 :focus:is(a, button, input, textarea) {
   @include focusOutline;
@@ -103,4 +104,12 @@ details {
 // default :focus-visibile state
 :focus-visible:is(a, button, input, textarea) {
   @include focusOutline;
+}
+
+// remove outline offset for form fields
+:focus,
+:focus-visible {
+  &:is(input, textarea) {
+    outline-offset: 0;
+  }
 }

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -106,10 +106,10 @@ details {
   @include focusOutline;
 }
 
-// remove outline offset for form fields
+// remove offset for form fields
 :focus,
 :focus-visible {
   &:is(input, textarea) {
-    outline-offset: 0;
+    box-shadow: 0 0 0 2px var(--color-accent-fg);
   }
 }

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -90,10 +90,12 @@ details {
 
 // global focus styles
 
-// add .focus
 // fallback :focus state
-:focus:is(a, button, input, textarea) {
-  @include focusOutline;
+:focus,
+.focus {
+  &:is(a, button, input, textarea) {
+    @include focusOutline;
+  }
 }
 
 // remove fallback :focus if :focus-visible is supported

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -112,6 +112,7 @@ details {
 :focus,
 :focus-visible {
   &:is(input, textarea) {
+    // stylelint-disable-next-line primer/box-shadow
     box-shadow: 0 0 0 2px var(--color-accent-fg);
   }
 }

--- a/src/base/normalize.scss
+++ b/src/base/normalize.scss
@@ -39,7 +39,8 @@ header,
 main, /* 2 */
 menu,
 nav,
-section { /* 1 */
+section {
+  /* 1 */
   display: block;
 }
 
@@ -94,16 +95,6 @@ template, /* 1 */
 
 a {
   background-color: transparent; /* 1 */
-}
-
-/**
- * Remove the outline on focused links when they are also active or hovered
- * in all browsers (opinionated).
- */
-
-a:active,
-a:hover {
-  outline-width: 0;
 }
 
 /* Text-level semantics
@@ -278,7 +269,8 @@ optgroup {
  */
 
 button,
-input { /* 1 */
+input {
+  /* 1 */
   overflow: visible;
 }
 
@@ -288,7 +280,8 @@ input { /* 1 */
  */
 
 button,
-select { /* 1 */
+select {
+  /* 1 */
   text-transform: none;
 }
 
@@ -303,29 +296,6 @@ html [type="button"], /* 1 */
 [type="reset"],
 [type="submit"] {
   -webkit-appearance: button; /* 2 */
-}
-
-/**
- * Remove the inner border and padding in Firefox.
- */
-
-button::-moz-focus-inner,
-[type="button"]::-moz-focus-inner,
-[type="reset"]::-moz-focus-inner,
-[type="submit"]::-moz-focus-inner {
-  border-style: none;
-  padding: 0;
-}
-
-/**
- * Restore the focus styles unset by the previous rule.
- */
-
-button:-moz-focusring,
-[type="button"]:-moz-focusring,
-[type="reset"]:-moz-focusring,
-[type="submit"]:-moz-focusring {
-  outline: 1px dotted ButtonText;
 }
 
 /**
@@ -367,8 +337,8 @@ textarea {
  * 2. Remove the padding in IE 10-.
  */
 
-[type="checkbox"],
-[type="radio"] {
+[type='checkbox'],
+[type='radio'] {
   box-sizing: border-box; /* 1 */
   padding: 0; /* 2 */
 }
@@ -377,27 +347,17 @@ textarea {
  * Correct the cursor style of increment and decrement buttons in Chrome.
  */
 
-[type="number"]::-webkit-inner-spin-button,
-[type="number"]::-webkit-outer-spin-button {
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
   height: auto;
-}
-
-/**
- * 1. Correct the odd appearance in Chrome and Safari.
- * 2. Correct the outline style in Safari.
- */
-
-[type="search"] {
-  -webkit-appearance: textfield; /* 1 */
-  outline-offset: -2px; /* 2 */
 }
 
 /**
  * Remove the inner padding and cancel buttons in Chrome and Safari on OS X.
  */
 
-[type="search"]::-webkit-search-cancel-button,
-[type="search"]::-webkit-search-decoration {
+[type='search']::-webkit-search-cancel-button,
+[type='search']::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -24,7 +24,7 @@
 
   &:disabled,
   &.disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     cursor: default;
   }
 
@@ -84,14 +84,14 @@
   }
 
   &.selected,
-  &[aria-selected=true] {
+  &[aria-selected='true'] {
     background-color: var(--color-btn-selected-bg);
     box-shadow: var(--color-primer-shadow-inset);
   }
 
   &:disabled,
   &.disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     color: var(--color-primer-fg-disabled);
     background-color: var(--color-btn-bg);
     border-color: var(--color-btn-border);
@@ -102,12 +102,12 @@
   }
 
   // Keep :focus after :disabled. Allows to see the focus ring even on disabled buttons
-  &:focus,
-  &.focus {
-    border-color: var(--color-btn-focus-border);
-    outline: none;
-    box-shadow: var(--color-btn-focus-shadow);
-  }
+  //   &:focus,
+  //   &.focus {
+  //     border-color: var(--color-btn-focus-border);
+  //     outline: none;
+  //     box-shadow: var(--color-btn-focus-shadow);
+  //   }
 }
 
 // Primary button
@@ -127,14 +127,14 @@
 
   &:active,
   &.selected,
-  &[aria-selected=true] {
+  &[aria-selected='true'] {
     background-color: var(--color-btn-primary-selected-bg);
     box-shadow: var(--color-btn-primary-selected-shadow);
   }
 
   &:disabled,
   &.disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     color: var(--color-btn-primary-disabled-text);
     background-color: var(--color-btn-primary-disabled-bg);
     border-color: var(--color-btn-primary-disabled-border);
@@ -144,12 +144,12 @@
     }
   }
 
-  &:focus,
-  &.focus {
-    background-color: var(--color-btn-primary-focus-bg);
-    border-color: var(--color-btn-primary-focus-border);
-    box-shadow: var(--color-btn-primary-focus-shadow);
-  }
+  //   &:focus,
+  //   &.focus {
+  //     background-color: var(--color-btn-primary-focus-bg);
+  //     border-color: var(--color-btn-primary-focus-border);
+  //     box-shadow: var(--color-btn-primary-focus-shadow);
+  //   }
 
   .Counter {
     color: inherit;
@@ -184,7 +184,7 @@
 
   &:active,
   &.selected,
-  &[aria-selected=true] {
+  &[aria-selected='true'] {
     color: var(--color-btn-outline-selected-text);
     background-color: var(--color-btn-outline-selected-bg);
     border-color: var(--color-btn-outline-selected-border);
@@ -193,7 +193,7 @@
 
   &:disabled,
   &.disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     color: var(--color-btn-outline-disabled-text);
     background-color: var(--color-btn-outline-disabled-bg);
     border-color: var(--color-btn-border);
@@ -204,10 +204,10 @@
     }
   }
 
-  &:focus {
-    border-color: var(--color-btn-outline-focus-border);
-    box-shadow: var(--color-btn-outline-focus-shadow);
-  }
+  //   &:focus {
+  //     border-color: var(--color-btn-outline-focus-border);
+  //     box-shadow: var(--color-btn-outline-focus-shadow);
+  //   }
 
   .Counter {
     color: inherit;
@@ -242,7 +242,7 @@
 
   &:active,
   &.selected,
-  &[aria-selected=true] {
+  &[aria-selected='true'] {
     color: var(--color-btn-danger-selected-text);
     background-color: var(--color-btn-danger-selected-bg);
     border-color: var(--color-btn-danger-selected-border);
@@ -251,7 +251,7 @@
 
   &:disabled,
   &.disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     color: var(--color-btn-danger-disabled-text);
     background-color: var(--color-btn-danger-disabled-bg);
     border-color: var(--color-btn-border);
@@ -266,10 +266,10 @@
     }
   }
 
-  &:focus {
-    border-color: var(--color-btn-danger-focus-border);
-    box-shadow: var(--color-btn-danger-focus-shadow);
-  }
+  //   &:focus {
+  //     border-color: var(--color-btn-danger-focus-border);
+  //     box-shadow: var(--color-btn-danger-focus-shadow);
+  //   }
 
   .Counter {
     color: inherit;

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -100,14 +100,6 @@
       color: var(--color-primer-fg-disabled);
     }
   }
-
-  // Keep :focus after :disabled. Allows to see the focus ring even on disabled buttons
-  //   &:focus,
-  //   &.focus {
-  //     border-color: var(--color-btn-focus-border);
-  //     outline: none;
-  //     box-shadow: var(--color-btn-focus-shadow);
-  //   }
 }
 
 // Primary button

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -136,13 +136,6 @@
     }
   }
 
-  //   &:focus,
-  //   &.focus {
-  //     background-color: var(--color-btn-primary-focus-bg);
-  //     border-color: var(--color-btn-primary-focus-border);
-  //     box-shadow: var(--color-btn-primary-focus-shadow);
-  //   }
-
   .Counter {
     color: inherit;
     background-color: var(--color-btn-primary-counter-bg);
@@ -195,11 +188,6 @@
       background-color: var(--color-btn-outline-disabled-counter-bg);
     }
   }
-
-  //   &:focus {
-  //     border-color: var(--color-btn-outline-focus-border);
-  //     box-shadow: var(--color-btn-outline-focus-shadow);
-  //   }
 
   .Counter {
     color: inherit;
@@ -257,11 +245,6 @@
       color: var(--color-btn-danger-disabled-text);
     }
   }
-
-  //   &:focus {
-  //     border-color: var(--color-btn-danger-focus-border);
-  //     box-shadow: var(--color-btn-danger-focus-shadow);
-  //   }
 
   .Counter {
     color: inherit;

--- a/src/buttons/misc.scss
+++ b/src/buttons/misc.scss
@@ -21,7 +21,7 @@
   }
 
   &:disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     &,
     &:hover {
       color: var(--color-primer-fg-disabled);
@@ -51,7 +51,7 @@
   &:active,
   &:focus,
   &.selected,
-  &[aria-selected=true],
+  &[aria-selected='true'],
   &.zeroclipboard-is-active {
     color: var(--color-accent-fg);
     background: none;
@@ -62,7 +62,7 @@
 
   &:disabled,
   &.disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     color: var(--color-primer-fg-disabled);
     background-color: transparent;
   }
@@ -86,14 +86,18 @@
   border: 0;
   box-shadow: none;
 
-  &:hover { color: var(--color-accent-fg); }
+  &:hover {
+    color: var(--color-accent-fg);
+  }
 
   &.disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     color: var(--color-primer-fg-disabled);
     cursor: default;
 
-    &:hover { color: var(--color-primer-fg-disabled); }
+    &:hover {
+      color: var(--color-primer-fg-disabled);
+    }
   }
 }
 

--- a/src/buttons/misc.scss
+++ b/src/buttons/misc.scss
@@ -49,15 +49,12 @@
   }
 
   &:active,
-  &:focus,
   &.selected,
   &[aria-selected='true'],
   &.zeroclipboard-is-active {
     color: var(--color-accent-fg);
     background: none;
-    border-color: var(--color-btn-active-border);
-    outline: none;
-    box-shadow: var(--color-btn-focus-shadow);
+    @include focusOutline;
   }
 
   &:disabled,
@@ -113,18 +110,13 @@
   color: var(--color-fg-muted);
   background: transparent;
   border: 0;
-  outline: none;
 
   &:hover {
     color: var(--color-fg-default);
   }
 
-  &:active,
-  &:focus {
-    color: var(--color-fg-muted);
-    border-color: var(--color-btn-active-border);
-    outline: none;
-    box-shadow: var(--color-btn-focus-shadow);
+  &:active {
+    @include focusOutline;
   }
 }
 
@@ -216,11 +208,5 @@
   &:hover {
     color: var(--color-accent-fg);
     cursor: pointer;
-  }
-
-  &:focus {
-    z-index: 1;
-    outline: 0;
-    box-shadow: var(--color-primer-shadow-focus);
   }
 }

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -82,12 +82,10 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 
-  &:focus,
   &:hover {
     color: var(--color-fg-on-emphasis);
     text-decoration: none;
     background-color: var(--color-accent-emphasis);
-    outline: none;
 
     > .octicon {
       color: inherit;

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -29,15 +29,7 @@ label {
   background-position: right 8px center; // For form validation. This keeps images 8px from right and centered vertically.
   border: $border-width $border-style var(--color-border-default);
   border-radius: $border-radius;
-  outline: none;
   box-shadow: var(--color-primer-shadow-inset);
-
-  &.focus,
-  &:focus {
-    border-color: var(--color-accent-emphasis);
-    outline: none;
-    box-shadow: var(--color-primer-shadow-focus);
-  }
 
   &[disabled] {
     color: var(--color-primer-fg-disabled);

--- a/src/navigation/menu.scss
+++ b/src/navigation/menu.scss
@@ -22,7 +22,9 @@
     border-top-left-radius: $border-radius;
     border-top-right-radius: $border-radius;
 
-    &::before { border-top-left-radius: $border-radius; }
+    &::before {
+      border-top-left-radius: $border-radius;
+    }
   }
 
   &:last-child {
@@ -30,13 +32,9 @@
     border-bottom-right-radius: $border-radius;
     border-bottom-left-radius: $border-radius;
 
-    &::before { border-bottom-left-radius: $border-radius; }
-  }
-
-  &:focus {
-    z-index: 1;
-    outline: none;
-    box-shadow: var(--color-primer-shadow-focus);
+    &::before {
+      border-bottom-left-radius: $border-radius;
+    }
   }
 
   &:hover {
@@ -49,8 +47,8 @@
   }
 
   &.selected,
-  &[aria-selected=true],
-  &[aria-current]:not([aria-current=false]) {
+  &[aria-selected='true'],
+  &[aria-current]:not([aria-current='false']) {
     cursor: default;
     background-color: var(--color-menu-bg-active);
 

--- a/src/navigation/sidenav.scss
+++ b/src/navigation/sidenav.scss
@@ -43,23 +43,16 @@
 
 // States
 
-.SideNav-item:focus {
-  z-index: 1;
-  outline: none;
-  box-shadow: var(--color-primer-shadow-focus);
-}
-
 .SideNav-item:hover {
   text-decoration: none;
   background-color: var(--color-neutral-subtle);
-  outline: none;
 }
 
 .SideNav-item:active {
   background-color: var(--color-canvas-subtle);
 }
 
-.SideNav-item[aria-current]:not([aria-current=false]),
+.SideNav-item[aria-current]:not([aria-current='false']),
 .SideNav-item[aria-selected='true'] {
   background-color: var(--color-sidenav-selected-bg);
 
@@ -94,14 +87,12 @@
   border: 0;
 }
 
-.SideNav-subItem:hover,
-.SideNav-subItem:focus {
+.SideNav-subItem:hover {
   color: var(--color-fg-default);
   text-decoration: none;
-  outline: none;
 }
 
-.SideNav-subItem[aria-current]:not([aria-current=false]),
+.SideNav-subItem[aria-current]:not([aria-current='false']),
 .SideNav-subItem[aria-selected='true'] {
   font-weight: $font-weight-semibold;
   color: var(--color-fg-default);

--- a/src/support/mixins/misc.scss
+++ b/src/support/mixins/misc.scss
@@ -10,7 +10,7 @@
     width: 8px;
     height: 16px;
     pointer-events: none;
-    content: " ";
+    content: ' ';
     clip-path: polygon(0 50%, 100% 0, 100% 100%);
   }
 
@@ -23,4 +23,11 @@
   &::before {
     background-color: $border;
   }
+}
+
+@mixin focusOutline {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid var(--color-accent-fg);
+  outline-offset: 2px;
 }

--- a/src/support/mixins/misc.scss
+++ b/src/support/mixins/misc.scss
@@ -25,9 +25,13 @@
   }
 }
 
+// global focus styles
+// change to outline when Safari has better support
+// outline: 2px solid var(--color-accent-fg);
+// outline-offset: 2px;
 @mixin focusOutline {
   position: relative;
   z-index: 1;
-  outline: 2px solid var(--color-accent-fg);
-  outline-offset: 2px;
+  outline: solid 1px transparent;
+  box-shadow: 0 0 0 2px var(--color-canvas-default), 0 0 0 4px var(--color-accent-fg);
 }

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -40,9 +40,7 @@
   background-color: transparent;
   border: 0;
 
-  &:focus,
   &:hover {
-    outline: none;
     opacity: 0.7;
   }
 
@@ -119,6 +117,10 @@
 }
 
 @keyframes Toast--spinner {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/src/toasts/toasts.scss
+++ b/src/toasts/toasts.scss
@@ -120,6 +120,7 @@
   from {
     transform: rotate(0deg);
   }
+
   to {
     transform: rotate(360deg);
   }


### PR DESCRIPTION
- Adds global `:focus` and `:focus-visible' styles for `a, button, input, textarea` elements
- Removes _most_ `outline: 0;` from primer-css (there are some special edge cases)
- Uses `box-shadow` to retain border-radius (we can easily change to `outline` when Safari catches up)
- Creates a default fake offset using `var(--color-canvas-default)` to help meet color contrast requirements


| element | img |
| :- | :- |
| `input` | ![image](https://user-images.githubusercontent.com/18661030/141021011-e17705e7-1289-4b9b-a193-441aeb0002fa.png) |
| `textarea` | ![image](https://user-images.githubusercontent.com/18661030/141021177-c29dcc6f-e906-4586-a5c3-dc156171bd3f.png) |
| `button` | ![image](https://user-images.githubusercontent.com/18661030/141021222-cfffd627-0dba-4903-9880-3ffe145f8e1b.png) |
| `a` |  ![image](https://user-images.githubusercontent.com/18661030/141021266-58964ef2-d691-4fe6-b13b-d5ecf5beea5b.png) |




Inspiration/research: https://www.sarasoueidan.com/blog/focus-indicators/ 

-  Fixes: https://github.com/github/primer/issues/410

/cc @primer/css-reviewers
