### PR TITLE
Remove "Linting dotcom" section from docs

### DIFF
--- a/docs/content/tools/linting.md
+++ b/docs/content/tools/linting.md
@@ -97,7 +97,3 @@ We test for the proper use of the [Octicons helper](https://github.com/primer/oc
 ## IE rule limit
 
 We check that our compiled CSS assets don't contain more selectors than the [IE CSS selector limits](https://blogs.msdn.microsoft.com/ieinternals/2011/05/14/stylesheet-limits-in-internet-explorer/).
-
-## Linting dotcom
-
-There are a few handy scripts to make your life easier when working with CSS on dotcom, especially when doing bigger refactors. Checkout the [Stylelint guide](https://github.com/github/design-systems/blob/main/tools/stylelint.md).


### PR DESCRIPTION
### What are you trying to accomplish?

This closes https://github.com/primer/css/issues/1941 by removing the [Linting dotcom](https://primer.style/css/tools/linting#linting-dotcom) section.

### What approach did you choose and why?

Initially I tried to fix the broken link reported in https://github.com/primer/css/issues/1941. But I'm not sure where  that [Stylelint guide](https://github.com/github/design-systems/blob/main/tools/stylelint.md) now lives. And then I thought it might be better to remove the whole section because it would be an internal link and talking about "dotcom" doesn't mean much for a contributor (non Hubber).

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 
