### PR TITLE
Bump primer/primitives to `7.4.0`

### DIFF
--- a/.changeset/beige-hairs-jam.md
+++ b/.changeset/beige-hairs-jam.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Bump primer/primitives to `7.4.0`

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "storybook": "cd docs && yarn && yarn storybook"
   },
   "dependencies": {
-    "@primer/primitives": "^7.2.0"
+    "@primer/primitives": "^7.4.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,10 +966,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@primer/primitives@^7.2.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.3.0.tgz#8e362465fa641ae8c840205e3c296635279c5786"
-  integrity sha512-A8iG4wL7jaSKWYnV/47IEsnNrKM4ZKgcFQba1rvOmuXBdCugmK3Iw/iskSy/CworC+rU/3fy5Z54hvilRxGM1w==
+"@primer/primitives@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.4.0.tgz#75df54a80233a432b687c0e3010e4be6bd60a82d"
+  integrity sha512-gD6yHXN7YKox/bdUNgxhoSS/WXZVaORK1r4dOAyTrdoPrLV/ucIfRInPyVcTF+Mqr0zcTFJtiMtuA5Y8CSyOEg==
 
 "@primer/stylelint-config@12.2.0":
   version "12.2.0"


### PR DESCRIPTION
### What are you trying to accomplish?

This bumps primer/primitives to [`7.4.0`](https://github.com/primer/primitives/pull/286)

### What approach did you choose and why?

`yarn add @primer/primitives@^7.4.0`

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢  The new variables added will be used in https://github.com/primer/css/pull/1830.
