### PR TITLE
[ActionList] Add hover to `aria-current` elements and other micro interactions

### DIFF
--- a/.changeset/six-avocados-promise.md
+++ b/.changeset/six-avocados-promise.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+[ActionList] Add hover to `aria-current` elements and other micro interactions

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -186,7 +186,7 @@
 
     .ActionList--subGroup {
       visibility: visible;
-      overflow: auto;
+      overflow: visible;
       height: auto;
       opacity: 1;
       transform: translateY(0);

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -98,6 +98,10 @@
     &:not(.ActionList-item--danger) {
       background: var(--color-action-list-item-default-selected-bg);
 
+      &:hover {
+        background-color: var(--color-action-list-item-default-hover-bg);
+      }
+
       // stylelint-disable-next-line selector-max-specificity
       &::before,
       + .ActionList-item::before {
@@ -117,6 +121,12 @@
   // target items inside expanded subgroups
   &[aria-expanded] {
     .ActionList--subGroup {
+      transition: opacity 160ms cubic-bezier(0.25, 1, 0.5, 1), transform 160ms cubic-bezier(0.25, 1, 0.5, 1);
+
+      @media (prefers-reduced-motion) {
+        transition: none;
+      }
+
       .ActionList-content {
         padding-left: $spacer-4;
       }
@@ -154,7 +164,11 @@
     }
 
     .ActionList--subGroup {
-      display: block;
+      visibility: visible;
+      overflow: auto;
+      height: auto;
+      opacity: 1;
+      transform: translateY(0);
     }
 
     &.ActionList-item--hasActiveSubItem {
@@ -172,7 +186,12 @@
     }
 
     .ActionList--subGroup {
-      display: none;
+      display: block;
+      visibility: hidden;
+      overflow: hidden;
+      height: 0;
+      opacity: 0;
+      transform: translateY(-$spacer-3);
     }
 
     // show active indicator on parent collapse if child is active

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -94,6 +94,8 @@
   &.ActionList-item--hasSubItem {
     // first child
     > .ActionList-content {
+      z-index: 1;
+
       @media (hover: hover) {
         &:hover {
           background-color: var(--color-action-list-item-default-hover-bg);

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -22,6 +22,8 @@
   list-style: none;
   background-color: transparent;
   border-radius: $border-radius;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 
   &:hover,
   &:active {
@@ -35,9 +37,11 @@
 
   // only hover li without list as children
   &:not(.ActionList-item--hasSubItem) {
-    &:hover {
-      cursor: pointer;
-      background-color: var(--color-action-list-item-default-hover-bg);
+    @media (hover: hover) {
+      &:hover {
+        cursor: pointer;
+        background-color: var(--color-action-list-item-default-hover-bg);
+      }
     }
 
     &:active {
@@ -63,10 +67,20 @@
       }
       // stylelint-enable primer/box-shadow
     }
+    
+    // hide dividers
 
-    &:hover,
+    @media (hover: hover) {
+      &:hover {
+        // stylelint-disable-next-line selector-max-specificity
+        .ActionList-item-label::before,
+        + .ActionList-item .ActionList-item-label::before {
+          visibility: hidden;
+        }
+      }
+    }
+
     &:active {
-      // hide dividers
       // stylelint-disable-next-line selector-max-specificity
       .ActionList-item-label::before,
       + .ActionList-item .ActionList-item-label::before {
@@ -80,8 +94,13 @@
   &.ActionList-item--hasSubItem {
     // first child
     > .ActionList-content {
-      &:hover {
-        background-color: var(--color-action-list-item-default-hover-bg);
+      @media (hover: hover) {
+        &:hover {
+          background-color: var(--color-action-list-item-default-hover-bg);
+        }
+      }
+      &:active {
+        background-color: var(--color-action-list-item-default-active-bg);
       }
     }
   }
@@ -98,8 +117,10 @@
     &:not(.ActionList-item--danger) {
       background: var(--color-action-list-item-default-selected-bg);
 
-      &:hover {
-        background-color: var(--color-action-list-item-default-hover-bg);
+      @media (hover: hover) {
+        &:hover {
+          background-color: var(--color-action-list-item-default-hover-bg);
+        }
       }
 
       // stylelint-disable-next-line selector-max-specificity
@@ -121,10 +142,8 @@
   // target items inside expanded subgroups
   &[aria-expanded] {
     .ActionList--subGroup {
-      transition: opacity 160ms cubic-bezier(0.25, 1, 0.5, 1), transform 160ms cubic-bezier(0.25, 1, 0.5, 1);
-
-      @media (prefers-reduced-motion) {
-        transition: none;
+      @media screen and (prefers-reduced-motion: no-preference) {
+        transition: opacity 160ms cubic-bezier(0.25, 1, 0.5, 1), transform 160ms cubic-bezier(0.25, 1, 0.5, 1);
       }
 
       .ActionList-content {
@@ -319,7 +338,7 @@
       color: var(--color-danger-fg);
     }
 
-    @media (hover: hover) and (pointer: fine) {
+    @media (hover: hover) {
       &:hover {
         background: var(--color-action-list-item-danger-hover-bg);
 
@@ -346,7 +365,7 @@
       fill: var(--color-primer-fg-disabled);
     }
 
-    @media (hover: hover) and (pointer: fine) {
+    @media (hover: hover) {
       &:hover {
         cursor: not-allowed;
         background-color: transparent;
@@ -371,6 +390,7 @@
   font-weight: $font-weight-normal;
   color: var(--color-fg-default);
   user-select: none;
+  touch-action: manipulation;
   border-radius: $border-radius;
   transition: $actionList-item-bg-transition;
   grid-template-rows: min-content;

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -1,3 +1,5 @@
+// stylelint-disable max-nesting-depth, selector-max-specificity
+
 @mixin focusOutline {
   position: relative;
   z-index: 1;
@@ -53,13 +55,11 @@
 
       // stylelint-disable primer/box-shadow
       @keyframes ActionList-item-active-bg {
-        // stylelint-disable-next-line max-nesting-depth
         50% {
           box-shadow: inset 0 0 0 rgba(#000, 0.04);
           transform: scale(1);
         }
 
-        // stylelint-disable-next-line max-nesting-depth
         100% {
           box-shadow: inset 0 3px 9px rgba(#000, 0.04);
           transform: scale(0.97);
@@ -67,21 +67,19 @@
       }
       // stylelint-enable primer/box-shadow
     }
-    
+
     // hide dividers
 
     @media (hover: hover) {
       &:hover {
-        // stylelint-disable-next-line selector-max-specificity
         .ActionList-item-label::before,
         + .ActionList-item .ActionList-item-label::before {
           visibility: hidden;
         }
       }
     }
-
+    // stylelint-disable-next-line no-duplicate-selectors
     &:active {
-      // stylelint-disable-next-line selector-max-specificity
       .ActionList-item-label::before,
       + .ActionList-item .ActionList-item-label::before {
         visibility: hidden;
@@ -101,6 +99,7 @@
           background-color: var(--color-action-list-item-default-hover-bg);
         }
       }
+
       &:active {
         background-color: var(--color-action-list-item-default-active-bg);
       }
@@ -125,7 +124,6 @@
         }
       }
 
-      // stylelint-disable-next-line selector-max-specificity
       &::before,
       + .ActionList-item::before {
         visibility: hidden;
@@ -155,7 +153,7 @@
 
     // has 16px leading visual
     .ActionList-content--visual16 + .ActionList--subGroup {
-      // stylelint-disable-next-line selector-max-compound-selectors, selector-max-specificity
+      // stylelint-disable-next-line selector-max-compound-selectors
       .ActionList-content {
         padding-left: $spacer-5;
       }
@@ -163,7 +161,7 @@
 
     // has 20px leading visual
     .ActionList-content--visual20 + .ActionList--subGroup {
-      // stylelint-disable-next-line selector-max-compound-selectors, selector-max-specificity
+      // stylelint-disable-next-line selector-max-compound-selectors
       .ActionList-content {
         padding-left: $spacer-2 * 4.5; // 36px
       }
@@ -171,7 +169,7 @@
 
     // has 24px leading visual
     .ActionList-content--visual24 + .ActionList--subGroup {
-      // stylelint-disable-next-line selector-max-compound-selectors, selector-max-specificity
+      // stylelint-disable-next-line selector-max-compound-selectors
       .ActionList-content {
         padding-left: $spacer-6;
       }
@@ -185,15 +183,14 @@
     }
 
     .ActionList--subGroup {
-      visibility: visible;
-      overflow: visible;
       height: auto;
+      overflow: visible;
+      visibility: visible;
       opacity: 1;
       transform: translateY(0);
     }
 
     &.ActionList-item--hasActiveSubItem {
-      // stylelint-disable-next-line selector-max-specificity
       > .ActionList-content > .ActionList-item-label {
         font-weight: $font-weight-bold;
       }
@@ -207,10 +204,9 @@
     }
 
     .ActionList--subGroup {
-      display: block;
-      visibility: hidden;
-      overflow: hidden;
       height: 0;
+      overflow: hidden;
+      visibility: hidden;
       opacity: 0;
       transform: translateY(-$spacer-3);
     }
@@ -223,7 +219,6 @@
         font-weight: $font-weight-bold;
       }
 
-      // stylelint-disable-next-line selector-max-specificity
       &::before,
       + .ActionList-item::before {
         visibility: hidden;
@@ -344,7 +339,6 @@
       &:hover {
         background: var(--color-action-list-item-danger-hover-bg);
 
-        // stylelint-disable-next-line max-nesting-depth
         .ActionList-item-label {
           color: var(--color-action-list-item-danger-hover-text);
         }


### PR DESCRIPTION
This PR started as a quick fix for https://github.com/github/github/discussions/201185#discussioncomment-1907903 (private for hubbers), but I've also touched a couple of other related micro interactions:

- [x] Add hover background for selected item (fixes https://github.com/github/github/discussions/201185#discussioncomment-1907903)
- [x] Makes `-webkit-tap-highlight-color` transparent — this removes a blueish highlight background on touch devices. It was particularly problematic on items with `subGroup` elements. Since `:active` states remain available on touch, users should see the regular gray background instead.

    <details>
    <summary>Preview</summary>

    > <img src="https://user-images.githubusercontent.com/293280/148474775-1f8b685a-31cb-4c75-b572-ddd9ea81e63a.png" alt="" width="375">
    
    > <img src="https://user-images.githubusercontent.com/293280/148474753-35d90d3b-5493-467d-8d8c-667580dc8a7a.png" alt="" width="375">
    
    </details> 

- [x] Add `touch-action: manipulation`. This should speed up the tap response on touch devices. [From MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action):
    > Enable panning and pinch zoom gestures, but disable additional non-standard gestures such as double-tap to zoom. Disabling double-tap to zoom removes the need for browsers to delay the generation of click events when the user taps the screen. This is an alias for "pan-x pan-y pinch-zoom" (which, for compatibility, is itself still valid).

- [x] Wrap `:hover` styles around `@media (hover: hover) { }` media queries, to avoid sticky hovers on touch.

- [x] Add "slide down" animation when expanding `subGroup`. This should hopefully improve the parsing when interacting with longer lists, and compensate the user expectation since we're no longer redirecting to the first sub-item right away. 
    > https://user-images.githubusercontent.com/293280/148475453-f01ef999-087b-49b2-8e7a-5aa75c8f3795.mov

- [x] Disable `max-nesting-depth` and `selector-max-specificity` stylelint rules in the file level, as, per design, the component requires more nuanced CSS selectors throughout.

### Are additional changes needed?

- [x] No, this PR should be ok to ship as is. 🚢 
