### PR TITLE
Refactor Flash alert

### DIFF
--- a/docs/src/stories/components/Alerts/Flash.stories.jsx
+++ b/docs/src/stories/components/Alerts/Flash.stories.jsx
@@ -1,0 +1,130 @@
+import React from 'react'
+import clsx from 'clsx'
+import {InfoIcon, AlertIcon, StopIcon, CheckIcon, XIcon} from '@primer/octicons-react'
+
+export default {
+  title: 'Components/Alerts/Flash',
+  parameters: {
+    // design: {
+    //   type: 'figma',
+    //   url: 'https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=4371%3A7128'
+    // },
+    layout: 'padded'
+  },
+
+  excludeStories: ['FlashTemplate'],
+  argTypes: {
+    variant: {
+      control: 'inline-radio',
+      options: ['info', 'warning', 'error', 'success'],
+    },
+    message: {
+      control: 'text',
+      description: 'The message to alert',
+    },
+    hasVisual: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    hasCloseButton: {
+      control: 'boolean',
+    },
+    isFull: {
+      control: 'boolean',
+    },
+    isFullWhenNarrow: {
+      control: 'boolean',
+    },
+    visualChildren: {
+      description: 'creates a slot for custom visuals',
+    },
+    actionChildren: {
+      description: 'creates a slot for action buttons',
+    }
+  },
+}
+
+export const FlashTemplate = ({
+  variant,
+  message,
+  hasVisual,
+  hasAction,
+  hasCloseButton,
+  isFull,
+  isFullWhenNarrow,
+  visualChildren,
+  actionChildren
+}) => {
+
+  const defaultMessages = {
+    'info': 'This is an info message',
+    'warning': 'This is a warning message',
+    'error': 'This is an error message',
+    'success': 'Your site is published at <a href="#">https://monalisa.github.io/</a>',
+  };
+
+  variant = variant ?? 'info';
+  message = message ?? defaultMessages[variant];
+  hasVisual = hasVisual ?? true;
+
+
+  return (
+    <>
+      <div className={clsx('Flash', variant && `Flash--${variant}`, isFull && `Flash--full`, isFullWhenNarrow && `Flash--full-whenNarrow`)}>
+        {hasVisual && (
+          <div className={clsx('Flash-visual')}>
+            {visualChildren && (
+              <>
+                {visualChildren}
+              </>
+            ) || (
+              <>
+                {variant === 'info' && (<InfoIcon />)}
+                {variant === 'warning' && (<AlertIcon />)}
+                {variant === 'error' && (<StopIcon />)}
+                {variant === 'success' && (<CheckIcon />)}
+              </>
+            )}
+          </div>
+        )}
+
+        <div className={clsx('Flash-message')} dangerouslySetInnerHTML={{__html: message}}></div>
+
+        {hasAction && (
+          <div className={clsx('Flash-actions')}>
+            {actionChildren && (
+              <>
+                {actionChildren}
+              </>
+            ) || (
+              <>
+                <button className="btn" type="submit">Action</button>
+              </>
+            )}
+          </div>
+        )}
+
+        {hasCloseButton && (
+          <div className={clsx('Flash-close')}>
+            {/* Replace with new IconButton component */}
+            <button className="btn btn-octicon p-2" type="button" aria-label="Close">
+              <XIcon />
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+export const Playground = FlashTemplate.bind({})
+
+Playground.args = {
+  variant: 'info',
+  hasVisual: true,
+  hasAction: false,
+  hasCloseButton: true,
+  isFull: false,
+  isFullWhenNarrow: false,
+};

--- a/docs/src/stories/components/Alerts/FlashFeatures.stories.jsx
+++ b/docs/src/stories/components/Alerts/FlashFeatures.stories.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import clsx from 'clsx'
+import {FlashTemplate} from './Flash.stories'
+
+
+export default {
+  title: 'Components/Alerts/Flash/Features',
+  parameters: {
+    // design: {
+    //   type: 'figma',
+    //   url: 'https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=4371%3A7128'
+    // },
+    // layout: 'padded'
+  },
+}
+
+export const WithTitleAndAction = FlashTemplate.bind({})
+WithTitleAndAction.args = {
+  variant: 'error',
+  message:
+    `<strong>You’ve used 100% of your spending limit.</strong><br />
+     To continue using metered services uninterrupted, update your spending limit.`,
+  hasAction: true,
+  actionChildren: (
+    <>
+      <button className="btn">Update spending limit</button>
+    </>
+  )
+}
+
+export const WithPrimaryButton = FlashTemplate.bind({})
+WithPrimaryButton.args = {
+  variant: 'info',
+  hasVisual: false,
+  message:
+    `<strong>vdepizzol</strong> requested your review on this pull request.`,
+  hasAction: true,
+  actionChildren: (
+    <>
+      <button className="btn btn-primary">Add your review</button>
+    </>
+  )
+}
+
+export const WithCloseButton = FlashTemplate.bind({})
+WithCloseButton.args = {
+  variant: 'info',
+  message: `The repository default branch has been updated to <strong>main</strong>.`,
+  hasCloseButton: true,
+}

--- a/src/alerts/flash-refactor.scss
+++ b/src/alerts/flash-refactor.scss
@@ -1,0 +1,134 @@
+// Flash alert
+
+.Flash {
+  position: relative;
+  display: grid;
+  // stylelint-disable-next-line primer/spacing
+  padding: $spacer-2;
+  border: $border-width $border-style;
+  border-radius: $border-radius;
+  grid-auto-flow: column;
+  grid-template-areas: 'visual message actions close';
+  grid-template-columns: min-content 1fr min-content min-content;
+  grid-template-rows: min-content;
+
+  // `sm` breakpoint variantion
+  @media (max-width: #{map-get($breakpoints, 'sm') - 0.02px}) {
+    grid-template-areas:
+    'visual message close'
+    '  .    actions actions';
+    grid-template-columns: min-content 1fr min-content;
+    grid-template-rows: min-content min-content;
+
+    .Flash-actions {
+      margin: $spacer-2 0 0 $spacer-2;
+    }
+  }
+
+  // Elements
+
+  .Flash-visual {
+    grid-area: visual;
+    // stylelint-disable-next-line primer/spacing
+    padding: calc((#{$spacer-5} - 20px) / 2) $spacer-2;
+    display: grid;
+    align-self: start;
+
+    > .octicon {
+      margin-block: calc((#{$spacer-1}) / 2);
+    }
+    
+    > * {
+      align-self: center;
+    }
+  }
+
+  .Flash-message {
+    // stylelint-disable-next-line primer/spacing
+    padding: calc((#{$spacer-5} - 20px) / 2) $spacer-2;
+    grid-area: message;
+    align-self: center;
+
+    p:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .Flash-actions {
+    grid-area: actions;
+
+    &:last-child {
+      align-self: end;
+    }
+  }
+
+  .Flash-close {
+    grid-area: close;
+    margin: 0 0 0 $spacer-2;
+
+    button {
+      &:hover {
+        background-color: var(--color-action-list-item-default-hover-bg);
+      }
+    }
+  }
+
+  // Variants
+
+  color: var(--color-fg-default);
+  background-image: linear-gradient(var(--color-accent-subtle), var(--color-accent-subtle));
+  border-color: var(--color-accent-muted);
+
+  .Flash-visual .octicon {
+    color: var(--color-accent-fg);
+  }
+
+  &.Flash--warning {
+    color: var(--color-fg-default);
+    background-image: linear-gradient(var(--color-attention-subtle), var(--color-attention-subtle));
+    border-color: var(--color-attention-muted);
+
+    .Flash-visual .octicon {
+      color: var(--color-attention-fg);
+    }
+  }
+
+  &.Flash--error {
+    color: var(--color-fg-default);
+    background-image: linear-gradient(var(--color-danger-subtle), var(--color-danger-subtle));
+    border-color: var(--color-danger-muted);
+
+    .Flash-visual .octicon {
+      color: var(--color-danger-fg);
+    }
+  }
+
+  &.Flash--success {
+    color: var(--color-fg-default);
+    background-image: linear-gradient(var(--color-success-subtle), var(--color-success-subtle));
+    border-color: var(--color-success-muted);
+
+    .Flash-visual .octicon {
+      color: var(--color-success-fg);
+    }
+  }
+
+  // Full-width
+
+  &.Flash--full {
+    margin-top: ($border-width * -1);
+    border-left: 0;
+    border-right: 0;
+    border-radius: 0;
+  }
+
+  // Replace with Primitives' Narrow viewport range
+  @media (max-width: #{map-get($breakpoints, 'md') - 0.02px}) {
+    &.Flash--full-whenNarrow {
+      margin-top: ($border-width * -1);
+      border-left: 0;
+      border-right: 0;
+      border-radius: 0;
+    }
+  }
+}

--- a/src/alerts/index.scss
+++ b/src/alerts/index.scss
@@ -1,3 +1,4 @@
 // support files
 @import '../support/index.scss';
 @import './flash.scss';
+@import './flash-refactor.scss';


### PR DESCRIPTION
### What are you trying to accomplish?

This PR adds a new `Flash` component, meant to eventually replace our existing `flash` alert. This update aims to fix long standing issues found in it, mainly regarding responsive support.

Main updates:
> Improved alignments and spacing
>
> ![Screen Shot 2022-03-03 at 15 44 08](https://user-images.githubusercontent.com/293280/156671888-d0d8f346-5274-411c-a25e-0570c36e2d21.png)
>
> ![Screen Shot 2022-03-03 at 15 47 47](https://user-images.githubusercontent.com/293280/156672281-bf430b4f-571d-404b-a51f-ee284186972d.png)
>
> ![Screen Shot 2022-03-03 at 15 43 01](https://user-images.githubusercontent.com/293280/156671782-56b506ed-c5be-41eb-90d8-bf00b9b4ae30.png)
>
> ![Screen Shot 2022-03-03 at 15 44 37](https://user-images.githubusercontent.com/293280/156671940-00233660-a1ab-4782-bfc6-c18a61d0ebba.png)

> Responsive support
>
> ![Screen Shot 2022-03-03 at 15 45 32](https://user-images.githubusercontent.com/293280/156672056-8b57e518-5442-4a39-8b6a-ee7299233538.png)
>
> ![Screen Shot 2022-03-03 at 15 45 05](https://user-images.githubusercontent.com/293280/156672006-dabd3356-dad6-45fa-bfb2-1d2406f594b0.png)

A lot of the spacing values used in this refactor are hardcoded, and will benefit from the Primer Primitives [spacing update](https://github.com/github/primer/issues/681) once that's available. (link only available for Hubbers).

### What approach did you choose and why?

I've kept the current `flash` alert in place, and created a new `flash-refactor.scss` file, in a similar fashion to how @langermank has considered the refactor for the Button component (#1874).

After all instances of `flash` are replaced with this new component (specially after updating its [ViewComponent](https://github.com/primer/view_components/blob/main/app/components/primer/flash_component.rb), we can clean up these files.

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 
