### PR TITLE
feat: changes background of input field so contrast w placeholder tex…

### DIFF
--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -70,11 +70,7 @@ textarea.form-control {
 
 // Inputs with contrast for easy light gray backgrounds against white.
 .input-contrast {
-  background-color: var(--color-canvas-inset);
-
-  &:focus {
-    background-color: var(--color-canvas-default);
-  }
+  background-color: var(--color-canvas-default);
 }
 
 // Custom styling for HTML5 validation bubbles (WebKit only)


### PR DESCRIPTION
…t can be higher

### What are you trying to accomplish?

In the course our accessibility audit, we found the contrast between input background and placeholder text to be too low. See https://github.com/github/github/issues/194694.

### What approach did you choose and why?

Design suggested changing the background color.

### What should reviewers focus on?

n/a

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 
