### PR TITLE
[Bug Fix] Adding white-space nowrap to Labels

### DIFF
--- a/.changeset/yellow-mirrors-doubt.md
+++ b/.changeset/yellow-mirrors-doubt.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+[Bug Fix] Adding white-space nowrap to Labels

--- a/.changeset/yellow-mirrors-doubt.md
+++ b/.changeset/yellow-mirrors-doubt.md
@@ -2,4 +2,4 @@
 "@primer/css": patch
 ---
 
-[Bug Fix] Adding white-space nowrap to Labels
+[Bug Fix] Adding white-space nowrap to Labels 

--- a/src/labels/mixins.scss
+++ b/src/labels/mixins.scss
@@ -11,9 +11,9 @@
   font-size: $font-size-small;
   font-weight: $font-weight-semibold;
   line-height: 18px;
+  white-space: nowrap;
   border: $border-width $border-style transparent;
   border-radius: 2em;
-  white-space: nowrap;
 }
 
 @mixin labels-large {

--- a/src/labels/mixins.scss
+++ b/src/labels/mixins.scss
@@ -13,6 +13,7 @@
   line-height: 18px;
   border: $border-width $border-style transparent;
   border-radius: 2em;
+  white-space: nowrap;
 }
 
 @mixin labels-large {


### PR DESCRIPTION
### What are you trying to accomplish?

I'm adding a `white-space: nowrap` rule to our `.Label` component to fix an issue where labels can wrap when containing two words.

| Before | After |
| :- | :- |
| <img width="398" alt="image" src="https://user-images.githubusercontent.com/54012/156609078-f330711e-7075-4425-9d77-4b9febaf8bb7.png"> | <img width="389" alt="image" src="https://user-images.githubusercontent.com/54012/156609110-d2979116-5ab2-4d18-bccd-2d0f2d7af604.png"> |

### What approach did you choose and why?

I don't think we'd ever want our labels to wrap like that, but if someone can think of a place let me know.


### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 
