### PR TITLE
In markdown, update summary > heading style

### DIFF
--- a/.changeset/tall-experts-hammer.md
+++ b/.changeset/tall-experts-hammer.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Render headings inline when in a `<summary>`

--- a/src/markdown/headings.scss
+++ b/src/markdown/headings.scss
@@ -71,4 +71,15 @@
     font-size: 0.85em;
     color: var(--color-fg-muted);
   }
+  
+  summary {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      display: inline-block;
+    }
+  }
 }

--- a/src/markdown/headings.scss
+++ b/src/markdown/headings.scss
@@ -74,12 +74,9 @@
 
   summary {
     h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      display: inline-block;
+    h2 {
+      border-bottom: none;
+      padding-bottom: 0;
     }
   }
 }

--- a/src/markdown/headings.scss
+++ b/src/markdown/headings.scss
@@ -84,8 +84,8 @@
 
     h1,
     h2 {
-      border-bottom: 0;
       padding-bottom: 0;
+      border-bottom: 0;
     }
   }
 }

--- a/src/markdown/headings.scss
+++ b/src/markdown/headings.scss
@@ -74,6 +74,15 @@
 
   summary {
     h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      display: inline-block;
+    }
+
+    h1,
     h2 {
       border-bottom: none;
       padding-bottom: 0;

--- a/src/markdown/headings.scss
+++ b/src/markdown/headings.scss
@@ -84,7 +84,7 @@
 
     h1,
     h2 {
-      border-bottom: none;
+      border-bottom: 0;
       padding-bottom: 0;
     }
   }

--- a/src/markdown/headings.scss
+++ b/src/markdown/headings.scss
@@ -71,7 +71,7 @@
     font-size: 0.85em;
     color: var(--color-fg-muted);
   }
-  
+
   summary {
     h1,
     h2,


### PR DESCRIPTION
### What are you trying to accomplish?

Rendering a heading in a summary tag in Markdown currently looks a bit goofy.

<details>
<summary><h2>Hello Hello!</h2></summary>

Some fantastical text
</details>

It would be great if instead it looked more intentional like:

<img width="722" alt="Screen Shot 2022-02-22 at 4 05 28 PM" src="https://user-images.githubusercontent.com/1221423/155240756-be518982-7742-4573-a048-a0fc153c468a.png">

This would also help the Docs team with accessibility for an upcoming project. For Hubbers, you should see the reference link below the original post of this pull request.

<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->

### What approach did you choose and why?

I looked and tried to find the best file available for this. There doesn't appear to be any custom styling for details/summary in Markdown, just some general styles. Not sure if this would be a good global property, or better limited to just Markdown rendering.

<!-- Here you can explain your approach and reasoning in more detail. -->

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

Hmmm... not sure :) Happy to make any needed changes.

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 

cc @emilyistoofunky @parkerbxyz