### PR TITLE
Add .color-bg-transparent

### DIFF
--- a/.changeset/ninety-phones-run.md
+++ b/.changeset/ninety-phones-run.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Adding .color-bg-transparent utility class

--- a/docs/content/utilities/colors.mdx
+++ b/docs/content/utilities/colors.mdx
@@ -75,6 +75,8 @@ Background colors are most commonly used for filling large blocks of content or 
 
 <div class="color-bg-sponsors p-2 rounded mb-2">.color-bg-sponsors</div>
 <div class="color-bg-sponsors-emphasis color-fg-on-emphasis p-2 rounded">.color-bg-sponsors-emphasis</div>
+
+<div class="color-bg-transparent p-2 rounded mb-2">.color-bg-transparent</div>
 ```
 
 ## Border

--- a/src/utilities/colors.scss
+++ b/src/utilities/colors.scss
@@ -53,6 +53,8 @@
 .color-bg-sponsors          { background-color: var(--color-sponsors-subtle) !important; }
 .color-bg-sponsors-emphasis { background-color: var(--color-sponsors-emphasis) !important; }
 
+.color-bg-transparent { background-color: transparent !important; }
+
 // Border
 
 .color-border-default { border-color: var(--color-border-default) !important; }


### PR DESCRIPTION
### What are you trying to accomplish?

This adds a new utility class that applies `background-color: transparent`. I had the need for such and realized, based on looking at https://primer.style/css/utilities/colors#background, that no such class existed.

### What approach did you choose and why?

I named the class `color-bg-transparent`, following the existing `color-bg-` prefix naming.

### What should reviewers focus on?

Did I update all that I needed to? I wasn't sure if a CHANGELOG.md update was warranted or if that would come in a different branch.

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 
