### PR TITLE
Update mark tag to use background-color: var(--color-attention-subtle);

### DIFF
--- a/.changeset/lazy-snails-try.md
+++ b/.changeset/lazy-snails-try.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Update mark tag to use background-color: var(--color-attention-subtle);

--- a/src/base/normalize.scss
+++ b/src/base/normalize.scss
@@ -161,7 +161,7 @@ h1 {
  */
 
 mark {
-  background-color: #ff0;
+  background-color: var(--color-attention-subtle);
   color: var(--color-text-primary);
 }
 


### PR DESCRIPTION


Finally, tell us more about the change here, in the description.

I'd love to be able to remove this in the docs:
https://github.com/github/docs/blob/main/components/Search.module.scss#L12

/cc @primer/css-reviewers
