### PR TITLE
Update bg utilities in the docs

### DIFF
--- a/docs/content/components/select-menu.md
+++ b/docs/content/components/select-menu.md
@@ -457,7 +457,7 @@ A `SelectMenu-message` can be used to show different kind of messages to a user.
         </button>
       </header>
       <div class="SelectMenu-list">
-        <div class="SelectMenu-message color-bg-danger-subtle color-fg-danger">Message goes here</div>
+        <div class="SelectMenu-message color-bg-danger color-fg-danger">Message goes here</div>
         <button class="SelectMenu-item" role="menuitem">Item 1</button>
         <button class="SelectMenu-item" role="menuitem">Item 2</button>
         <button class="SelectMenu-item" role="menuitem">Item 3</button>

--- a/docs/content/objects/grid.md
+++ b/docs/content/objects/grid.md
@@ -136,24 +136,24 @@ Use padding utilities to create gutters for more customized layouts.
 ```html live title="Gutters with padding"
 <div class="container-lg clearfix">
   <div class="col-3 float-left pr-2 mb-3">
-    <div class="border color-bg-attention-subtle">.pr-2</div>
+    <div class="border color-bg-attention">.pr-2</div>
   </div>
   <div class="col-3 float-left px-2 mb-3">
-    <div class="border color-bg-attention-subtle">.px-2</div>
+    <div class="border color-bg-attention">.px-2</div>
   </div>
   <div class="col-3 float-left px-2 mb-3">
-    <div class="border color-bg-attention-subtle">.px-2</div>
+    <div class="border color-bg-attention">.px-2</div>
   </div>
   <div class="col-3 float-left pl-2 mb-3">
-    <div class="border color-bg-attention-subtle">.pl-2</div>
+    <div class="border color-bg-attention">.pl-2</div>
   </div>
 </div>
 <div class="container-lg clearfix">
   <div class="col-3 float-left pr-2">
-    <div class="border color-bg-attention-subtle">.pr-2</div>
+    <div class="border color-bg-attention">.pr-2</div>
   </div>
   <div class="col-9 float-left pl-2">
-    <div class="border color-bg-attention-subtle">.pl-2</div>
+    <div class="border color-bg-attention">.pl-2</div>
   </div>
 </div>
 ```

--- a/docs/content/utilities/margin.md
+++ b/docs/content/utilities/margin.md
@@ -43,13 +43,13 @@ Use uniform spacing utilities to apply equal margin to all sides of an element. 
 
 ```html live
 <div class="d-flex flex-items-baseline flex-justify-around">
-  <div class="color-bg-attention-subtle"><div class="m-0 p-1 color-bg-subtle">.m-0</div></div>
-  <div class="color-bg-attention-subtle"><div class="m-1 p-1 color-bg-subtle">.m-1</div></div>
-  <div class="color-bg-attention-subtle"><div class="m-2 p-1 color-bg-subtle">.m-2</div></div>
-  <div class="color-bg-attention-subtle"><div class="m-3 p-1 color-bg-subtle">.m-3</div></div>
-  <div class="color-bg-attention-subtle"><div class="m-4 p-1 color-bg-subtle">.m-4</div></div>
-  <div class="color-bg-attention-subtle"><div class="m-5 p-1 color-bg-subtle">.m-5</div></div>
-  <div class="color-bg-attention-subtle"><div class="m-6 p-1 color-bg-subtle">.m-6</div></div>
+  <div class="color-bg-attention"><div class="m-0 p-1 color-bg-subtle">.m-0</div></div>
+  <div class="color-bg-attention"><div class="m-1 p-1 color-bg-subtle">.m-1</div></div>
+  <div class="color-bg-attention"><div class="m-2 p-1 color-bg-subtle">.m-2</div></div>
+  <div class="color-bg-attention"><div class="m-3 p-1 color-bg-subtle">.m-3</div></div>
+  <div class="color-bg-attention"><div class="m-4 p-1 color-bg-subtle">.m-4</div></div>
+  <div class="color-bg-attention"><div class="m-5 p-1 color-bg-subtle">.m-5</div></div>
+  <div class="color-bg-attention"><div class="m-6 p-1 color-bg-subtle">.m-6</div></div>
 </div>
 ```
 
@@ -59,12 +59,12 @@ Use directional utilities to apply margin to an individual side, or the X and Y 
 
 ```html live
 <div class="d-flex flex-items-baseline flex-justify-around">
-  <div class="color-bg-attention-subtle"><div class="mt-3 p-1 color-bg-subtle">.mt-3</div></div>
-  <div class="color-bg-attention-subtle"><div class="mr-3 p-1 color-bg-subtle">.mr-3</div></div>
-  <div class="color-bg-attention-subtle"><div class="mb-3 p-1 color-bg-subtle">.mb-3</div></div>
-  <div class="color-bg-attention-subtle"><div class="ml-3 p-1 color-bg-subtle">.ml-3</div></div>
-  <div class="color-bg-attention-subtle"><div class="mx-3 p-1 color-bg-subtle">.mx-3</div></div>
-  <div class="color-bg-attention-subtle"><div class="my-3 p-1 color-bg-subtle">.my-3</div></div>
+  <div class="color-bg-attention"><div class="mt-3 p-1 color-bg-subtle">.mt-3</div></div>
+  <div class="color-bg-attention"><div class="mr-3 p-1 color-bg-subtle">.mr-3</div></div>
+  <div class="color-bg-attention"><div class="mb-3 p-1 color-bg-subtle">.mb-3</div></div>
+  <div class="color-bg-attention"><div class="ml-3 p-1 color-bg-subtle">.ml-3</div></div>
+  <div class="color-bg-attention"><div class="mx-3 p-1 color-bg-subtle">.mx-3</div></div>
+  <div class="color-bg-attention"><div class="my-3 p-1 color-bg-subtle">.my-3</div></div>
 </div>
 ```
 
@@ -73,12 +73,12 @@ Use directional utilities to apply margin to an individual side, or the X and Y 
 The extended scale starts from spacer `7` up to `12`. **Note**: Only the y-axis (`mt`, `mb` and `my`) and its responsive variants are supported.
 
 ```html live
-<div class="color-bg-attention-subtle d-inline-block"><div class="mt-7  p-1 color-bg-subtle">.mb-7</div></div>
-<div class="color-bg-attention-subtle d-inline-block"><div class="mt-8  p-1 color-bg-subtle">.mb-8</div></div>
-<div class="color-bg-attention-subtle d-inline-block"><div class="mt-9  p-1 color-bg-subtle">.mb-9</div></div>
-<div class="color-bg-attention-subtle d-inline-block"><div class="mt-10 p-1 color-bg-subtle">.mb-10</div></div>
-<div class="color-bg-attention-subtle d-inline-block"><div class="mt-11 p-1 color-bg-subtle">.mb-11</div></div>
-<div class="color-bg-attention-subtle d-inline-block"><div class="mt-12 p-1 color-bg-subtle">.mb-12</div></div>
+<div class="color-bg-attention d-inline-block"><div class="mt-7  p-1 color-bg-subtle">.mb-7</div></div>
+<div class="color-bg-attention d-inline-block"><div class="mt-8  p-1 color-bg-subtle">.mb-8</div></div>
+<div class="color-bg-attention d-inline-block"><div class="mt-9  p-1 color-bg-subtle">.mb-9</div></div>
+<div class="color-bg-attention d-inline-block"><div class="mt-10 p-1 color-bg-subtle">.mb-10</div></div>
+<div class="color-bg-attention d-inline-block"><div class="mt-11 p-1 color-bg-subtle">.mb-11</div></div>
+<div class="color-bg-attention d-inline-block"><div class="mt-12 p-1 color-bg-subtle">.mb-12</div></div>
 ```
 
 ## Center elements
@@ -86,7 +86,7 @@ The extended scale starts from spacer `7` up to `12`. **Note**: Only the y-axis 
 Use `mx-auto`to center block elements with a set width.
 
 ```html live
-<div class="color-bg-attention-subtle">
+<div class="color-bg-attention">
   <div class="mx-auto color-bg-subtle text-center" style="max-width: 500px;">.mx-auto</div>
 </div>
 ```
@@ -109,7 +109,7 @@ We also provide directional margin auto. `mt-auto, mr-auto, mb-auto, ml-auto`
 Reset margins built into typography elements or other components with `m-0`, `mt-0`, `mr-0`, `mb-0`, `ml-0`, `mx-0`, and `my-0`.
 
 ```html live
-<div class="color-bg-attention-subtle border">
+<div class="color-bg-attention border">
   <p class="mb-0 color-bg-subtle p-1">No bottom margin on this paragraph.</p>
 </div>
 ```
@@ -119,7 +119,7 @@ Reset margins built into typography elements or other components with `m-0`, `mt
 All margin utilities can be adjusted per [breakpoint](/objects/grid#breakpoints) using the following formula: `m[direction]-[breakpoint]-[spacer]`. Each responsive style is applied to the specified breakpoint and up.
 
 ```html live
-<div class="color-bg-attention-subtle d-inline-block">
+<div class="color-bg-attention d-inline-block">
   <div class="mx-sm-2 mx-md-4 color-bg-subtle p-1">
     .mx-sm-2 .mx-md-4
   </div>
@@ -132,7 +132,7 @@ You can add negative margins to the top, right, bottom, or left of an item by ad
 
 ```html live
 <div class="d-flex flex-justify-center">
-  <div class="color-bg-attention-subtle">
+  <div class="color-bg-attention">
     <div class="m-3 ml-n4 ml-md-n6 border-left color-border-danger color-bg-subtle p-2">
       .m-3 .ml-n4 .ml-md-n6
     </div>
@@ -146,7 +146,7 @@ You can use the extended spacing scale for `top` and `bottom` margins, ranging f
 
 ```html live
 <div class="d-flex flex-justify-center">
-  <div class="py-6 px-3 color-bg-attention-subtle">
+  <div class="py-6 px-3 color-bg-attention">
     <div class="mt-n8 border-left color-border-danger color-bg-subtle p-2">
       .mt-n8
     </div>

--- a/docs/content/utilities/padding.md
+++ b/docs/content/utilities/padding.md
@@ -44,13 +44,13 @@ _**Note:** The blue in the examples below represents the element, and the green 
 Use uniform spacing utilities to apply equal padding to all sides of an element. These utilities can be used with a spacing scale from 0-6.
 
 ```html live
-<div class="p-0 mr-3 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.p-0</div></div>
-<div class="p-1 mr-3 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.p-1</div></div>
-<div class="p-2 mr-3 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.p-2</div></div>
-<div class="p-3 mr-3 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.p-3</div></div>
-<div class="p-4 mr-3 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.p-4</div></div>
-<div class="p-5 mr-3 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.p-5</div></div>
-<div class="p-6 mr-3 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.p-6</div></div>
+<div class="p-0 mr-3 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.p-0</div></div>
+<div class="p-1 mr-3 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.p-1</div></div>
+<div class="p-2 mr-3 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.p-2</div></div>
+<div class="p-3 mr-3 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.p-3</div></div>
+<div class="p-4 mr-3 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.p-4</div></div>
+<div class="p-5 mr-3 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.p-5</div></div>
+<div class="p-6 mr-3 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.p-6</div></div>
 ```
 
 ## Directional padding
@@ -58,12 +58,12 @@ Use uniform spacing utilities to apply equal padding to all sides of an element.
 Use directional utilities to apply padding to an individual side, or the X and Y axis of an element. Directional utilities can change or override default padding, and can be used with a spacing scale of 0-6.
 
 ```html live
-<div class="pt-3 mr-3 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.pt-3</div></div>
-<div class="pr-3 mr-3 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.pr-3</div></div>
-<div class="pb-3 mr-3 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.pb-3</div></div>
-<div class="pl-3 mr-3 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.pl-3</div></div>
-<div class="py-3 mr-3 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.py-3</div></div>
-<div class="px-3 mr-3 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.px-3</div></div>
+<div class="pt-3 mr-3 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.pt-3</div></div>
+<div class="pr-3 mr-3 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.pr-3</div></div>
+<div class="pb-3 mr-3 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.pb-3</div></div>
+<div class="pl-3 mr-3 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.pl-3</div></div>
+<div class="py-3 mr-3 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.py-3</div></div>
+<div class="px-3 mr-3 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.px-3</div></div>
 ```
 
 ## Extended directional padding
@@ -71,12 +71,12 @@ Use directional utilities to apply padding to an individual side, or the X and Y
 The extended directional padding scale starts from spacer `7` and goes up to `12`. All directions and their responsive variants are supported, except for `px`.
 
 ```html live
-<div class="pt-7  mr-1 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.pt-7</div></div>
-<div class="pt-8  mr-1 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.pt-8</div></div>
-<div class="pt-9  mr-1 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.pt-9</div></div>
-<div class="pt-10 mr-1 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.pt-10</div></div>
-<div class="pt-11 mr-1 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.pt-11</div></div>
-<div class="pt-12 mr-1 color-bg-attention-subtle d-inline-block"><div class="color-bg-subtle p-1">.pt-12</div></div>
+<div class="pt-7  mr-1 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.pt-7</div></div>
+<div class="pt-8  mr-1 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.pt-8</div></div>
+<div class="pt-9  mr-1 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.pt-9</div></div>
+<div class="pt-10 mr-1 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.pt-10</div></div>
+<div class="pt-11 mr-1 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.pt-11</div></div>
+<div class="pt-12 mr-1 color-bg-attention d-inline-block"><div class="color-bg-subtle p-1">.pt-12</div></div>
 ```
 
 
@@ -85,7 +85,7 @@ The extended directional padding scale starts from spacer `7` and goes up to `12
 All padding utilities can be adjusted per [breakpoint](/support/breakpoints) using the following formula: <br /> `p-[direction]-[breakpoint]-[spacer]`. Each responsive style is applied to the specified breakpoint and up.
 
 ```html live
-<div class="px-sm-2 px-md-4 color-bg-attention-subtle d-inline-block">
+<div class="px-sm-2 px-md-4 color-bg-attention d-inline-block">
   <div class="color-bg-subtle p-1">.px-sm-2 .px-md-4</div>
 </div>
 ```
@@ -101,7 +101,7 @@ All padding utilities can be adjusted per [breakpoint](/support/breakpoints) usi
 It's the equvilent of adding the `.px-3 .px-sm-6 .px-lg-3` utility classes.
 
 ```html live
-<div class="p-responsive color-bg-attention-subtle">
+<div class="p-responsive color-bg-attention">
   <div class="color-bg-subtle p-1">.p-responsive</div>
 </div>
 ```


### PR DESCRIPTION
Some of the docs still have the wrong `bg` utilities (with `-subtle`).

Before | After
--- | ---
![Screen Shot 2021-11-19 at 13 31 52](https://user-images.githubusercontent.com/378023/142565904-b16d8644-6e61-4822-99e6-8ea35ddc641d.png) | ![Screen Shot 2021-11-19 at 13 32 18](https://user-images.githubusercontent.com/378023/142565906-7619d48c-17db-407f-882d-9a8e8f3aaf8f.png)
`color-bg-danger-subtle` | `color-bg-danger`
