### PR TITLE
Fix color-fg utilities in links

### DIFF
--- a/.changeset/gorgeous-birds-hear.md
+++ b/.changeset/gorgeous-birds-hear.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fix color-fg utilities in links

--- a/src/links/link.scss
+++ b/src/links/link.scss
@@ -49,7 +49,7 @@
 .Link--secondary,
 .Link--primary,
 .Link--muted {
-  &:hover [class*='color-text'] {
+  &:hover [class*='color-fg'] {
     color: inherit !important;
   }
 }


### PR DESCRIPTION
### What are you trying to accomplish?

This fixes a regression where `color-fg` utilities inside a `Link` wouldn't inherit the color when hovering the `Link`.

Before | After
--- | ---
![Screen Shot 2022-03-11 at 15 24 03](https://user-images.githubusercontent.com/378023/157814022-883dd562-e6ee-490b-a0b9-5072d47b7854.png) | ![Screen Shot 2022-03-11 at 15 24 26](https://user-images.githubusercontent.com/378023/157814023-ffc60e25-00d0-4ccb-8b37-f7929f7218a5.png)

### What approach did you choose and why?

We forgot to update this when replacing `color-text` with `color-fg`.

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 

---

Closes https://github.com/github/primer/issues/700