### PR TITLE
Support fractional viewport sizes for `max-width` media queries

### DIFF
--- a/.changeset/afraid-jars-occur.md
+++ b/.changeset/afraid-jars-occur.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Support fractional viewport sizes for `max-width` media queries

--- a/.changeset/serious-emus-worry.md
+++ b/.changeset/serious-emus-worry.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Support fractional viewport sizes for the `hide` utilities

--- a/src/layout/layout.scss
+++ b/src/layout/layout.scss
@@ -6,18 +6,18 @@
   --Layout-sidebar-width: #{map-get($sidebar-width, 'sm')};
   --Layout-gutter: 16px;
 
-  @media (max-width: calc(#{$width-sm} - 1px)) {
+  @media (max-width: calc(#{$width-sm} - 0.02px)) {
     @include flow-as-row;
   }
 
   &.Layout--flowRow-until-md {
-    @media (max-width: calc(#{$width-md} - 1px)) {
+    @media (max-width: calc(#{$width-md} - 0.02px)) {
       @include flow-as-row;
     }
   }
 
   &.Layout--flowRow-until-lg {
-    @media (max-width: calc(#{$width-lg} - 1px)) {
+    @media (max-width: calc(#{$width-lg} - 0.02px)) {
       @include flow-as-row;
     }
   }

--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -196,7 +196,7 @@
 // Responsive Popover
 // For < md it will show full-width anchored to the bottom
 
-@media (max-width: ($width-md - 1px)) {
+@media (max-width: ($width-md - 0.02px)) {
   .Popover {
     position: fixed;
     top: auto !important;

--- a/src/utilities/visibility-display.scss
+++ b/src/utilities/visibility-display.scss
@@ -14,19 +14,19 @@
 
 // Hide utilities for each breakpoint
 // Each hide utility only applies to one breakpoint range.
-@media (max-width: $width-sm - 1px) {
+@media (max-width: $width-sm - 0.02px) {
   .hide-sm {
     display: none !important;
   }
 }
 
-@media (min-width: $width-sm) and (max-width: $width-md - 1px) {
+@media (min-width: $width-sm) and (max-width: $width-md - 0.02px) {
   .hide-md {
     display: none !important;
   }
 }
 
-@media (min-width: $width-md) and (max-width: $width-lg - 1px) {
+@media (min-width: $width-md) and (max-width: $width-lg - 0.02px) {
   .hide-lg {
     display: none !important;
   }


### PR DESCRIPTION
### What are you trying to accomplish?

This came up in https://github.com/primer/css/pull/1737#discussion_r768182848 and adds support for "fractional viewport sizes" where we use `max-width` media queries. Like for the [`hide` utilities](https://primer.style/css/utilities/layout#responsive-hide).

### What approach did you choose and why?

Using `- 0.02px` instead of `- 1px` should add better support for hi-dpi screens or zooming. From https://www.w3.org/TR/mediaqueries-4/#mq-min-max

> the possibility of fractional viewport sizes which can occur as a result of non-integer pixel densities (e.g. on high-dpi displays or as a result of zooming/scaling)

In case you're wondering why `- 0.02px` and not `- 0.01px`:

> // Uses 0.02px rather than 0.01px to work around a current rounding bug in Safari.
> // See https://bugs.webkit.org/show_bug.cgi?id=178261

### What should reviewers focus on?

Should this rather be a variable? How should we call it?

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 
