### PR TITLE
IconButton sizing

### DIFF
--- a/docs/src/stories/components/Button/Button.stories.jsx
+++ b/docs/src/stories/components/Button/Button.stories.jsx
@@ -116,6 +116,13 @@ export default {
       table: {
         category: 'Interactive'
       }
+    },
+    btnGroupItem: {
+      defaultValue: false,
+      control: {type: 'boolean'},
+      table: {
+        category: 'CSS'
+      }
     }
   }
 }
@@ -139,7 +146,8 @@ export const ButtonTemplate = ({
   selected,
   closeBtn,
   focusElement,
-  focusAllElements
+  focusAllElements,
+  btnGroupItem
 }) => (
   <>
     <button
@@ -150,7 +158,8 @@ export const ButtonTemplate = ({
         size && `${size}`,
         fullWidth && 'btn-block',
         closeBtn && 'close-button',
-        focusAllElements && 'focus'
+        focusAllElements && 'focus',
+        btnGroupItem && 'BtnGroup-item'
       )}
       aria-selected={selected}
     >

--- a/docs/src/stories/components/IconButton/IconButton.stories.jsx
+++ b/docs/src/stories/components/IconButton/IconButton.stories.jsx
@@ -11,29 +11,72 @@ export default {
   argTypes: {
     variant: {
       options: [0, 1, 2, 3], // iterator
-      mapping: [
-        null,
-        'btn-outline',
-        'btn-danger',
-        'btn-invisible'
-      ], // values
+      mapping: [null, 'btn-outline', 'btn-danger', 'btn-invisible'], // values
       control: {
-        type: 'select',
+        type: 'inline-radio',
         labels: ['default', 'outline', 'danger', 'invisible']
       },
       table: {
         category: 'CSS'
       }
     },
-    label: {
-      defaultValue: '<svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.75 2.5h12.5a.25.25 0 01.25.25v7.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25v-7.5a.25.25 0 01.25-.25zM14.25 1H1.75A1.75 1.75 0 000 2.75v7.5C0 11.216.784 12 1.75 12h3.727c-.1 1.041-.52 1.872-1.292 2.757A.75.75 0 004.75 16h6.5a.75.75 0 00.565-1.243c-.772-.885-1.193-1.716-1.292-2.757h3.727A1.75 1.75 0 0016 10.25v-7.5A1.75 1.75 0 0014.25 1zM9.018 12H6.982a5.72 5.72 0 01-.765 2.5h3.566a5.72 5.72 0 01-.765-2.5z"></path></svg>',
+    size: {
+      options: [0, 1, 2], // iterator
+      mapping: [null, 'btn--icon-sm', 'btn--icon-lg'], // values
+      control: {
+        type: 'inline-radio',
+        labels: ['default', 'small', 'large']
+      },
+      table: {
+        category: 'CSS'
+      }
+    },
+    icon: {
+      defaultValue:
+        '<path fill-rule="evenodd" d="M1.75 2.5h12.5a.25.25 0 01.25.25v7.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25v-7.5a.25.25 0 01.25-.25zM14.25 1H1.75A1.75 1.75 0 000 2.75v7.5C0 11.216.784 12 1.75 12h3.727c-.1 1.041-.52 1.872-1.292 2.757A.75.75 0 004.75 16h6.5a.75.75 0 00.565-1.243c-.772-.885-1.193-1.716-1.292-2.757h3.727A1.75 1.75 0 0016 10.25v-7.5A1.75 1.75 0 0014.25 1zM9.018 12H6.982a5.72 5.72 0 01-.765 2.5h3.566a5.72 5.72 0 01-.765-2.5z"></path>',
       type: 'string',
-      name: 'label',
-      description: 'Paste [Octicon](https://primer.style/octicons/) in control field',
+      name: 'icon',
+      description: 'Paste [Octicon path](https://primer.style/octicons/) in control field',
       table: {
         category: 'HTML'
       }
     },
+    ariaLabel: {
+      type: 'string',
+      name: 'ariaLabel',
+      description: 'Button description - required',
+      table: {
+        category: 'HTML'
+      }
+    },
+    disabled: {
+      defaultValue: false,
+      control: {type: 'boolean'},
+      table: {
+        category: 'Interactive'
+      }
+    },
+    btnGroupItem: {
+      defaultValue: false,
+      control: {type: 'boolean'},
+      table: {
+        category: 'CSS'
+      }
+    },
+    focusElement: {
+      control: {type: 'boolean'},
+      description: 'set focus on one element',
+      table: {
+        category: 'Interactive'
+      }
+    },
+    focusAllElements: {
+      control: {type: 'boolean'},
+      description: 'set focus on all elements for viewing in all themes',
+      table: {
+        category: 'Interactive'
+      }
+    }
   }
 }
 
@@ -45,23 +88,33 @@ const focusMethod = function getFocus() {
 }
 
 export const IconButtonTemplate = ({
-  label,
+  icon,
   variant,
   disabled,
   selected,
   focusElement,
+  ariaLabel,
+  size,
+  btnGroupItem
 }) => (
   <>
     <button
       disabled={disabled}
-      className={clsx(
-        'btn',
-        'btn-icon',
-        variant && `${variant}`,
-      )}
+      className={clsx('btn', 'btn--icon', variant && `${variant}`, size && `${size}`, btnGroupItem && 'BtnGroup-item')}
       aria-selected={selected}
+      aria-label={ariaLabel}
+      disabled={disabled}
     >
-      <span className="" dangerouslySetInnerHTML={{__html: label}} />
+      <svg
+        class="octicon"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        width="16"
+        height="16"
+        aria-hidden="true"
+        focusable="false"
+        dangerouslySetInnerHTML={{__html: icon}}
+      />
     </button>
     {focusElement && focusMethod()}
   </>
@@ -70,5 +123,10 @@ export const IconButtonTemplate = ({
 export const Playground = IconButtonTemplate.bind({})
 Playground.args = {
   focusElement: false,
-  focusAllElements: false
+  focusAllElements: false,
+  ariaLabel: 'describe what this button does',
+  btnGroupItem: false,
+  disabled: false,
+  variant: 0,
+  size: 0
 }

--- a/docs/src/stories/components/IconButton/IconButtonFeatures.stories.jsx
+++ b/docs/src/stories/components/IconButton/IconButtonFeatures.stories.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import clsx from 'clsx'
+import {IconButtonTemplate} from './IconButton.stories'
+import {ButtonTemplate} from '../Button/Button.stories'
+
+export default {
+  title: 'Components/IconButton/Features'
+}
+
+// ButtonGroup needs a refactor, so this looks broken (but we should make it work in the future)
+export const ButtonGroup = ({}) => (
+  <div className="BtnGroup">
+    <ButtonTemplate label="Default button" btnGroupItem />
+    <IconButtonTemplate
+      btnGroupItem
+      icon={
+        '<path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"></path>'
+      }
+    />
+  </div>
+)
+ButtonGroup.storyName = 'Button Group: right'

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -321,13 +321,6 @@
   place-content: center;
 }
 
-.btn--icon-sm {
-  .octicon {
-    width: 14px;
-    height: 14px;
-  }
-}
-
 // desktop friendly sizing
 @media (hover: hover) and (pointer: fine) {
   .btn--icon {
@@ -338,6 +331,11 @@
   .btn--icon-sm {
     height: 28px;
     width: 28px;
+
+    .octicon {
+      width: 14px;
+      height: 14px;
+    }
   }
 
   .btn--icon-lg {

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -315,31 +315,33 @@
 // default mobile sizing
 .btn--icon {
   display: grid;
-  width: 48px;
-  height: 48px;
+  width: 32px;
+  height: 32px;
   padding: 0;
   place-content: center;
 }
 
+.btn--icon-sm {
+  width: 28px;
+  height: 28px;
+
+  .octicon {
+    width: 14px;
+    height: 14px;
+  }
+}
+
+.btn--icon-lg {
+  width: 40px;
+  height: 40px;
+}
+
 // desktop friendly sizing
-@media (hover: hover) and (pointer: fine) {
+@media (pointer: course) {
   .btn--icon {
-    width: 32px;
-    height: 32px;
-  }
-
-  .btn--icon-sm {
-    width: 28px;
-    height: 28px;
-
-    .octicon {
-      width: 14px;
-      height: 14px;
+    &::before {
+      @include minTouchTarget(48px, 48px);
+      background: deeppink !important;
     }
-  }
-
-  .btn--icon-lg {
-    width: 40px;
-    height: 40px;
   }
 }

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -24,7 +24,7 @@
 
   &:disabled,
   &.disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     cursor: default;
   }
 
@@ -84,14 +84,14 @@
   }
 
   &.selected,
-  &[aria-selected=true] {
+  &[aria-selected='true'] {
     background-color: var(--color-btn-selected-bg);
     box-shadow: var(--color-primer-shadow-inset);
   }
 
   &:disabled,
   &.disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     color: var(--color-primer-fg-disabled);
     background-color: var(--color-btn-bg);
     border-color: var(--color-btn-border);
@@ -127,14 +127,14 @@
 
   &:active,
   &.selected,
-  &[aria-selected=true] {
+  &[aria-selected='true'] {
     background-color: var(--color-btn-primary-selected-bg);
     box-shadow: var(--color-btn-primary-selected-shadow);
   }
 
   &:disabled,
   &.disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     color: var(--color-btn-primary-disabled-text);
     background-color: var(--color-btn-primary-disabled-bg);
     border-color: var(--color-btn-primary-disabled-border);
@@ -184,7 +184,7 @@
 
   &:active,
   &.selected,
-  &[aria-selected=true] {
+  &[aria-selected='true'] {
     color: var(--color-btn-outline-selected-text);
     background-color: var(--color-btn-outline-selected-bg);
     border-color: var(--color-btn-outline-selected-border);
@@ -193,7 +193,7 @@
 
   &:disabled,
   &.disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     color: var(--color-btn-outline-disabled-text);
     background-color: var(--color-btn-outline-disabled-bg);
     border-color: var(--color-btn-border);
@@ -242,7 +242,7 @@
 
   &:active,
   &.selected,
-  &[aria-selected=true] {
+  &[aria-selected='true'] {
     color: var(--color-btn-danger-selected-text);
     background-color: var(--color-btn-danger-selected-bg);
     border-color: var(--color-btn-danger-selected-border);
@@ -251,7 +251,7 @@
 
   &:disabled,
   &.disabled,
-  &[aria-disabled=true] {
+  &[aria-disabled='true'] {
     color: var(--color-btn-danger-disabled-text);
     background-color: var(--color-btn-danger-disabled-bg);
     border-color: var(--color-btn-border);
@@ -312,14 +312,36 @@
 }
 
 // Icon-only buttons
-.btn-icon {
-  display: inline-block;
-  // stylelint-disable-next-line primer/spacing
-  padding: 7px;
-  line-height: $lh-condensed-ultra;
-  vertical-align: middle;
+// default mobile sizing
+.btn--icon {
+  padding: 0;
+  height: 48px;
+  width: 48px;
+  display: grid;
+  place-content: center;
+}
 
-  &.btn-invisible {
-    padding: $spacer-2;
+.btn--icon-sm {
+  .octicon {
+    width: 14px;
+    height: 14px;
+  }
+}
+
+// desktop friendly sizing
+@media (hover: hover) and (pointer: fine) {
+  .btn--icon {
+    height: 32px;
+    width: 32px;
+  }
+
+  .btn--icon-sm {
+    height: 28px;
+    width: 28px;
+  }
+
+  .btn--icon-lg {
+    height: 40px;
+    width: 40px;
   }
 }

--- a/src/support/mixins/misc.scss
+++ b/src/support/mixins/misc.scss
@@ -24,3 +24,19 @@
     background-color: $border;
   }
 }
+
+// if min-width is undefined, return only min-height
+@mixin minTouchTarget($min-height: 48px, $min-width: '') {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  height: 100%;
+  min-height: $min-height;
+  content: '';
+  transform: translateX(-50%) translateY(-50%);
+
+  @if $min-width != '' {
+    min-width: $min-width;
+  }
+}


### PR DESCRIPTION
Some ideas around handling button sizing for IconButton. Since we already enforce `white-space: nowrap` we could consider changing our button sizing approach to use explicit `height` and `width` values (for square icon buttons) rather than `padding`. 

- These values should be tokenized as SCSS vars (and eventually primitives?) to be shared with other components, like form elements. For example, `input` sizing should probably match that of Button for form styling.
- I've set a media query checking for "desktop" (use of a mouse) to handle button sizing, forcing all buttons to be 48px on mobile. This is a bigger change and could easily be broken out into a followup where we address it for all Primer buttons (breaking change, refactor type project)

/cc @primer/css-reviewers
