### PR TITLE
Allow dropdown items to be disabled

### DIFF
--- a/.changeset/fair-dolphins-compete.md
+++ b/.changeset/fair-dolphins-compete.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Allow dropdown items to be disabled

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -81,6 +81,17 @@
   color: var(--color-fg-default);
   text-overflow: ellipsis;
   white-space: nowrap;
+  cursor: pointer;
+
+  &[disabled] {
+    color: var(--color-fg-subtle);
+    cursor: not-allowed;
+
+    &:hover {
+      background-color: var(--color-bg-default);
+      color: var(--color-fg-subtle);
+    }
+  }
 
   &:focus,
   &:hover {

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -84,7 +84,7 @@
   cursor: pointer;
 
   &[disabled] {
-    color: var(--color-fg-subtle);
+    color: var(--color-primer-fg-disabled);
     cursor: not-allowed;
 
     &:hover {


### PR DESCRIPTION
### What are you trying to accomplish?

Currently, adding the `disabled` HTML attribute to dropdown items doesn't appear to do anything (the items still highlight when hovered and the text color is the same as non-disabled items). This PR adds some styling that addresses these concerns.

### What approach did you choose and why?

I added a `&[disabled]` selector that overrides the foreground and background colors of the item on hover.

### Before

![image](https://user-images.githubusercontent.com/575280/155803675-ed9bceee-d9d2-45fe-80dc-fdf97315818f.png)

### After

![image](https://user-images.githubusercontent.com/575280/155803595-9ddb121c-4caf-461c-abb7-54f7d8fe9ee0.png)

### Are additional changes needed?

- [x] No, this PR should be ok to ship as is. 🚢 