### PR TITLE
Add `theme-high-contrast` mixin

### DIFF
--- a/src/support/mixins/color-modes.scss
+++ b/src/support/mixins/color-modes.scss
@@ -111,7 +111,7 @@
 // Mixin for applying high contrast-specific styles
 //
 // Example
-// 
+//
 // border-color: linear-gradient(...);
 //
 // @include theme-high-contrast {
@@ -119,18 +119,18 @@
 // }
 
 @mixin theme-high-contrast() {
-  @at-root :is([data-color-mode="light"][data-light-theme$='high_contrast'], [data-color-mode="dark"][data-dark-theme$='high_contrast']) & {
+  @at-root :is([data-color-mode='light'][data-light-theme$='high_contrast'], [data-color-mode='dark'][data-dark-theme$='high_contrast']) & {
     @content;
   }
 
   @media (prefers-color-scheme: light) {
-    @at-root [data-color-mode="auto"][data-light-theme$='high_contrast'] & {
+    @at-root [data-color-mode='auto'][data-light-theme$='high_contrast'] & {
       @content;
     }
   }
 
   @media (prefers-color-scheme: dark) {
-    @at-root [data-color-mode="auto"][data-dark-theme$='high_contrast'] & {
+    @at-root [data-color-mode='auto'][data-dark-theme$='high_contrast'] & {
       @content;
     }
   }

--- a/src/support/mixins/color-modes.scss
+++ b/src/support/mixins/color-modes.scss
@@ -107,3 +107,31 @@
     }
   }
 }
+
+// Mixin for applying high contrast-specific styles
+//
+// Example
+// 
+// border-color: linear-gradient(...);
+//
+// @include theme-high-contrast {
+//   border-color: var(--color-border-default);
+// }
+
+@mixin theme-high-contrast() {
+  @at-root :is([data-color-mode="light"][data-light-theme$='high_contrast'], [data-color-mode="dark"][data-dark-theme$='high_contrast']) & {
+    @content;
+  }
+
+  @media (prefers-color-scheme: light) {
+    @at-root [data-color-mode="auto"][data-light-theme$='high_contrast'] & {
+      @content;
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    @at-root [data-color-mode="auto"][data-dark-theme$='high_contrast'] & {
+      @content;
+    }
+  }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

This should make it easier to add high-contrast specific stylesheets in components when relying on themable colors is not enough.

Application example:

```scss
.messaging-tray {
  // any rich visual that shouldn't appear in high contrast
  background: linear-gradient(to bottom, var(--color-border-default) var(--space-8), var(--color-canvas-inset));

  @include theme-high-contrast {
    background: var(--color-canvas-inset);
 }
}
```

### What should reviewers focus on?

I haven't touched theming-specific stylesheets before. Any naming convention/structure feedback is much appreciated 🙇 .

### Are additional changes needed?

- [ ] Question: Should this also include a [`forced-colors` media query](https://github.com/primer/css/blob/74d0438bd4dbaed447b553c5d3c8b945da282836/src/color-modes/native.scss#L13-L22)?