### PR TITLE
Fix `input-block` in `form-group`

### DIFF
--- a/.changeset/famous-masks-end.md
+++ b/.changeset/famous-masks-end.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fix `input-block` in `form-group`

--- a/src/forms/form-group.scss
+++ b/src/forms/form-group.scss
@@ -30,6 +30,7 @@
 
     &.short { width: 250px; }
 
+    &.input-block,
     &.long { width: 100%; }
   }
 


### PR DESCRIPTION
### What are you trying to accomplish?

This fixes https://github.com/primer/css/issues/1951 where an `input-block` inside `form-group` would not take up full width.

Before | After
--- | ---
![Screen Shot 2022-02-25 at 14 22 55](https://user-images.githubusercontent.com/378023/155660957-9c436246-7328-4195-bcd2-defd9e33e777.png) | ![Screen Shot 2022-02-25 at 14 24 36](https://user-images.githubusercontent.com/378023/155660962-ad84c85d-ed08-43bb-b0b4-8d5a02c44a75.png)


### What approach did you choose and why?

It seems we already account for  the`.long` modifier. This PR does the same for `.input-block`.

<!--### What should reviewers focus on?

 Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 
