### PR TITLE
Fix `<sup><a>` from getting wrapped with `[ ]`

### DIFF
--- a/.changeset/ninety-moles-clap.md
+++ b/.changeset/ninety-moles-clap.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fix `<sup><a>` from getting wrapped with `[ ]`

--- a/src/markdown/footnotes.scss
+++ b/src/markdown/footnotes.scss
@@ -6,6 +6,7 @@
     &::before {
       content: '[';
     }
+
     &::after {
       content: ']';
     }

--- a/src/markdown/footnotes.scss
+++ b/src/markdown/footnotes.scss
@@ -1,37 +1,48 @@
 // stylelint-disable selector-max-type
 // stylelint-disable selector-max-compound-selectors
 
-.markdown-body .footnotes {
-  font-size: $h6-size;
-  color: var(--color-fg-muted);
-  border-top: $border;
-
-  ol {
-    padding-left: $spacer-3;
+.markdown-body {
+  [data-footnote-ref] {
+    &::before {
+      content: '[';
+    }
+    &::after {
+      content: ']';
+    }
   }
 
-  li {
-    position: relative;
-  }
+  .footnotes {
+    font-size: $h6-size;
+    color: var(--color-fg-muted);
+    border-top: $border;
 
-  li:target::before {
-    position: absolute;
-    top: -$spacer-2;
-    right: -$spacer-2;
-    bottom: -$spacer-2;
-    left: -$spacer-4;
-    pointer-events: none;
-    content: '';
-    // stylelint-disable-next-line primer/borders
-    border: 2px $border-style var(--color-accent-emphasis);
-    border-radius: $border-radius;
-  }
+    ol {
+      padding-left: $spacer-3;
+    }
 
-  li:target {
-    color: var(--color-fg-default);
-  }
+    li {
+      position: relative;
+    }
 
-  .data-footnote-backref g-emoji {
-    font-family: monospace;
+    li:target::before {
+      position: absolute;
+      top: -$spacer-2;
+      right: -$spacer-2;
+      bottom: -$spacer-2;
+      left: -$spacer-4;
+      pointer-events: none;
+      content: '';
+      // stylelint-disable-next-line primer/borders
+      border: 2px $border-style var(--color-accent-emphasis);
+      border-radius: $border-radius;
+    }
+
+    li:target {
+      color: var(--color-fg-default);
+    }
+
+    .data-footnote-backref g-emoji {
+      font-family: monospace;
+    }
   }
 }

--- a/src/markdown/markdown-body.scss
+++ b/src/markdown/markdown-body.scss
@@ -93,12 +93,4 @@
       margin-bottom: 0;
     }
   }
-
-  sup > a::before {
-    content: '[';
-  }
-
-  sup > a::after {
-    content: ']';
-  }
 }


### PR DESCRIPTION
### What are you trying to accomplish?

This fixes https://github.com/github/primer/issues/677.

Before | After
--- | ---
<img width="431" alt="Screen Shot 2022-02-02 at 20 51 28" src="https://user-images.githubusercontent.com/378023/152153116-e1533460-56ee-4049-a5d3-72c554c0929d.png"> | <img width="435" alt="Screen Shot 2022-02-02 at 21 16 01" src="https://user-images.githubusercontent.com/378023/152153125-e91e95a3-ded6-4840-bff1-675d4c4ab635.png">

Currently when adding 

```
Hi, <sup><a href="#">world</a></sup>
```

to a comment, the link is wrapped with `[ ]`: Hi, <sup><a href="#">world</a></sup>

### What approach did you choose and why?

Replace the loosely scoped styles for footnotes:

https://github.com/primer/css/blob/670149dc8d7896628d4773fc6a70a92ea31d3710/src/markdown/markdown-body.scss#L97-L103

with:

```scss
 [data-footnote-ref] {
    &::before {
      content: '[';
    }
    &::after {
      content: ']';
    }
  }
```

### What should reviewers focus on?

Diff is best viewed with "[whitespace hidden](https://github.com/primer/css/pull/1928/files?diff=split&w=1)".

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 
