### PR TITLE
Add Overlay CSS

### DIFF
--- a/docs/src/stories/components/Dialog/Dialog.stories.jsx
+++ b/docs/src/stories/components/Dialog/Dialog.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-// import clsx from 'clsx'
+import clsx from 'clsx'
 
 export default {
   title: 'Components/Dialog',
@@ -11,9 +11,9 @@ export default {
   argTypes: {
     title: {
       name: 'title',
-      type: { name: 'string', required: false },
+      type: {name: 'string', required: false},
       description: 'The heading element of the dialog',
-      defaultValue: "",
+      defaultValue: '',
       table: {
         category: 'HTML'
       }
@@ -22,7 +22,7 @@ export default {
       name: 'description',
       type: 'string',
       description: 'The sub-heading element of the dialog',
-      defaultValue: "",
+      defaultValue: '',
       table: {
         category: 'HTML'
       }
@@ -35,6 +35,78 @@ export default {
         category: 'Interactive'
       }
     },
+    width: {
+      options: [0, 1, 2, 3, 4], // iterator
+      mapping: [
+        'Overlay--width-small',
+        'Overlay--width-medium',
+        'Overlay--width-large',
+        'Overlay--width-xlarge',
+        'Overlay--width-xxlarge'
+      ], // values
+      control: {
+        type: 'inline-radio',
+        labels: ['small', 'medium', 'large', 'xlarge', 'xxlarge']
+      },
+      description: 'Width options: small: 256px, medium: 320px, large: 480px, xlarge: 640px, xxlarge: 960px',
+      table: {
+        category: 'CSS'
+      }
+    },
+    height: {
+      options: [0, 1, 2, 3, 4, 5], // iterator
+      mapping: [
+        'Overlay--height-auto',
+        'Overlay--height-xsmall',
+        'Overlay--height-small',
+        'Overlay--height-medium',
+        'Overlay--height-large',
+        'Overlay--height-xlarge'
+      ], // values
+      control: {
+        type: 'inline-radio',
+        labels: ['auto', 'xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge']
+      },
+      description:
+        'Height options: auto: adjusts to content, xsmall: 192px, small: 256px, medium: 320px, large: 432px, xlarge: 600px',
+      table: {
+        category: 'CSS'
+      }
+    },
+    showFooterDivider: {
+      control: {type: 'boolean'},
+      defaultValue: false,
+      description: 'Show dividers above footer',
+      table: {
+        category: 'CSS'
+      }
+    },
+    showHeaderDivider: {
+      control: {type: 'boolean'},
+      defaultValue: false,
+      description: 'Show dividers below header',
+      table: {
+        category: 'CSS'
+      }
+    },
+    headerRegion: {
+      control: {type: 'boolean'},
+      description:
+        'A header region may be used to provide context to the user by displaying a title, description, and offering an easy-to-escape route with a Close button. Headers may also provide ways for the user to interact with the content, such as with search and tabs.',
+      defaultValue: true,
+      table: {
+        category: 'HTML'
+      }
+    },
+    footerRegion: {
+      control: {type: 'boolean'},
+      description:
+        'The footer region may be used to show confirmation actions, navigation links, or other important elements that should appear outside of the content scrolling region.',
+      defaultValue: true,
+      table: {
+        category: 'HTML'
+      }
+    }
   }
 }
 
@@ -45,38 +117,74 @@ const focusMethod = function getFocus() {
 
 const toggleDialog = () => {
   const dialog = document.getElementById('modal-dialog-backdrop')
-  dialog.classList.toggle("modal-hide");
+  dialog.classList.toggle('Overlay-hidden')
   focusMethod()
 }
 
-
-export const DialogTemplate = ({title, description, focusElement}) => (
+export const DialogTemplate = ({
+  title,
+  description,
+  focusElement,
+  width,
+  height,
+  showFooterDivider,
+  showHeaderDivider,
+  headerRegion,
+  footerRegion
+}) => (
   <>
-    <button class="btn modal-button" onClick={toggleDialog}><span>Open dialog</span></button>
-    <div id="modal-dialog-backdrop" class="modal-dialog-backdrop modal-hide">
-      <modal-dialog class="modal-dialog " width="xlarge" height="auto" role="dialog" aria-labelledby="react-aria8832355892-4" aria-describedby="react-aria8832355892-5" data-focus-trap="active" open>
-        <header class="dialog-header">
-          <div class="header-container">
-            <div class="header-container-title">
-              <h1 id={`dialog-title`} class="title">{title}</h1>
-              {description &&
-                <h2 id={`dialog-description`} class="subtitle">{description}</h2>
-              }
+    <button class="btn modal-button" onClick={toggleDialog}>
+      <span>Open dialog</span>
+    </button>
+    <div
+      id="modal-dialog-backdrop"
+      className={clsx('Overlay-backdrop', 'Overlay-backdrop--positionCenter')}
+      role="dialog"
+      aria-labelledby="react-aria8832355892-4"
+      aria-describedby="react-aria8832355892-5"
+      data-focus-trap="active"
+      open
+    >
+      <div
+        className={clsx('Dialog', 'Overlay', width && `${width}`, height && `${height}`)}
+        data-focus-trap="active"
+        open
+      >
+        {headerRegion && (
+          <header className={clsx('Overlay-header', showHeaderDivider && 'Overlay-header--divided')}>
+            <div className="Overlay-header--contentWrap">
+              <div className="Overlay-header--titleWrap">
+                {title && (
+                  <h1 id={`dialog-title`} className="Overlay-title">
+                    {title}
+                  </h1>
+                )}
+                {description && (
+                  <h2 id={`dialog-description`} className="Overlay-description">
+                    {description}
+                  </h2>
+                )}
+              </div>
+              <button className="Overlay-closeButton" aria-label="Close" onClick={toggleDialog}>
+                <svg aria-hidden="true" viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+                  <path
+                    fill-rule="evenodd"
+                    d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"
+                  ></path>
+                </svg>
+              </button>
             </div>
-            <button class="close-button" aria-label="Close" onClick={toggleDialog}>
-              <svg aria-hidden="true" role="img" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" style={{"display": "inline-block", "user-select": "none", "vertical-align": "text-bottom", "overflow": "visible"}}>
-                <path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path>
-              </svg>
+          </header>
+        )}
+        <div className="Overlay-body">This is the body of the dialog</div>
+        {footerRegion && (
+          <footer className={clsx('Dialog-footer', 'Overlay-footer', showFooterDivider && 'Overlay-footer--divided')}>
+            <button class="btn" onClick={toggleDialog}>
+              <span>Continue</span>
             </button>
-          </div>
-        </header>
-        <div class="dialog-body">
-          This is the body of the dialog
-        </div>
-        <footer class="dialog-footer">
-          <button class="btn" onClick={toggleDialog}><span>Continue</span></button>
-        </footer>
-      </modal-dialog>
+          </footer>
+        )}
+      </div>
       {focusElement && focusMethod()}
     </div>
   </>
@@ -86,5 +194,5 @@ export const Playground = DialogTemplate.bind({})
 Playground.args = {
   title: 'This is the title of the dialog',
   description: 'This is the subtitle of the dialog',
-  focusElement: false,
+  focusElement: false
 }

--- a/docs/src/stories/ui-patterns/Overlay/Overlay.stories.jsx
+++ b/docs/src/stories/ui-patterns/Overlay/Overlay.stories.jsx
@@ -1,0 +1,223 @@
+import clsx from 'clsx'
+import React from 'react'
+
+export default {
+  title: 'Ui Patterns/Overlay',
+  parameters: {
+    layout: 'padded'
+  },
+
+  excludeStories: ['DialogTemplate'],
+  argTypes: {
+    title: {
+      name: 'title',
+      type: {name: 'string', required: false},
+      description: 'The heading element of the dialog',
+      defaultValue: '',
+      table: {
+        category: 'HTML'
+      }
+    },
+    description: {
+      name: 'description',
+      type: 'string',
+      description: 'The sub-heading element of the dialog',
+      defaultValue: '',
+      table: {
+        category: 'HTML'
+      }
+    },
+    focusElement: {
+      control: {type: 'boolean'},
+      description: 'focus the dialog',
+      defaultValue: false,
+      table: {
+        category: 'Interactive'
+      }
+    },
+    toggleOverlay: {
+      control: {type: 'boolean'},
+      description: 'show/hide overlay',
+      defaultValue: false,
+      table: {
+        category: 'Interactive'
+      }
+    },
+    width: {
+      options: [0, 1, 2, 3, 4], // iterator
+      mapping: [
+        'Overlay--width-small',
+        'Overlay--width-medium',
+        'Overlay--width-large',
+        'Overlay--width-xlarge',
+        'Overlay--width-xxlarge'
+      ], // values
+      control: {
+        type: 'inline-radio',
+        labels: ['small', 'medium', 'large', 'xlarge', 'xxlarge']
+      },
+      description: 'Width options: small: 256px, medium: 320px, large: 480px, xlarge: 640px, xxlarge: 960px',
+      table: {
+        category: 'CSS'
+      }
+    },
+    height: {
+      options: [0, 1, 2, 3, 4, 5], // iterator
+      mapping: [
+        'Overlay--height-auto',
+        'Overlay--height-xsmall',
+        'Overlay--height-small',
+        'Overlay--height-medium',
+        'Overlay--height-large',
+        'Overlay--height-xlarge'
+      ], // values
+      control: {
+        type: 'inline-radio',
+        labels: ['auto', 'xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge']
+      },
+      description:
+        'Height options: auto: adjusts to content, xsmall: 192px, small: 256px, medium: 320px, large: 432px, xlarge: 600px',
+      table: {
+        category: 'CSS'
+      }
+    },
+    position: {
+      options: [0, 1, 2, 3], // iterator
+      mapping: [null, 'Overlay-backdrop--positionCenter', 'Overlay-backdrop--positionBottom'], // values
+      control: {
+        type: 'inline-radio',
+        labels: ['none', 'center', 'bottom', 'side']
+      },
+      description: 'Positions overlay',
+      table: {
+        category: 'CSS'
+      },
+      defaultValue: 'Overlay--position-center'
+    },
+    headerRegion: {
+      control: {type: 'boolean'},
+      description:
+        'A header region may be used to provide context to the user by displaying a title, description, and offering an easy-to-escape route with a Close button. Headers may also provide ways for the user to interact with the content, such as with search and tabs.',
+      defaultValue: true,
+      table: {
+        category: 'HTML'
+      }
+    },
+    footerRegion: {
+      control: {type: 'boolean'},
+      description:
+        'The footer region may be used to show confirmation actions, navigation links, or other important elements that should appear outside of the content scrolling region.',
+      defaultValue: true,
+      table: {
+        category: 'HTML'
+      }
+    },
+    showFooterDivider: {
+      control: {type: 'boolean'},
+      defaultValue: false,
+      description: 'Show dividers above footer',
+      table: {
+        category: 'CSS'
+      }
+    },
+    showHeaderDivider: {
+      control: {type: 'boolean'},
+      defaultValue: false,
+      description: 'Show dividers below header',
+      table: {
+        category: 'CSS'
+      }
+    },
+    showInputField: {
+      control: {type: 'boolean'},
+      defaultValue: false,
+      description: 'Slot for input field',
+      table: {
+        category: 'CSS'
+      }
+    }
+  }
+}
+
+const focusMethod = function getFocus() {
+  const dialog = document.getElementsByTagName('modal-dialog')[0]
+  dialog.focus()
+}
+
+const toggleDialog = () => {
+  const dialog = document.getElementById('modal-dialog-backdrop')
+  dialog.classList.toggle('modal-hide')
+  focusMethod()
+}
+
+export const DialogTemplate = ({
+  title,
+  description,
+  focusElement,
+  toggleOverlay,
+  width,
+  height,
+  showFooterDivider,
+  showHeaderDivider,
+  headerRegion,
+  footerRegion,
+  position,
+  showInputField
+}) => (
+  <>
+    <div
+      id="modal-dialog-backdrop"
+      className={clsx(toggleOverlay && 'Overlay-hidden', 'Overlay-backdrop', position && `${position}`)}
+    >
+      <div className={clsx('Overlay', width && `${width}`, height && `${height}`)} data-focus-trap="active" open>
+        {headerRegion && (
+          <header className={clsx('Overlay-header', showHeaderDivider && 'Overlay-header--divided')}>
+            <div className="Overlay-header--contentWrap">
+              <div className="Overlay-header--titleWrap">
+                {title && (
+                  <h1 id={`dialog-title`} className="Overlay-title">
+                    {title}
+                  </h1>
+                )}
+                {description && (
+                  <h2 id={`dialog-description`} className="Overlay-description">
+                    {description}
+                  </h2>
+                )}
+              </div>
+              <button className="Overlay-closeButton" aria-label="Close" onClick={toggleDialog}>
+                <svg aria-hidden="true" viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+                  <path
+                    fill-rule="evenodd"
+                    d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"
+                  ></path>
+                </svg>
+              </button>
+            </div>
+            {showInputField && (
+              <div className="Overlay-header-inputField">
+                <input className="form-control input-block" />
+              </div>
+            )}
+          </header>
+        )}
+        <div className="Overlay-body">This is the body of the dialog</div>
+        {footerRegion && (
+          <footer className={clsx('Overlay-footer', showFooterDivider && 'Overlay-footer--divided')}>
+            <button class="btn" onClick={toggleDialog}>
+              <span>Continue</span>
+            </button>
+          </footer>
+        )}
+      </div>
+      {focusElement && focusMethod()}
+    </div>
+  </>
+)
+
+export const Playground = DialogTemplate.bind({})
+Playground.args = {
+  title: 'This is the title of the dialog',
+  description: 'This is the subtitle of the dialog',
+  focusElement: false
+}

--- a/src/core/index.scss
+++ b/src/core/index.scss
@@ -24,6 +24,8 @@
 @import '../pagination/index.scss';
 @import '../tooltips/index.scss';
 @import '../truncate/index.scss';
+@import '../dialog/index.scss';
+@import '../overlay/index.scss';
 
 // Utilities always go last so that they can override components
 @import '../utilities/index.scss';

--- a/src/dialog/dialog.scss
+++ b/src/dialog/dialog.scss
@@ -1,113 +1,10 @@
-.modal-hide {
-  display: none !important;
-}
-
-.modal-dialog-backdrop {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: var(--color-neutral-muted);
-  animation: 200ms cubic-bezier(0.33, 1, 0.68, 1) 0s 1 normal none running dialog-backdrop-appear;
-}
-
-.modal-dialog {
-  display: flex;
-  width: 640px;
-  min-width: 296px;
-  max-width: calc(100vw - 64px);
-  height: auto;
-  max-height: calc(100vh - 64px);
-  flex-direction: column;
-  background-color: var(--color-canvas-default);
-  // stylelint-disable-next-line primer/borders
-  border-radius: $border-radius-5;
-  box-shadow: var(--color-shadow-extra-large);
-  opacity: 1;
+.Dialog {
   animation: 200ms cubic-bezier(0.33, 1, 0.68, 1) 0s 1 normal none running overlay--dialog-appear;
+}
 
-  .dialog-header {
-    z-index: 1;
-    padding: $spacer-2;
-    border-bottom: $border-width $border-style var(--color-border-default);
-    flex-shrink: 0;
-
-    .header-container {
-      display: flex;
-    }
-  }
-
-  .header-container-title {
-    display: flex;
-    padding: $spacer-2;
-    flex-direction: column;
-    -webkit-box-flex: 1;
-    flex-grow: 1;
-
-    .title {
-      margin: $spacer-0;
-      font-size: $body-font-size;
-      font-weight: $font-weight-bold;
-    }
-
-    .subtitle {
-      margin: $spacer-1 $spacer-0 $spacer-0;
-      font-size: $font-size-small;
-      color: var(--color-fg-muted);
-    }
-  }
-
-  .close-button {
-    position: relative;
-    display: inline-block;
-    padding: $spacer-2;
-    font-family: inherit;
-    font-size: $body-font-size;
-    font-weight: $font-weight-bold;
-    line-height: $lh-normal;
-    color: var(--color-fg-muted);
-    text-align: center;
-    text-decoration: none;
-    white-space: nowrap;
-    vertical-align: middle;
-    cursor: pointer;
-    user-select: none;
-    background: transparent;
-    border: $border-width $border-style transparent;
-    // stylelint-disable-next-line primer/borders
-    border-radius: $border-radius-1;
-    box-shadow: none;
-    appearance: none;
-    align-self: flex-start;
-
-    &:hover,
-    &:focus {
-      background-color: var(--color-canvas-inset);
-      border: $border-width $border-style var(--color-border-muted);
-    }
-  }
-
-  .dialog-body {
-    padding: $spacer-3;
-    -webkit-box-flex: 1;
-    flex-grow: 1;
-    overflow: auto;
-  }
-
-  .dialog-footer {
-    z-index: 1;
-    display: flex;
-    padding: $spacer-3;
-    border-top: $border-width $border-style var(--color-border-default);
-    flex-flow: wrap;
-    -webkit-box-pack: end;
-    justify-content: flex-end;
-    flex-shrink: 0;
-  }
+.Dialog-footer {
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 @keyframes overlay--dialog-appear {
@@ -119,9 +16,4 @@
     opacity: 1;
     transform: scale(1);
   }
-}
-
-.Dialog-footer {
-  justify-content: flex-end;
-  gap: 8px;
 }

--- a/src/dialog/dialog.scss
+++ b/src/dialog/dialog.scss
@@ -109,3 +109,19 @@
     flex-shrink: 0;
   }
 }
+
+@keyframes overlay--dialog-appear {
+  0% {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.Dialog-footer {
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/src/dialog/dialog.scss
+++ b/src/dialog/dialog.scss
@@ -12,6 +12,7 @@
     opacity: 0;
     transform: scale(0.5);
   }
+
   100% {
     opacity: 1;
     transform: scale(1);

--- a/src/overlay/README.md
+++ b/src/overlay/README.md
@@ -1,0 +1,25 @@
+---
+bundle: "overlay"
+generated: true
+---
+
+# Primer CSS: `overlay` bundle
+
+## Usage
+
+Primer CSS source files are written in [SCSS]. To include this Primer CSS module in your own build, ensure that your `node_modules` directory is listed in your Sass include paths, then import it with:
+
+```scss
+@import "@primer/css/overlay/index.scss";
+```
+
+## Build
+
+The `@primer/css` npm package includes a standalone CSS build of this module in `dist/overlay.css`.
+
+## License
+
+[MIT](https://github.com/primer/css/blob/main/LICENSE) &copy; [GitHub](https://github.com/)
+
+
+[scss]: https://sass-lang.com/documentation/syntax#scss

--- a/src/overlay/index.scss
+++ b/src/overlay/index.scss
@@ -1,0 +1,2 @@
+@import '../support/index.scss';
+@import './overlay.scss';

--- a/src/overlay/overlay.scss
+++ b/src/overlay/overlay.scss
@@ -1,0 +1,182 @@
+.Overlay-hidden {
+  display: none !important;
+}
+
+.Overlay {
+  display: flex;
+  flex-direction: column;
+  min-width: 320px;
+  max-width: calc(100vw - 64px);
+  background-color: var(--color-canvas-default);
+  border-radius: 12px;
+  box-shadow: var(--color-shadow-extra-large);
+  opacity: 1;
+  aspect-ratio: 1.6 / 1;
+
+  &.Overlay--height-auto {
+    height: auto;
+  }
+
+  &.Overlay--height-xsmall {
+    height: 192px;
+  }
+
+  &.Overlay--height-small {
+    height: 256px;
+  }
+
+  &.Overlay--height-medium {
+    height: 320px;
+  }
+
+  &.Overlay--height-large {
+    height: 432px;
+  }
+
+  &.Overlay--height-xlarge {
+    height: 600px;
+  }
+
+  &.Overlay--width-small {
+    width: 256px;
+  }
+
+  &.Overlay--width-medium {
+    width: 320px;
+  }
+
+  &.Overlay--width-large {
+    width: 480px;
+  }
+
+  &.Overlay--width-xlarge {
+    width: 640px;
+  }
+
+  &.Overlay--width-xxlarge {
+    width: 960px;
+  }
+}
+
+.Overlay-header {
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+
+  &.Overlay-header--divided {
+    border-bottom: $border-width $border-style var(--color-border-default);
+  }
+
+  .Overlay-header--contentWrap {
+    display: flex;
+    gap: 8px;
+  }
+
+  .Overlay-header--titleWrap {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: 8px;
+    padding: 16px 0px 16px 16px;
+
+    .Overlay-title {
+      font-size: $body-font-size;
+      font-weight: $font-weight-bold;
+      margin: 0;
+    }
+
+    .Overlay-description {
+      font-size: $font-size-small;
+      font-weight: $font-weight-normal;
+      color: var(--color-fg-muted);
+      margin: 0;
+    }
+  }
+
+  .Overlay-header-inputField {
+    padding: 0px 8px 8px 8px;
+  }
+}
+
+// generic body content slot
+.Overlay-body {
+  flex-grow: 1;
+  padding: 16px 16px 0 16px;
+  overflow: auto;
+}
+
+// generic footer slot
+.Overlay-footer {
+  z-index: 1;
+  display: flex;
+  flex-direction: row;
+  flex-shrink: 0;
+  padding: 16px;
+
+  &.Overlay-footer--divided {
+    border-top: $border-width $border-style var(--color-border-default);
+  }
+}
+
+// TODO: replace with refactored IconButton
+.Overlay-closeButton {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  display: grid;
+  place-content: center;
+  position: relative;
+  cursor: pointer;
+  user-select: none;
+  background-color: transparent;
+  border-radius: $border-radius;
+  transition: 0.2s cubic-bezier(0.3, 0, 0.5, 1);
+  transition-property: color, background-color, border-color;
+  color: var(--color-fg-muted);
+  border: $border-width $border-style transparent;
+  align-self: flex-start;
+  margin-right: 8px;
+  margin-top: 8px;
+  flex-shrink: 0;
+
+  &:hover,
+  &:focus {
+    background-color: var(--color-btn-hover-bg);
+    border: $border-width $border-style var(--color-btn-hover-bg);
+  }
+}
+
+.Overlay-backdrop {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  background-color: var(--color-neutral-muted);
+  animation: 200ms cubic-bezier(0.33, 1, 0.68, 1) 0s 1 normal none running dialog-backdrop-appear;
+
+  @keyframes dialog-backdrop-appear {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+
+  &.Overlay-backdrop--positionCenter {
+    align-items: center;
+    justify-content: center;
+  }
+
+  &.Overlay-backdrop--positionBottom {
+    align-items: end;
+    justify-content: center;
+
+    .Overlay {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+}

--- a/src/overlay/overlay.scss
+++ b/src/overlay/overlay.scss
@@ -4,10 +4,11 @@
 
 .Overlay {
   display: flex;
-  flex-direction: column;
   min-width: 320px;
   max-width: calc(100vw - 64px);
+  flex-direction: column;
   background-color: var(--color-canvas-default);
+  // stylelint-disable-next-line primer/borders
   border-radius: 12px;
   box-shadow: var(--color-shadow-extra-large);
   opacity: 1;
@@ -74,34 +75,34 @@
 
   .Overlay-header--titleWrap {
     display: flex;
+    padding: $spacer-3 0 $spacer-3 $spacer-3;
     flex-direction: column;
     flex-grow: 1;
     gap: 8px;
-    padding: 16px 0px 16px 16px;
 
     .Overlay-title {
+      margin: 0;
       font-size: $body-font-size;
       font-weight: $font-weight-bold;
-      margin: 0;
     }
 
     .Overlay-description {
+      margin: 0;
       font-size: $font-size-small;
       font-weight: $font-weight-normal;
       color: var(--color-fg-muted);
-      margin: 0;
     }
   }
 
   .Overlay-header-inputField {
-    padding: 0px 8px 8px 8px;
+    padding: 0 $spacer-2 $spacer-2 $spacer-2;
   }
 }
 
 // generic body content slot
 .Overlay-body {
   flex-grow: 1;
-  padding: 16px 16px 0 16px;
+  padding: $spacer-3 $spacer-3 0 $spacer-3;
   overflow: auto;
 }
 
@@ -109,9 +110,9 @@
 .Overlay-footer {
   z-index: 1;
   display: flex;
+  padding: $spacer-3;
   flex-direction: row;
   flex-shrink: 0;
-  padding: 16px;
 
   &.Overlay-footer--divided {
     border-top: $border-width $border-style var(--color-border-default);
@@ -120,23 +121,23 @@
 
 // TODO: replace with refactored IconButton
 .Overlay-closeButton {
+  position: relative;
+  display: grid;
   width: 32px;
   height: 32px;
   padding: 0;
-  display: grid;
-  place-content: center;
-  position: relative;
+  margin-top: $spacer-2;
+  margin-right: $spacer-2;
+  color: var(--color-fg-muted);
   cursor: pointer;
   user-select: none;
   background-color: transparent;
+  border: $border-width $border-style transparent;
   border-radius: $border-radius;
   transition: 0.2s cubic-bezier(0.3, 0, 0.5, 1);
   transition-property: color, background-color, border-color;
-  color: var(--color-fg-muted);
-  border: $border-width $border-style transparent;
+  place-content: center;
   align-self: flex-start;
-  margin-right: 8px;
-  margin-top: 8px;
   flex-shrink: 0;
 
   &:hover,
@@ -160,6 +161,7 @@
     0% {
       opacity: 0;
     }
+
     100% {
       opacity: 1;
     }
@@ -175,8 +177,8 @@
     justify-content: center;
 
     .Overlay {
-      border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
+      border-bottom-left-radius: 0;
     }
   }
 }

--- a/src/product/index.scss
+++ b/src/product/index.scss
@@ -14,7 +14,6 @@
 @import '../avatars/index.scss';
 @import '../blankslate/index.scss';
 @import '../branch-name/index.scss';
-@import '../dialog/index.scss';
 @import '../dropdown/index.scss';
 @import '../header/index.scss';
 @import '../labels/index.scss';
@@ -25,4 +24,4 @@
 @import '../select-menu/index.scss';
 @import '../subhead/index.scss';
 @import '../timeline/index.scss';
-@import '../toasts/index.scss'
+@import '../toasts/index.scss';


### PR DESCRIPTION
This PR abstracts the common Overlay patterns into `overlay.scss` to be consumed by components like Dialog, Anchored overlay, and ActionMenu. This is "private" CSS and has been organized in Storybook under `UI Patterns`. 

To do:

- [ ] Replace px values with vars
- [ ] Finalize sizing (or at least pick a default to start/unblock Dialog)