### PR TITLE
Default .PageLayout to display block

### DIFF
--- a/.changeset/new-masks-matter.md
+++ b/.changeset/new-masks-matter.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Default .PageLayout to display block

--- a/src/layout/page-layout.scss
+++ b/src/layout/page-layout.scss
@@ -23,6 +23,7 @@ $Layout-responsive-variant-max-breakpoint: 'md' !default;
 }
 
 .PageLayout {
+  display: block;
   // stylelint-disable-next-line primer/spacing
   margin: var(--Layout-outer-spacing-y) var(--Layout-outer-spacing-x);
 


### PR DESCRIPTION
### What are you trying to accomplish?

The currently implementation of the PageLayout view component, always has the `.PageLayout` class on a `<div>` element. I'm making some updates to change this to a web-component `<page-layout>` The default for custom tags isn't block so I wanted to add that as the default here. rather than targeting the tag `<page-layout>`.

- [x] No, this PR should be ok to ship as is. 🚢 
