### PR TITLE
[Bug fix] Handle pointer-events on ActionList visuals

### DIFF
--- a/.changeset/unlucky-oranges-worry.md
+++ b/.changeset/unlucky-oranges-worry.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Handle pointer-events on ActionList visuals

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -191,8 +191,7 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition:
-        visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 
@@ -528,6 +527,7 @@
   color: var(--color-fg-muted); // if visual is text
   fill: var(--color-fg-muted);
   align-items: center;
+  pointer-events: none;
 }
 
 // text

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -191,7 +191,8 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition:
+        visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 
@@ -525,9 +526,9 @@
   display: flex;
   min-height: $actionList-item-height-sm;
   color: var(--color-fg-muted); // if visual is text
+  pointer-events: none;
   fill: var(--color-fg-muted);
   align-items: center;
-  pointer-events: none;
 }
 
 // text


### PR DESCRIPTION
### What are you trying to accomplish?

Set `pointer-events: none;` on visuals (span elements) inside `ActionList-item`

Fixes https://github.com/github/primer/issues/745

### Are additional changes needed?

- [x] No, this PR should be ok to ship as is. 🚢 
