### PR TITLE
Use <h2> instead of <div> on Subhead-heading docs

### DIFF
--- a/.changeset/shaggy-coats-relate.md
+++ b/.changeset/shaggy-coats-relate.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Use <h2> instead of <div> on Subhead-heading docs

--- a/docs/content/components/subhead.md
+++ b/docs/content/components/subhead.md
@@ -8,13 +8,13 @@ bundle: subhead
 ---
 
 
-The basic Subhead consists of a `.Subhead` container, which has a light gray bottom border. Use `.Subhead-heading` for the heading itself. It's an `<h2>` sized heading with normal font-weight.
+The basic Subhead consists of a `.Subhead` container, which has a light gray bottom border. Use `.Subhead-heading` for the heading itself. It is styled as an `<h2>` sized heading with normal font-weight.
 
 Use a heading element whenever possible as they can be used as navigation for assistive technologies, and avoid skipping levels.
 
 ```html live title="Subhead"
 <div class="Subhead">
-  <div class="Subhead-heading">Plain subhead</div>
+  <h2 class="Subhead-heading">Plain subhead</h2>
 </div>
 ```
 
@@ -22,7 +22,7 @@ To add a top margin to the Subhead, use `.Subhead--spacious`. This is useful for
 
 ```html live title="Spacious Subhead"
 <div class="Subhead Subhead--spacious">
-  <div class="Subhead-heading">Spacious subhead</div>
+  <h2 class="Subhead-heading">Spacious subhead</h2>
 </div>
 ```
 
@@ -30,7 +30,7 @@ You can add a one line description to the subhead with `.Subhead-description`.
 
 ```html live title="Subhead with description"
 <div class="Subhead">
-  <div class="Subhead-heading">Subhead with description</div>
+  <h2 class="Subhead-heading">Subhead with description</h2>
   <div class="Subhead-description">The subhead is a subdued header style with a light bottom border.</div>
 </div>
 ```
@@ -39,7 +39,7 @@ For longer descriptions, it is recommended that you use a paragraph below the Su
 
 ```html live  title="Subhead with longer description"
 <div class="Subhead">
-  <div class="Subhead-heading">Plain subhead</div>
+  <h2 class="Subhead-heading">Plain subhead</h2>
 </div>
 <p>
   This is a longer description that is sitting below the Subheader. It's much longer than a description that could sit comfortably in the Subhead. It might even have <strong>bold</strong> text. <a href="#">Click to learn more.</a>
@@ -50,12 +50,12 @@ You can add a button or something to the right of `.Subhead-heading` with the `.
 
 ```html live title="Subhead with actions"
 <div class="Subhead">
-  <div class="Subhead-heading">Subhead with button</div>
+  <h2 class="Subhead-heading">Subhead with button</h2>
   <div class="Subhead-actions"><a href="#url" class="btn btn-sm btn-primary" role="button">Action</a></div>
 </div>
 
 <div class="Subhead Subhead--spacious">
-  <div class="Subhead-heading">Subhead with link</div>
+  <h2 class="Subhead-heading">Subhead with link</h2>
   <div class="Subhead-actions"><a href="#url">Learn more</a></div>
 </div>
 ```
@@ -64,7 +64,7 @@ Use all the elements together to create a Subhead with actions and a description
 
 ```html live title="Subhead with actions and description"
 <div class="Subhead">
-  <div class="Subhead-heading">Subhead with actions and description</div>
+  <h2 class="Subhead-heading">Subhead with actions and description</h2>
   <div class="Subhead-actions"><a href="#url" class="btn btn-sm btn-primary" role="button">Action</a></div>
   <div class="Subhead-description">The subhead is a subdued header style with a light bottom border.</div>
 </div>
@@ -74,6 +74,6 @@ Use the `.Subhead-heading--danger` modifier to make the text bold and red. This 
 
 ```html live title="Subhead danger"
 <div class="Subhead">
-  <div class="Subhead-heading Subhead-heading--danger">Danger zone</div>
+  <h2 class="Subhead-heading Subhead-heading--danger">Danger zone</h2>
 </div>
 ```


### PR DESCRIPTION
### What are you trying to accomplish?

Default to h2 elements instead of using div on the Subhead-heading docs to avoid unintentional mistakes when copying code from those examples.

No visual changes.

#### Before
![Screen Shot 2022-02-24 at 15 35 21](https://user-images.githubusercontent.com/24622853/155544706-b5b0d969-d8a1-4b90-a496-fb547aa7f557.png)

#### After
![Screen Shot 2022-02-24 at 15 35 17](https://user-images.githubusercontent.com/24622853/155544689-9ff403c4-9c85-49f9-b5e8-7af2b2b1574c.png)

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 
