### PR TITLE
Bump primer/primitives to 7.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "storybook": "cd docs && yarn && yarn storybook"
   },
   "dependencies": {
-    "@primer/primitives": "^7.1.0"
+    "@primer/primitives": "^7.2.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -965,10 +965,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@primer/primitives@^7.1.0":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.1.1.tgz#46edb7f06fbe8809ebe2822bc692fc6c74dba98c"
-  integrity sha512-+Gwo89YK1OFi6oubTlah/zPxxzMNaMLy+inECAYI646KIFdzzhAsKWb3z5tSOu5Ff7no4isRV64rWfMSKLZclw==
+"@primer/primitives@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.2.0.tgz#049fc6d2fef20ea7fa517e583671aa0a8a26e9e9"
+  integrity sha512-7HkPAn7gnCcKPfDrqJc9OCUttPwBcoJRj2JR78obUbCkSfRV4I7cZiMS8tf9rYJ9HV69u+km8ab2Jrf4eOnVBg==
 
 "@primer/stylelint-config@12.1.1":
   version "12.1.1"


### PR DESCRIPTION
This PR is getting ahead of dependabot to unblock https://github.com/primer/css/pull/1792.

It will add these changes: https://github.com/primer/primitives/pull/278
