### PR TITLE
[Layout component] Avoid resizing `main` while loading

### DIFF
--- a/.changeset/stale-pugs-eat.md
+++ b/.changeset/stale-pugs-eat.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+[Layout component] Avoid resizing `main` while loading

--- a/src/layout/layout.scss
+++ b/src/layout/layout.scss
@@ -1,4 +1,3 @@
-// stylelint-disable primer/no-undefined-vars
 // Layout component
 
 .Layout {

--- a/src/layout/layout.scss
+++ b/src/layout/layout.scss
@@ -24,7 +24,7 @@
   // Flow as column
 
   grid-auto-flow: column;
-  grid-template-columns: auto 0 1fr; // sidebar column, separator, main column
+  grid-template-columns: auto 0 minmax(0, calc(100% - var(--Layout-sidebar-width) - var(--Layout-gutter))); // sidebar column, separator, main column
   // stylelint-disable-next-line primer/no-undefined-vars
   grid-gap: var(--Layout-gutter);
 
@@ -101,7 +101,7 @@
   }
 
   &.Layout--sidebarPosition-end {
-    grid-template-columns: 1fr 0 auto;
+    grid-template-columns: minmax(0, calc(100% - var(--Layout-sidebar-width) - var(--Layout-gutter))) 0 auto;
 
     .Layout-main {
       grid-column: 1;


### PR DESCRIPTION
This quick fix makes sure the alpha `Layout` component doesn't render the `main` column at full width while the page is loading.

/cc @jonrohan 