### PR TITLE
Make `pagination` responsive by default

### DIFF
--- a/.changeset/swift-actors-drum.md
+++ b/.changeset/swift-actors-drum.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Make `pagination` responsive by default

--- a/src/pagination/pagination.scss
+++ b/src/pagination/pagination.scss
@@ -90,17 +90,17 @@
 
 .pagination {
   // Hide everything by default
-  & > * {
+  > * {
     display: none;
   }
 
   // 0 -> sm
   // Only show [Previous] [Next]
 
-  & > :first-child,
-  & > :last-child,
-  & > .previous_page,
-  & > .next_page {
+  > :first-child,
+  > :last-child,
+  > .previous_page,
+  > .next_page {
     display: inline-block;
   }
 
@@ -108,10 +108,10 @@
   // Also show [first] [last] [current number] and [...]
 
   @include breakpoint(sm) {
-    & > :nth-child(2),
-    & > :nth-last-child(2),
-    & > .current,
-    & > .gap {
+    > :nth-child(2),
+    > :nth-last-child(2),
+    > .current,
+    > .gap {
       display: inline-block;
     }
   }
@@ -120,7 +120,7 @@
   // Show everything
 
   @include breakpoint(md) {
-    & > * {
+    > * {
       display: inline-block;
     }
   }

--- a/src/pagination/pagination.scss
+++ b/src/pagination/pagination.scss
@@ -86,6 +86,46 @@
   }
 }
 
+// Responsive
+
+.pagination {
+  // Hide everything by default
+  & > * {
+    display: none;
+  }
+
+  // 0 -> sm
+  // Only show [Previous] [Next]
+
+  & > :first-child,
+  & > :last-child,
+  & > .previous_page,
+  & > .next_page {
+    display: inline-block;
+  }
+
+  // sm -> md
+  // Also show [first] [last] [current number] and [...]
+
+  @include breakpoint(sm) {
+    & > :nth-child(2),
+    & > :nth-last-child(2),
+    & > .current,
+    & > .gap {
+      display: inline-block;
+    }
+  }
+
+  // md -> or more
+  // Show everything
+
+  @include breakpoint(md) {
+    & > * {
+      display: inline-block;
+    }
+  }
+}
+
 // Unified centered pagination across the site
 .paginate-container {
   margin-top: $spacer-3;

--- a/src/pagination/pagination.scss
+++ b/src/pagination/pagination.scss
@@ -84,11 +84,9 @@
       clip-path: polygon(6.2px 3.2px, 7.3px 3.2px, 11.5px 7.5px, 11.5px 8.5px, 7.3px 12.8px, 6.2px 11.7px, 9.9px 8px, 6.2px 4.3px, 6.2px 3.2px);
     }
   }
-}
 
-// Responsive
+  // Responsive
 
-.pagination {
   // Hide everything by default
   > * {
     display: none;

--- a/src/pagination/pagination.scss
+++ b/src/pagination/pagination.scss
@@ -4,7 +4,6 @@
   a,
   span,
   em {
-    display: inline-block;
     min-width: 32px;
     // stylelint-disable-next-line primer/spacing
     padding: 5px 10px;


### PR DESCRIPTION
### What are you trying to accomplish?

This closes https://github.com/github/primer/issues/537 by making the [`pagination`](https://primer.style/css/components/pagination#numbered-pagination) component responsive by default.

### What approach did you choose and why?

It uses the breakpoints to only show certain parts when the viewport is wide enough.

0 -> sm | sm -> md | md -> or wider
--- | ---  | ---
![image](https://user-images.githubusercontent.com/378023/72122416-26af5f00-33a1-11ea-934d-598cf7a4d1ec.png) | ![image](https://user-images.githubusercontent.com/378023/71514613-d33e0b00-28e2-11ea-9e94-e575237fd4f9.png) | ![image](https://user-images.githubusercontent.com/378023/71514622-e3ee8100-28e2-11ea-8f17-87bec2357b21.png)
Only shows `[Previous]` and `[Next]` | Also shows `[current number]` and `[...]` | Shows everything

### What should reviewers focus on?

The responsive styles added here have been in production for 1-2 years. It's currently scoped to [`.page-responsive`](https://github.com/github/github/blob/d48a2e8b243f1e0b427bba9071c0796fe5db2ccc/app/assets/stylesheets/hacks/hx_responsive-pagination.scss#L5) but I think it should be safe to make it responsive by default everywhere since most pages are responsive.

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- ⚠️ Yes, once this ships to dotcom we can remove [these styles](https://github.com/github/github/blob/d48a2e8b243f1e0b427bba9071c0796fe5db2ccc/app/assets/stylesheets/hacks/hx_responsive-pagination.scss) again.
