### PR TITLE
Storybook: Examples as the last item

### DIFF
--- a/docs/.storybook/preview.js
+++ b/docs/.storybook/preview.js
@@ -101,7 +101,19 @@ export const parameters = {
   html: {
     root: '#story' // target id for html tab (should be direct parent of <Story /> for easy copy/paste)
   },
-  viewport: {viewports: customViewports}
+  viewport: {viewports: customViewports},
+  options: {
+    storySort: (storyA, storyB) => {
+      if (storyA[1].title.includes('Examples')) {
+        // if both are stories, sort alphabetically
+        if (storyB[1].title.includes('Examples')) return -1
+        // if only 1 is a story, push the examples story down
+        else return 1
+      }
+      // sort as usual = alphabetical
+      return -1
+    }
+  }
 }
 
 const themes = [
@@ -131,9 +143,10 @@ export const decorators = [
   (Story, context) => {
     return (
       <div class="theme-wrap">
-        { themes.map((theme) => {
-            if (context.globals.theme === theme || context.globals.theme === 'all') {
-              return <div
+        {themes.map(theme => {
+          if (context.globals.theme === theme || context.globals.theme === 'all') {
+            return (
+              <div
                 id="story"
                 className="story-wrap"
                 data-color-mode={theme.startsWith('dark') ? 'dark' : 'light'}
@@ -142,8 +155,9 @@ export const decorators = [
               >
                 <Story {...context} />
               </div>
-            }
-          })}
+            )
+          }
+        })}
       </div>
     )
   }


### PR DESCRIPTION
Follow up on https://github.com/primer/css/pull/1879, adding a [sorting function](https://storybook.js.org/docs/react/writing-stories/naming-components-and-hierarchy#sorting-stories) to put `Examples` as the last section for any component.

![Examples is the last item in ActionList section](https://user-images.githubusercontent.com/1863771/150085849-f14e9f10-be93-4e1b-b5d7-e38ce178a1df.png)


