### PR TITLE
ActionList item outlines for high contrast theme

### DIFF
--- a/.changeset/few-mice-scream.md
+++ b/.changeset/few-mice-scream.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+ActionList item outlines for high contrast theme

--- a/.changeset/few-mice-scream.md
+++ b/.changeset/few-mice-scream.md
@@ -2,4 +2,4 @@
 "@primer/css": patch
 ---
 
-ActionList item outlines for high contrast theme
+ActionList item outlines for high contrast theme 

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -240,7 +240,8 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition:
+        visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -34,14 +34,28 @@
   }
 
   // only hover li without list as children
-  &:not(.ActionList-item--hasSubItem) {
+  &:not(.ActionList-item--hasSubItem),
+  // target contents of first child li if sub-item (li wraps item label + nested ul)
+  &.ActionList-item--hasSubItem > .ActionList-content {
     &:hover {
       cursor: pointer;
       background-color: var(--color-action-list-item-default-hover-bg);
+
+      // stylelint-disable-next-line selector-max-specificity
+      &:not(.ActionList-item--navActive) {
+        outline: $border-style $border-width var(--color-action-list-item-default-hover-border);
+        outline-offset: -$border-width;
+      }
     }
 
     &:active {
       background: var(--color-action-list-item-default-active-bg);
+
+      // stylelint-disable-next-line selector-max-specificity
+      &:not(.ActionList-item--navActive) {
+        outline: $border-style $border-width var(--color-action-list-item-default-active-border);
+        outline-offset: -$border-width;
+      }
 
       @media screen and (prefers-reduced-motion: no-preference) {
         animation: ActionList-item-active-bg 4s forwards cubic-bezier(0.33, 1, 0.68, 1);
@@ -49,13 +63,13 @@
 
       // stylelint-disable primer/box-shadow
       @keyframes ActionList-item-active-bg {
-        // stylelint-disable-next-line max-nesting-depth
+        // stylelint-disable-next-line max-nesting-depth, selector-max-specificity
         50% {
           box-shadow: inset 0 0 0 rgba(#000, 0.04);
           transform: scale(1);
         }
 
-        // stylelint-disable-next-line max-nesting-depth
+        // stylelint-disable-next-line max-nesting-depth, selector-max-specificity
         100% {
           box-shadow: inset 0 3px 9px rgba(#000, 0.04);
           transform: scale(0.97);
@@ -67,21 +81,10 @@
     &:hover,
     &:active {
       // hide dividers
-      // stylelint-disable-next-line selector-max-specificity
+      // stylelint-disable-next-line selector-max-specificity, selector-max-compound-selectors
       .ActionList-item-label::before,
       + .ActionList-item .ActionList-item-label::before {
         visibility: hidden;
-      }
-    }
-  }
-
-  // target contents of li if sub-item (li wraps item label + nested ul)
-  // collapse styles here
-  &.ActionList-item--hasSubItem {
-    // first child
-    > .ActionList-content {
-      &:hover {
-        background-color: var(--color-action-list-item-default-hover-bg);
       }
     }
   }
@@ -237,8 +240,7 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition:
-        visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -43,8 +43,11 @@
 
       // stylelint-disable-next-line selector-max-specificity
       &:not(.ActionList-item--navActive) {
+        // Support for "Windows high contrast mode"
+        outline: $border-style $border-width transparent;
+        outline-offset: -$border-width;
         // stylelint-disable-next-line primer/box-shadow
-        box-shadow: inset 0 0 0 $border-width var(--color-action-list-item-default-active-border);
+        box-shadow: inset 0 0 0 2px var(--color-action-list-item-default-active-border);
       }
     }
 
@@ -53,8 +56,11 @@
 
       // stylelint-disable-next-line selector-max-specificity
       &:not(.ActionList-item--navActive) {
+        // Support for "Windows high contrast mode"
+        outline: $border-style $border-width transparent;
+        outline-offset: -$border-width;
         // stylelint-disable-next-line primer/box-shadow
-        box-shadow: inset 0 0 0 $border-width var(--color-action-list-item-default-active-border);
+        box-shadow: inset 0 0 0 2px var(--color-action-list-item-default-active-border);
       }
 
       @media screen and (prefers-reduced-motion: no-preference) {
@@ -65,13 +71,13 @@
       @keyframes ActionList-item-active-bg {
         // stylelint-disable-next-line max-nesting-depth, selector-max-specificity
         50% {
-          box-shadow: inset 0 0 0 rgba(var(--color-fg-default), 0.04);
+          // this could work if primitive supported rgb (not valid right now)
+          // box-shadow: inset 0px 2px 12px 6px rgba(var(--color-canvas-default), 0.4), inset 0px 0px 0px 2px var(--color-action-list-item-default-active-border)
           transform: scale(1);
         }
 
         // stylelint-disable-next-line max-nesting-depth, selector-max-specificity
         100% {
-          box-shadow: inset 0 3px 9px rgba(var(--color-fg-default), 0.04);
           transform: scale(0.97);
         }
       }
@@ -240,7 +246,9 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition: visibility 0 linear $actionList-item-checkmark-transition-timing, opacity $actionList-item-checkmark-transition-timing;
+      transition:
+        visibility 0 linear $actionList-item-checkmark-transition-timing,
+        opacity $actionList-item-checkmark-transition-timing;
     }
 
     // singleselect checkmark

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -285,7 +285,8 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition:
+        visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -53,7 +53,7 @@
 
       // stylelint-disable-next-line selector-max-specificity
       &:not(.ActionList-item--navActive) {
-        outline: $border-style $border-width var(--color-action-list-item-default-active-border);
+        box-shadow: inset 0 0 0 $border-width var(--color-action-list-item-default-active-border);
         outline-offset: -$border-width;
       }
 

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -73,8 +73,7 @@
 
       @keyframes ActionList-item-active-bg {
         50% {
-          // this could work if primitive supported rgb (not valid right now)
-          // box-shadow: inset 0px 2px 12px 6px rgba(var(--color-canvas-default), 0.4), inset 0px 0px 0px 2px var(--color-action-list-item-default-active-border)
+          box-shadow: inset 0px 2px 12px 6px rgba(var(--color-canvas-default), 0.4);
           transform: scale(1);
         }
 
@@ -285,8 +284,7 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition:
-        visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -43,8 +43,7 @@
 
       // stylelint-disable-next-line selector-max-specificity
       &:not(.ActionList-item--navActive) {
-        outline: $border-style $border-width var(--color-action-list-item-default-hover-border);
-        outline-offset: -$border-width;
+        box-shadow: inset 0 0 0 $border-width var(--color-action-list-item-default-active-border);
       }
     }
 
@@ -54,7 +53,6 @@
       // stylelint-disable-next-line selector-max-specificity
       &:not(.ActionList-item--navActive) {
         box-shadow: inset 0 0 0 $border-width var(--color-action-list-item-default-active-border);
-        outline-offset: -$border-width;
       }
 
       @media screen and (prefers-reduced-motion: no-preference) {
@@ -240,8 +238,7 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition:
-        visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -1,4 +1,4 @@
-// stylelint-disable max-nesting-depth, selector-max-specificity
+// stylelint-disable max-nesting-depth, selector-max-specificity, selector-max-compound-selectors
 
 @mixin focusOutline {
   position: relative;
@@ -38,18 +38,27 @@
   }
 
   // only hover li without list as children
-  &:not(.ActionList-item--hasSubItem) {
+  &:not(.ActionList-item--hasSubItem),
+  // target contents of first child li if sub-item (li wraps item label + nested ul)
+  &.ActionList-item--hasSubItem > .ActionList-content {
     @media (hover: hover) {
       &:hover {
         cursor: pointer;
         background-color: var(--color-action-list-item-default-hover-bg);
+
+        &:not(.ActionList-item--navActive) {
+          // Support for "Windows high contrast mode"
+          outline: $border-style $border-width transparent;
+          outline-offset: -$border-width;
+          // stylelint-disable-next-line primer/box-shadow
+          box-shadow: inset 0 0 0 2px var(--color-action-list-item-default-active-border);
+        }
       }
     }
 
     &:active {
       background: var(--color-action-list-item-default-active-bg);
 
-      // stylelint-disable-next-line selector-max-specificity
       &:not(.ActionList-item--navActive) {
         // Support for "Windows high contrast mode" https://sarahmhigley.com/writing/whcm-quick-tips/
         outline: $border-style $border-width transparent;
@@ -73,7 +82,6 @@
           transform: scale(0.97);
         }
       }
-      // stylelint-enable primer/box-shadow
     }
 
     // hide dividers
@@ -161,7 +169,6 @@
 
     // has 16px leading visual
     .ActionList-content--visual16 + .ActionList--subGroup {
-      // stylelint-disable-next-line selector-max-compound-selectors
       .ActionList-content {
         padding-left: $spacer-5;
       }
@@ -169,7 +176,6 @@
 
     // has 20px leading visual
     .ActionList-content--visual20 + .ActionList--subGroup {
-      // stylelint-disable-next-line selector-max-compound-selectors
       .ActionList-content {
         padding-left: $spacer-2 * 4.5; // 36px
       }
@@ -177,7 +183,6 @@
 
     // has 24px leading visual
     .ActionList-content--visual24 + .ActionList--subGroup {
-      // stylelint-disable-next-line selector-max-compound-selectors
       .ActionList-content {
         padding-left: $spacer-6;
       }
@@ -280,7 +285,8 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition:
+        visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -43,6 +43,7 @@
 
       // stylelint-disable-next-line selector-max-specificity
       &:not(.ActionList-item--navActive) {
+        // stylelint-disable-next-line primer/box-shadow
         box-shadow: inset 0 0 0 $border-width var(--color-action-list-item-default-active-border);
       }
     }
@@ -52,6 +53,7 @@
 
       // stylelint-disable-next-line selector-max-specificity
       &:not(.ActionList-item--navActive) {
+        // stylelint-disable-next-line primer/box-shadow
         box-shadow: inset 0 0 0 $border-width var(--color-action-list-item-default-active-border);
       }
 
@@ -63,13 +65,13 @@
       @keyframes ActionList-item-active-bg {
         // stylelint-disable-next-line max-nesting-depth, selector-max-specificity
         50% {
-          box-shadow: inset 0 0 0 rgba(#000, 0.04);
+          box-shadow: inset 0 0 0 rgba(var(--color-fg-default), 0.04);
           transform: scale(1);
         }
 
         // stylelint-disable-next-line max-nesting-depth, selector-max-specificity
         100% {
-          box-shadow: inset 0 3px 9px rgba(#000, 0.04);
+          box-shadow: inset 0 3px 9px rgba(var(--color-fg-default), 0.04);
           transform: scale(0.97);
         }
       }
@@ -238,8 +240,7 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
-        opacity $actionList-item-checkmark-transition-timing;
+      transition: visibility 0 linear $actionList-item-checkmark-transition-timing, opacity $actionList-item-checkmark-transition-timing;
     }
 
     // singleselect checkmark

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -56,7 +56,7 @@
 
       // stylelint-disable-next-line selector-max-specificity
       &:not(.ActionList-item--navActive) {
-        // Support for "Windows high contrast mode"
+        // Support for "Windows high contrast mode" https://sarahmhigley.com/writing/whcm-quick-tips/
         outline: $border-style $border-width transparent;
         outline-offset: -$border-width;
         // stylelint-disable-next-line primer/box-shadow

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -73,7 +73,8 @@
 
       @keyframes ActionList-item-active-bg {
         50% {
-          box-shadow: inset 0px 2px 12px 6px rgba(var(--color-canvas-default), 0.4);
+          // stylelint-disable-next-line primer/box-shadow
+          box-shadow: inset 0 2px 12px 6px rgba(var(--color-canvas-default), 0.4);
           transform: scale(1);
         }
 

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -67,7 +67,6 @@
         animation: ActionList-item-active-bg 4s forwards cubic-bezier(0.33, 1, 0.68, 1);
       }
 
-      // stylelint-disable primer/box-shadow
       @keyframes ActionList-item-active-bg {
         // stylelint-disable-next-line max-nesting-depth, selector-max-specificity
         50% {


### PR DESCRIPTION
### What are you trying to accomplish?

This adds a few more improvements to the `ActionList`, mainly:

- [x] Improve `:hover` and `:active` state for the "Light high contrast" theme.
    - Addresses https://github.com/github/design-infrastructure/discussions/1439#discussioncomment-1805470.

### What approach did you choose and why?

- There is now an `outline` for `:hover/:active` that is `transparent` in most themes, except for the "high contrast" themes. 

### What should reviewers focus on?

- We didn't use a `border` for the `:hover/:active` state to not have to change any sizes. Downside is that in Safari the rounded corners are missing.
- The addition of a background color will overlay the vertical connections for tree-view. Is this okay, or do we need to address with a fix?
![image](https://user-images.githubusercontent.com/18661030/147121615-530e6001-17a7-4628-8d8d-1a9ff86e76de.png)

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- ⚠️ Yes, when updating dotcom, `primer/primitives` needs to be bumped to [`7.4.0`](https://github.com/primer/primitives/pull/286) to include the [new variables](https://github.com/primer/primitives/pull/283) used in this PR.
