### PR TITLE
Create `btn-icon` and deprecate `btn-octicon`.

### DIFF
--- a/docs/content/components/buttons.md
+++ b/docs/content/components/buttons.md
@@ -184,6 +184,32 @@ Icons can be added to any button.
 
 ### Icon-only button
 
+Icon-only buttons `.btn-icon` are fixed at `32x32`.
+
+```html live
+<button class="btn btn-icon mr-2" type="button" aria-label="Desktop icon">
+  <!-- <%= octicon "device-desktop" %> -->
+  <svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.75 2.5h12.5a.25.25 0 01.25.25v7.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25v-7.5a.25.25 0 01.25-.25zM14.25 1H1.75A1.75 1.75 0 000 2.75v7.5C0 11.216.784 12 1.75 12h3.727c-.1 1.041-.52 1.872-1.292 2.757A.75.75 0 004.75 16h6.5a.75.75 0 00.565-1.243c-.772-.885-1.193-1.716-1.292-2.757h3.727A1.75 1.75 0 0016 10.25v-7.5A1.75 1.75 0 0014.25 1zM9.018 12H6.982a5.72 5.72 0 01-.765 2.5h3.566a5.72 5.72 0 01-.765-2.5z"></path></svg>
+</button>
+
+<button class="btn btn-outline btn-icon mr-2" type="button" aria-label="Pencil icon">
+  <!-- <%= octicon "pencil" %> -->
+  <svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M11.013 1.427a1.75 1.75 0 012.474 0l1.086 1.086a1.75 1.75 0 010 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 01-.927-.928l.929-3.25a1.75 1.75 0 01.445-.758l8.61-8.61zm1.414 1.06a.25.25 0 00-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 000-.354l-1.086-1.086zM11.189 6.25L9.75 4.81l-6.286 6.287a.25.25 0 00-.064.108l-.558 1.953 1.953-.558a.249.249 0 00.108-.064l6.286-6.286z"></path></svg>
+</button>
+
+<button class="btn btn-danger btn-icon mr-2" type="button" aria-label="Trashcan icon">
+  <!-- <%= octicon "trashcan" %> -->
+  <svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M6.5 1.75a.25.25 0 01.25-.25h2.5a.25.25 0 01.25.25V3h-3V1.75zm4.5 0V3h2.25a.75.75 0 010 1.5H2.75a.75.75 0 010-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75zM4.496 6.675a.75.75 0 10-1.492.15l.66 6.6A1.75 1.75 0 005.405 15h5.19c.9 0 1.652-.681 1.741-1.576l.66-6.6a.75.75 0 00-1.492-.149l-.66 6.6a.25.25 0 01-.249.225h-5.19a.25.25 0 01-.249-.225l-.66-6.6z"></path></svg>
+</button>
+
+<button class="btn btn-invisible btn-icon" type="button" aria-label="Kebab icon">
+  <!-- <%= octicon "kebab-horizontal" %> -->
+  <svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M8 9a1.5 1.5 0 100-3 1.5 1.5 0 000 3zM1.5 9a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm13 0a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path></svg>
+</button>
+```
+
+### Icon-only button (deprecated)
+
 Icon-only buttons `.btn-octicon` turn blue on hover. Use `.btn-octicon-danger` to turn an icon red on hover.
 
 ```html live

--- a/docs/src/stories/components/IconButton/IconButton.stories.jsx
+++ b/docs/src/stories/components/IconButton/IconButton.stories.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import clsx from 'clsx'
+
+export default {
+  title: 'Components/IconButton',
+  parameters: {
+    layout: 'padded'
+  },
+
+  excludeStories: ['IconButtonTemplate'],
+  argTypes: {
+    variant: {
+      options: [0, 1, 2, 3], // iterator
+      mapping: [
+        null,
+        'btn-outline',
+        'btn-danger',
+        'btn-invisible'
+      ], // values
+      control: {
+        type: 'select',
+        labels: ['default', 'outline', 'danger', 'invisible']
+      },
+      table: {
+        category: 'CSS'
+      }
+    },
+    label: {
+      defaultValue: '<svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.75 2.5h12.5a.25.25 0 01.25.25v7.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25v-7.5a.25.25 0 01.25-.25zM14.25 1H1.75A1.75 1.75 0 000 2.75v7.5C0 11.216.784 12 1.75 12h3.727c-.1 1.041-.52 1.872-1.292 2.757A.75.75 0 004.75 16h6.5a.75.75 0 00.565-1.243c-.772-.885-1.193-1.716-1.292-2.757h3.727A1.75 1.75 0 0016 10.25v-7.5A1.75 1.75 0 0014.25 1zM9.018 12H6.982a5.72 5.72 0 01-.765 2.5h3.566a5.72 5.72 0 01-.765-2.5z"></path></svg>',
+      type: 'string',
+      name: 'label',
+      description: 'Paste [Octicon](https://primer.style/octicons/) in control field',
+      table: {
+        category: 'HTML'
+      }
+    },
+  }
+}
+
+const focusMethod = function getFocus() {
+  // find the focusable element
+  var button = document.getElementsByTagName('button')[0]
+  // set focus on element
+  button.focus()
+}
+
+export const IconButtonTemplate = ({
+  label,
+  variant,
+  disabled,
+  selected,
+  focusElement,
+}) => (
+  <>
+    <button
+      disabled={disabled}
+      className={clsx(
+        'btn',
+        'btn-icon',
+        variant && `${variant}`,
+      )}
+      aria-selected={selected}
+    >
+      <span className="" dangerouslySetInnerHTML={{__html: label}} />
+    </button>
+    {focusElement && focusMethod()}
+  </>
+)
+
+export const Playground = IconButtonTemplate.bind({})
+Playground.args = {
+  focusElement: false,
+  focusAllElements: false
+}

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -310,3 +310,16 @@
   width: 100%;
   text-align: center;
 }
+
+// Icon-only buttons
+.btn-icon {
+  display: inline-block;
+  // stylelint-disable-next-line primer/spacing
+  padding: 7px;
+  line-height: $lh-condensed-ultra;
+  vertical-align: middle;
+
+  &.btn-invisible {
+    padding: $spacer-2;
+  }
+}

--- a/src/buttons/misc.scss
+++ b/src/buttons/misc.scss
@@ -72,7 +72,7 @@
   }
 }
 
-// Octicon button
+// Octicon button (deprecated)
 //
 // Icon-only buttons
 .btn-octicon {


### PR DESCRIPTION
From https://github.com/github/primer/issues/253

I'm proposing a new `btn-icon` class that will be used with `btn` and `btn-${variant}`. This  will create a square (32x32) icon-only button that follows the button variants.


https://user-images.githubusercontent.com/11280312/144660074-7ff523ff-84f0-4755-aab5-bf90e11a1001.mov


/cc @primer/css-reviewers
