### PR TITLE
Remove `Label` bg hack

### DIFF
--- a/.changeset/heavy-rivers-retire.md
+++ b/.changeset/heavy-rivers-retire.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Remove `Label` bg hack

--- a/src/labels/labels.scss
+++ b/src/labels/labels.scss
@@ -10,7 +10,6 @@
 .label, // TODO: Deprecte
 .Label {
   @include labels-base;
-  background-color: transparent !important; // TODO: Remove again
   border-color: var(--color-border-default);
 
   &:hover {


### PR DESCRIPTION
This is part of https://github.com/github/primer/issues/331.

In the past we used a background color for `Label`s. But 1-2 years ago we changed all [`Label`](https://primer.style/css/components/labels#colored-labels)s to only have an "outline/border" but no background. To enforce that in a quick and dirty way 😅 , we just overrode the background to `transparent !important` in [Primer CSS](https://github.com/primer/css/blob/832e99886df66ea5860d725517aeb9d5f178dd58/src/labels/labels.scss#L13).

We should be able to remove this hack because all `Label` should now not use any background color anymore.
