### PR TITLE
Update pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,17 @@
-First, briefly describe your proposal in the title and delete this line.
+### What are you trying to accomplish?
 
-If your proposal fixes any issues, please list them below, then delete this line:
+<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->
 
--  Fixes: # (type an issue number after the # if applicable)
+### What approach did you choose and why?
 
-Finally, tell us more about the change here, in the description.
+<!-- Here you can explain your approach and reasoning in more detail. -->
 
-/cc @primer/css-reviewers
+### What should reviewers focus on?
+
+<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->
+
+### Are additional changes needed?
+
+<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->
+
+- [ ] No, this PR should be ok to ship as is. 🚢 


### PR DESCRIPTION
This updates the `pull_request_template`.

In [Slack](https://github.slack.com/archives/C02PTFZQ5LZ/p1639026646042800) I was wondering how we can highlight if a PR needs additional changes when shipping to "dotcom". An option would be to include it in the Changeset, but thinking about it, I'm not sure anymore. Because the [release notes](https://github.com/primer/css/releases) might become too noisy with "dotcom" specific stuff.

So this PR changes the `pull_request_template`. It's pretty similar to dotcom's but also has this part:

```
### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [ ] No, this PR should be ok to ship as is. 🚢 
```

Downside is that whoever updates dotcom with a new Primer CSS version has to click through each PR in "Release Tracking" to see if any need additional changes, but it keeps the release notes noise free.