### PR TITLE
Add `Header-divider`

### DIFF
--- a/docs/content/components/header.md
+++ b/docs/content/components/header.md
@@ -102,3 +102,19 @@ Add the `.Header-link` class to any anchor tags in the header to give them consi
   </div>
 </div>
 ```
+
+## Header-divider
+
+Add a `.Header-divider` to separate links and creating a "breadcrumb like" navigation.
+
+```html live
+<div class="Header">
+  <div class="Header-item">
+    <a href="#" class="Header-link">primer</a>
+    <span class="Header-divider">/</span>
+    <a href="#" class="Header-link">css</a>
+    <span class="Header-divider">/</span>
+    <a href="#" class="Header-link">Pull requests</a>
+  </div>
+</div>
+```

--- a/src/header/header.scss
+++ b/src/header/header.scss
@@ -25,13 +25,20 @@
 .Header-link {
   font-weight: $font-weight-bold;
   color: var(--color-header-logo);
-  white-space: nowrap;
+  white-space: nowrap;🐷
 
   &:hover,
   &:focus {
     color: var(--color-header-text);
     text-decoration: none;
   }
+}
+
+.Header-divider {
+  color: var(--color-header-divider);
+  margin-left: $spacer-2;
+  margin-right: $spacer-2;
+  cursor: default;
 }
 
 .Header-input {


### PR DESCRIPTION
This adds a new `Header-divider`.

## Problem

GG (`github/github`) has a feature preview for the "compact header". It shows a breadcumbs-like navigation with `/` to separate links. Currently the [`Header`](https://primer.style/css/components/header) component doesn't have that option so the following utilities were used to ship that feature:

```html
<span class="cursor-default mx-2 color-fg-muted">/</span>
```

This worked fine until we added the "Light High Contrast" theme where the dividers [weren't visible anymore](https://github.com/github/design-infrastructure/discussions/1439#discussioncomment-1715832):

<img width="863" alt="Bildschirmfoto 2021-11-29 um 14 20 19" src="https://user-images.githubusercontent.com/2427008/143875241-a632a479-809f-4809-a735-ec07360d0a33.png">

## Solution

- [x] **In PP**: https://github.com/primer/primitives/pull/282
- **In PCCs**: 
    - Add a new `Header-divider` child that uses the `--color-header-divider` variable.
    - Also use `cursor-default` + `mx-2` so the utilities are not needed anymore.

![Screen Shot 2021-12-07 at 15 41 45](https://user-images.githubusercontent.com/378023/144981423-ca0001b3-d0bd-428d-9a8a-1bcd0be90629.png)

## Alternatives considered

### Option 1

We could just add a hack to GG like  

```css
.hx_Header-divider {
  color: var(--color-header-divider);
}
```

and then use it to replace `color-fg-muted`.

### Option 2

Or maybe we could use the [`Breadcrumbs`](https://primer.style/css/components/breadcrumb) component inside `Header`?
