### PR TITLE
TreeView single item nesting

### DIFF
--- a/.changeset/cold-ducks-deny.md
+++ b/.changeset/cold-ducks-deny.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+TreeView single item nesting

--- a/docs/src/stories/ui-patterns/ActionList/ActionListItem.stories.jsx
+++ b/docs/src/stories/ui-patterns/ActionList/ActionListItem.stories.jsx
@@ -167,6 +167,13 @@ export default {
         category: 'HTML'
       }
     },
+    treeItemSingleton: {
+      defaultValue: false,
+      control: {type: 'boolean'},
+      table: {
+        category: 'CSS'
+      }
+    },
     ariaDisabled: {
       defaultValue: false,
       control: {type: 'boolean'},
@@ -243,7 +250,8 @@ export const ListItemTemplate = ({
   treeitem,
   ariaSetSize,
   ariaPosInset,
-  menuItem
+  menuItem,
+  treeItemSingleton
 }) => {
   const [isChecked, itemIsChecked] = useToggle()
   const itemStyle = {
@@ -256,7 +264,8 @@ export const ListItemTemplate = ({
         ariaCurrent && 'ActionList-item--navActive',
         subItem && `ActionList-item--subItem`,
         hasSubItem && `ActionList-item--hasSubItem`,
-        variant && `${variant}`
+        variant && `${variant}`,
+        treeitem && treeItemSingleton && `ActionList-item--singleton`
       )}
       aria-level={ariaLevel ? `${ariaLevel}` : undefined}
       aria-setsize={ariaSetSize ? `${ariaSetSize}` : undefined}
@@ -466,5 +475,6 @@ Playground.decorators = [
   )
 ]
 Playground.args = {
-  truncateItem: false
+  truncateItem: false,
+  treeItemSingleton: false
 }

--- a/docs/src/stories/ui-patterns/ActionList/ActionListTree.stories.jsx
+++ b/docs/src/stories/ui-patterns/ActionList/ActionListTree.stories.jsx
@@ -50,6 +50,18 @@ const trailingVisual = `<svg aria-hidden="true" role="img" class="color-fg-atten
 export const ActionListTreeViewTemplate = ({showGroupIcon, showSubItemIcon, text, truncateItem}) => (
   <ListTemplate ariaLabel="Some description" role="tree" variant="ActionList--tree">
     <>
+      <ListItemTemplate
+        truncateItem={truncateItem}
+        ariaLevel="1"
+        ariaSetSize="1"
+        ariaPosInset="1"
+        treeitem
+        text={text}
+        href="/"
+        leadingVisual={showSubItemIcon && file}
+        trailingVisual={trailingVisual}
+        treeItemSingleton
+      />
       <TreeViewListItemCollapsibleTemplate
         text="level 1"
         leadingVisual={showGroupIcon && folder}
@@ -59,6 +71,7 @@ export const ActionListTreeViewTemplate = ({showGroupIcon, showSubItemIcon, text
         ariaPosInset="2"
         collapsePosition={0}
         containsSubItem
+        containsActiveSubItem
       >
         <ListTemplate listType="nested">
           <ListItemTemplate
@@ -150,6 +163,18 @@ export const ActionListTreeViewTemplate = ({showGroupIcon, showSubItemIcon, text
           </TreeViewListItemCollapsibleTemplate>
         </ListTemplate>
       </TreeViewListItemCollapsibleTemplate>
+      <ListItemTemplate
+        truncateItem={truncateItem}
+        ariaLevel="1"
+        ariaSetSize="1"
+        ariaPosInset="1"
+        treeitem
+        text={text}
+        href="/"
+        leadingVisual={showSubItemIcon && file}
+        trailingVisual={trailingVisual}
+        treeItemSingleton
+      />
     </>
   </ListTemplate>
 )

--- a/docs/src/stories/ui-patterns/ActionList/TreeViewListItemCollapsible.stories.jsx
+++ b/docs/src/stories/ui-patterns/ActionList/TreeViewListItemCollapsible.stories.jsx
@@ -157,6 +157,13 @@ export default {
       table: {
         category: 'HTML'
       }
+    },
+    containsActiveSubItem: {
+      defaultValue: false,
+      control: {type: 'boolean'},
+      table: {
+        category: 'CSS'
+      }
     }
   }
 }
@@ -177,7 +184,8 @@ export const TreeViewListItemCollapsibleTemplate = ({
   ariaSetSize,
   ariaPosInset,
   ariaLevel,
-  ariaDisabled
+  ariaDisabled,
+  containsActiveSubItem
 }) => {
   const [isCollapsed, itemIsCollapsed] = useToggle()
   const itemStyle = {
@@ -185,7 +193,11 @@ export const TreeViewListItemCollapsibleTemplate = ({
   }
   return (
     <li
-      className={clsx('ActionList-item', containsSubItem && `ActionList-item--hasSubItem`)}
+      className={clsx(
+        'ActionList-item',
+        containsSubItem && `ActionList-item--hasSubItem`,
+        containsActiveSubItem && `ActionList-item--hasActiveSubItem`
+      )}
       onClick={itemIsCollapsed}
       id={id}
       aria-disabled={ariaDisabled ? 'true' : undefined}

--- a/src/actionlist/action-list-tree.scss
+++ b/src/actionlist/action-list-tree.scss
@@ -33,6 +33,13 @@
   }
 
   .ActionList-item {
+    // class for single tree items not within a group
+    &.ActionList-item--singleton {
+      .ActionList-content {
+        padding-left: $spacer-5;
+      }
+    }
+
     // start: copy from ActionList proper- backwards compatible for treeview with different markup structure
     &[aria-expanded] {
       .ActionList--subGroup {


### PR DESCRIPTION
If a single item exists in a Tree View next to a collapsible group, align item with nearby group's icon

| before | after |
| -- | -- |
| ![tree-view before fix](https://user-images.githubusercontent.com/18661030/153651307-1393c4e5-916a-450c-b10f-f826c1105223.png) |  ![tree-view after fix](https://user-images.githubusercontent.com/18661030/153651226-f6f8c0c5-c541-40b8-bb4f-5950eafabe95.png) |


An attempt _was made_ 😅 to handle this purely with CSS, but we can't handle the top level case (can't go up the tree in CSS, literally). This creates a new class `ActionList-item--singleton` to be conditionally added to `ActionList-item` when its needed. I confirmed with @talum that we have that data in the view component.