### PR TITLE
Set alt attribute on README img

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width="300px" src="./docs/src/readme.png">
+  <img width="300px" alt="" src="./docs/src/readme.png">
 </p>
 
 <h1 align="center">Primer CSS</h1>
@@ -14,7 +14,7 @@
     <img alt="" src="https://github.com/primer/css/actions/workflows/ci.yml/badge.svg">
   </a>
   <a aria-label="contributors graph" href="https://github.com/primer/css/graphs/contributors">
-    <img src="https://img.shields.io/github/contributors/primer/css.svg">
+    <img alt="" src="https://img.shields.io/github/contributors/primer/css.svg">
   </a>
   <a aria-label="last commit" href="https://github.com/primer/css/commits/main">
     <img alt="" src="https://img.shields.io/github/last-commit/primer/css.svg">


### PR DESCRIPTION
## What are you trying to accomplish?

[github-a11y chrome extension](https://github.com/khiga8/github-a11y) flagged that this README image is missing `alt`. I believe this is a decorative image so I'm setting the `alt` to empty. The `alt` attribute should always be set.

### Screenshot

<img width="913" alt="Screenshot of Primer README image with thick red border flagged by chrome extension" src="https://user-images.githubusercontent.com/16447748/154360590-16eb7358-4d1a-4c57-9012-f92ef3547450.png">

