### PR TITLE
Primer/css/storybook/improve theme picker

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -46,7 +46,7 @@ All `html` fenced code blocks in `src/**/*.md` will be rendered as stories and l
 Primer CSS Storybook is used for designing and prototyping components. Stories are written in HTML and leverage the Storybook API for configuring conditional logic. 
 
 ```sh
-npm storybook
+npm run storybook
 ```
 
 ### The Storybook directory

--- a/docs/.storybook/preview.js
+++ b/docs/.storybook/preview.js
@@ -97,6 +97,16 @@ export const parameters = {
   viewport: {viewports: customViewports}
 }
 
+const themes = [
+  'light',
+  'light_colorblind',
+  'light_high_contrast',
+  'dark',
+  'dark_dimmed',
+  'dark_high_contrast',
+  'dark_colorblind'
+]
+
 export const globalTypes = {
   theme: {
     name: 'Theme',
@@ -104,16 +114,7 @@ export const globalTypes = {
     defaultValue: 'light',
     toolbar: {
       icon: 'circlehollow',
-      items: [
-        'light',
-        'light_colorblind',
-        'light_high_contrast',
-        'dark',
-        'dark_dimmed',
-        'dark_high_contrast',
-        'dark_colorblind',
-        'all'
-      ],
+      items: [...themes, 'all'],
       showName: true
     }
   }
@@ -121,99 +122,21 @@ export const globalTypes = {
 
 export const decorators = [
   (Story, context) => {
-    if (context.globals.theme === 'all') {
-      return (
-        <div class="theme-wrap">
-          <div data-color-mode="light" data-light-theme="light" className="story-wrap" id="story">
-            <Story {...context} />
-          </div>
-
-          <div data-color-mode="light" data-light-theme="light_colorblind" className="story-wrap" id="story">
-            <Story {...context} />
-          </div>
-
-          <div data-color-mode="light" data-light-theme="light_high_contrast" className="story-wrap" id="story">
-            <Story {...context} />
-          </div>
-
-          <div data-color-mode="dark" data-dark-theme="dark" className="story-wrap" id="story">
-            <Story {...context} />
-          </div>
-
-          <div data-color-mode="dark" data-dark-theme="dark_dimmed" className="story-wrap" id="story">
-            <Story {...context} />
-          </div>
-
-          <div data-color-mode="dark" data-dark-theme="dark_high_contrast" className="story-wrap" id="story">
-            <Story {...context} />
-          </div>
-
-          <div data-color-mode="dark" data-dark-theme="dark_colorblind" className="story-wrap" id="story">
-            <Story {...context} />
-          </div>
-        </div>
-      )
-    }
-
-    if (context.globals.theme === 'light') {
-      return (
-        <div data-color-mode="light" data-light-theme="light" className="story-wrap" id="story">
-          <Story {...context} />
-        </div>
-      )
-    }
-
-    if (context.globals.theme === 'light_colorblind') {
-      return (
-        <div data-color-mode="light" data-light-theme="light_colorblind" className="story-wrap" id="story">
-          <Story {...context} />
-        </div>
-      )
-    }
-
-    if (context.globals.theme === 'light_high_contrast') {
-      return (
-        <div data-color-mode="light" data-light-theme="light_high_contrast" className="story-wrap" id="story">
-          <Story {...context} />
-        </div>
-      )
-    }
-
-    if (context.globals.theme === 'dark') {
-      return (
-        <div data-color-mode="dark" data-dark-theme="dark" className="story-wrap" id="story">
-          <Story {...context} />
-        </div>
-      )
-    }
-
-    if (context.globals.theme === 'dark_dimmed') {
-      return (
-        <div data-color-mode="dark" data-dark-theme="dark_dimmed" className="story-wrap" id="story">
-          <Story {...context} />
-        </div>
-      )
-    }
-
-    if (context.globals.theme === 'dark_high_contrast') {
-      return (
-        <div data-color-mode="dark" data-dark-theme="dark_high_contrast" className="story-wrap" id="story">
-          <Story {...context} />
-        </div>
-      )
-    }
-
-    if (context.globals.theme === 'dark_colorblind') {
-      return (
-        <div data-color-mode="dark" data-dark-theme="dark_colorblind" className="story-wrap" id="story">
-          <Story {...context} />
-        </div>
-      )
-    }
-
     return (
-      <div className="story-wrap" id="story">
-        <Story {...context} />
+      <div class="theme-wrap">
+        { themes.map((theme) => {
+            if (context.globals.theme === theme || context.globals.theme === 'all') {
+              return <div
+                id="story"
+                className="story-wrap"
+                data-color-mode={theme.startsWith('dark') ? 'dark' : 'light'}
+                data-light-theme={theme.startsWith('light') ? theme : undefined}
+                data-dark-theme={theme.startsWith('dark') ? theme : undefined}
+              >
+                <Story {...context} />
+              </div>
+            }
+          })}
       </div>
     )
   }


### PR DESCRIPTION
## What are you trying to accomplish?

- This PR improves the JS code in for the theme picker in the storybook decorator. 
- As well I added a fix in the storybook documentation. I changed `npm storybook` to be `npm run storybook`

## What approach did you choose and why?

- All themes are now wrapped around a `<div class="theme-wrap">` (even if it's only one).
- All theme has been extracted in its own array (except `all`), so it's more maintainable and easier to add a new theme. As well that array can be used anywhere else is needed (needs to be exported).
- The theme `all` to display all themes is now spread of the rest of the themes (`items: [...themes, 'all']`).

## If something goes wrong, what are the mitigation strategies?

* **Rollback** - Change can be disabled by deploying a revert commit.

/cc @primer/css-reviewers
