### PR TITLE
Bump `primer/primitives` to `^7.5.1`

### DIFF
--- a/.changeset/neat-pears-battle.md
+++ b/.changeset/neat-pears-battle.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Bump `primer/primitives` to `^7.5.1`

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "storybook": "cd docs && yarn && yarn storybook"
   },
   "dependencies": {
-    "@primer/primitives": "7.5.0"
+    "@primer/primitives": "^7.5.1"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,10 +1148,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@primer/primitives@7.5.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.5.0.tgz#c997637bc315b3fde6d1ed22031d60d24b04d85b"
-  integrity sha512-DNAGOxFvelUz2THCZNo1EuSRbtujhY7NR02WjQvSGlbBihMeMJ5yrUYgeQyo/OGrg+HlzbwLW56OLy9PN+iqXA==
+"@primer/primitives@^7.5.1":
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.5.1.tgz#18aa8a0f3a3f7fd49fcad31a7efb86688bffb9de"
+  integrity sha512-1pFKR+FcYRPXJ+zK/qtidrCJB7WmTaAX4sG7zE5LvGWjS5latue4pzZrK0FxxGGBdAU3HpoabANsGjv7T7sRRg==
 
 "@primer/stylelint-config@^12.3.3":
   version "12.3.3"


### PR DESCRIPTION
### What are you trying to accomplish?

This bumps `primer/primitives` to [`^7.5.1`](https://github.com/primer/primitives/pull/305)

### What approach did you choose and why?

```
yarn add @primer/primitives@^7.5.1
```

### What should reviewers focus on?

Adding back the `^` so that `primer/primitives` can be updated from dotcom.

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 
