### PR TITLE
Make `pane` an optional region for PageLayout component

### DIFF
--- a/.changeset/nasty-singers-compare.md
+++ b/.changeset/nasty-singers-compare.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Make `pane` an optional region for PageLayout component

--- a/docs/src/stories/components/Layout/LayoutBeta.stories.jsx
+++ b/docs/src/stories/components/Layout/LayoutBeta.stories.jsx
@@ -336,20 +336,14 @@ export const LayoutTemplate = ({
 
   if (hasPaneDivider) {
     paneDividerWhenNarrow = paneDividerWhenNarrow === 'inherit' ? 'line' : paneDividerWhenNarrow
-  } else {
-    paneDividerWhenNarrow = null
   }
 
   if (hasHeaderDivider) {
     headerDividerWhenNarrow = headerDividerWhenNarrow === 'inherit' ? 'line' : headerDividerWhenNarrow
-  } else {
-    headerDividerWhenNarrow = null
   }
 
   if (hasFooterDivider) {
     footerDividerWhenNarrow = footerDividerWhenNarrow === 'inherit' ? 'line' : footerDividerWhenNarrow
-  } else {
-    footerDividerWhenNarrow = null
   }
 
   PageLayoutBehavior()

--- a/docs/src/stories/components/Layout/LayoutBeta.stories.jsx
+++ b/docs/src/stories/components/Layout/LayoutBeta.stories.jsx
@@ -99,6 +99,13 @@ export default {
 
     // Pane
 
+    hasPane: {
+      control: {type: 'boolean'},
+      table: {
+        category: 'Pane'
+      }
+    },
+
     paneWidth: {
       options: ['default', 'narrow', 'wide'],
       control: {
@@ -275,6 +282,7 @@ export const LayoutTemplate = ({
   rowGap,
 
   // Pane
+  hasPane,
   paneWidth,
   panePosition,
   panePositionWhenNarrow,
@@ -386,54 +394,69 @@ export const LayoutTemplate = ({
             </div>
           )}
 
-          <div className={clsx(layoutClassName + '-columns')}>
-            {/* pane if rendered first */}
-            {panePosition === 'start' && (
-              <div
-                className={clsx(
-                  layoutClassName + '-region',
-                  layoutClassName + '-pane',
-                  paneDividerWhenNarrow &&
-                    layoutClassName +
-                      '-region--dividerNarrow-' +
-                      paneDividerWhenNarrow +
-                      (panePositionWhenNarrow === 'start' ? '-after' : '-before')
-                )}
-              >
-                {paneChildren}
-              </div>
-            )}
+          {hasPane && (
+            <div className={clsx(layoutClassName + '-columns')}>
+              {/* pane if rendered first */}
+              {panePosition === 'start' && (
+                <div
+                  className={clsx(
+                    layoutClassName + '-region',
+                    layoutClassName + '-pane',
+                    paneDividerWhenNarrow &&
+                      layoutClassName +
+                        '-region--dividerNarrow-' +
+                        paneDividerWhenNarrow +
+                        (panePositionWhenNarrow === 'start' ? '-after' : '-before')
+                  )}
+                >
+                  {paneChildren}
+                </div>
+              )}
 
-            {/* content */}
-            <div className={clsx(layoutClassName + '-region', layoutClassName + '-content')}>
-              {contentWidth ? (
-                <>
-                  <div className={layoutClassName + '-content-centered-' + contentWidth}>
-                    <div className={'container-' + contentWidth}>{contentChildren}</div>
-                  </div>
-                </>
-              ) : (
-                <>{contentChildren}</>
+              {/* content */}
+              <div className={clsx(layoutClassName + '-region', layoutClassName + '-content')}>
+                {contentWidth ? (
+                  <>
+                    <div className={layoutClassName + '-content-centered-' + contentWidth}>
+                      <div className={'container-' + contentWidth}>{contentChildren}</div>
+                    </div>
+                  </>
+                ) : (
+                  <>{contentChildren}</>
+                )}
+              </div>
+
+              {/* pane if rendered last */}
+              {panePosition === 'end' && (
+                <div
+                  className={clsx(
+                    layoutClassName + '-region',
+                    layoutClassName + '-pane',
+                    paneDividerWhenNarrow &&
+                      layoutClassName +
+                        '-region--dividerNarrow-' +
+                        paneDividerWhenNarrow +
+                        (panePositionWhenNarrow === 'start' ? '-after' : '-before')
+                  )}
+                >
+                  {paneChildren}
+                </div>
               )}
             </div>
-
-            {/* pane if rendered last */}
-            {panePosition === 'end' && (
-              <div
-                className={clsx(
-                  layoutClassName + '-region',
-                  layoutClassName + '-pane',
-                  paneDividerWhenNarrow &&
-                    layoutClassName +
-                      '-region--dividerNarrow-' +
-                      paneDividerWhenNarrow +
-                      (panePositionWhenNarrow === 'start' ? '-after' : '-before')
+          ) || (
+            <>
+              {/* single-column layout */}
+              <div className={clsx(layoutClassName + '-region', layoutClassName + '-content')}>
+                {contentWidth ? (
+                  <>
+                    <div className={'container-' + contentWidth}>{contentChildren}</div>
+                  </>
+                ) : (
+                  <>{contentChildren}</>
                 )}
-              >
-                {paneChildren}
               </div>
-            )}
-          </div>
+            </>
+          )}
 
           {/* footer */}
           {hasFooter && (
@@ -488,6 +511,7 @@ Playground.args = {
   responsiveVariant: 'stackRegions',
   primaryRegion: 'content',
 
+  hasPane: true,
   paneWidth: 'default',
   panePosition: 'end',
   panePositionWhenNarrow: 'inherit',

--- a/docs/src/stories/components/Layout/LayoutExamples.stories.jsx
+++ b/docs/src/stories/components/Layout/LayoutExamples.stories.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import clsx from 'clsx'
 import {PageLayoutTemplate} from './PageLayout.stories'
 import {SplitPageLayoutTemplate} from './SplitPageLayout.stories'
-import {RepoSettings, DiscussionsPane, ActionListTreeViewTemplate} from '../ActionList/ActionListExamples.stories'
+import {ActionListTreeViewTemplate} from '../../ui-patterns/ActionList/ActionListTree.stories'
+import {RepoSettings, NavDiscussionsPane} from '../NavigationList/NavigationListExamples.stories'
 import {LayoutAlphaTemplate} from './LayoutAlpha.stories'
 
 export default {
@@ -32,7 +33,7 @@ Settings.args = {
     <>
       <h2 className="h3 ml-2 mr-2">Repository settings</h2>
       <div className="ml-n2 mr-n2">
-        <NavRepoSettings {...NavRepoSettings.args} />
+        <RepoSettings {...RepoSettings.args} />
       </div>
     </>
   ),

--- a/docs/src/stories/components/Layout/PageLayout.stories.jsx
+++ b/docs/src/stories/components/Layout/PageLayout.stories.jsx
@@ -41,7 +41,7 @@ export default {
     },
 
     columnGap: {
-      options: ['normal', 'condensed'],
+      options: ['normal', 'condensed', 'none'],
       control: {
         type: 'inline-radio'
       },
@@ -51,7 +51,7 @@ export default {
       }
     },
     rowGap: {
-      options: ['normal', 'condensed'],
+      options: ['normal', 'condensed', 'none'],
       control: {
         type: 'inline-radio'
       },

--- a/docs/src/stories/components/Layout/PageLayout.stories.jsx
+++ b/docs/src/stories/components/Layout/PageLayout.stories.jsx
@@ -86,6 +86,13 @@ export default {
     },
 
     // Pane
+    
+    hasPane: {
+      control: {type: 'boolean'},
+      table: {
+        category: 'Pane'
+      }
+    },
 
     panePosition: {
       options: ['start', 'end'],
@@ -241,6 +248,7 @@ export const PageLayoutTemplate = ({
   rowGap,
   responsiveVariant,
   primaryRegion,
+  hasPane,
   paneWidth,
   panePosition,
   panePositionWhenNarrow,
@@ -271,6 +279,7 @@ export const PageLayoutTemplate = ({
         responsiveVariant={responsiveVariant}
         primaryRegion={primaryRegion}
 
+        hasPane={hasPane}
         paneWidth={paneWidth}
         panePosition={panePosition}
         panePositionWhenNarrow={panePositionWhenNarrow}
@@ -315,6 +324,7 @@ Playground.args = {
   primaryRegion: 'content',
 
   // Pane
+  hasPane: true,
   panePosition: 'end',
   panePositionWhenNarrow: 'inherit',
   paneWidth: 'default',

--- a/src/layout/page-layout.scss
+++ b/src/layout/page-layout.scss
@@ -294,7 +294,7 @@ $Layout-responsive-variant-max-breakpoint: 'md' !default;
     padding-left: var(--Layout-inner-spacing-max);
     grid-area: content;
   }
-  
+
   .PageLayout-pane {
     grid-area: pane;
   }

--- a/src/layout/page-layout.scss
+++ b/src/layout/page-layout.scss
@@ -270,12 +270,15 @@ $Layout-responsive-variant-max-breakpoint: 'md' !default;
   }
 }
 
+// PageLayout-wrapper bundles header, footer, pane, and content regions
 .PageLayout-wrapper {
   display: grid;
   grid: auto-flow / 1fr;
   row-gap: var(--Layout-row-gap);
 }
 
+// PageLayout-columns wrap pane and content regions
+// If layout has no pane, PageLayout-columns is not present
 .PageLayout-columns {
   display: grid;
   column-gap: var(--Layout-column-gap);
@@ -283,6 +286,18 @@ $Layout-responsive-variant-max-breakpoint: 'md' !default;
   grid-template-columns: var(--Layout-template-columns);
   grid-template-rows: 1fr;
   grid-template-areas: var(--Layout-template-areas);
+
+  .PageLayout-content {
+    // stylelint-disable-next-line primer/spacing
+    padding-right: var(--Layout-inner-spacing-max);
+    // stylelint-disable-next-line primer/spacing
+    padding-left: var(--Layout-inner-spacing-max);
+    grid-area: content;
+  }
+  
+  .PageLayout-pane {
+    grid-area: pane;
+  }
 }
 
 // outer spacing
@@ -366,16 +381,4 @@ $Layout-responsive-variant-max-breakpoint: 'md' !default;
 .PageLayout-footer {
   // stylelint-disable-next-line primer/spacing
   padding: var(--Layout-inner-spacing-min);
-}
-
-.PageLayout-content {
-  // stylelint-disable-next-line primer/spacing
-  padding-right: var(--Layout-inner-spacing-max);
-  // stylelint-disable-next-line primer/spacing
-  padding-left: var(--Layout-inner-spacing-max);
-  grid-area: content;
-}
-
-.PageLayout-pane {
-  grid-area: pane;
 }


### PR DESCRIPTION
### What are you trying to accomplish?

This PR adds an expected functionality to PageLayout, making the `pane` region optional, and allowing single-column pages to also benefit from PageLayout's spacing structure.

![Screen Shot](https://user-images.githubusercontent.com/293280/158250657-53816179-43ab-45b4-a306-e8d7fb4a4316.png)

I've also fixed two Storybook-related issues:
- [Align PageLayout story spacing props with component](https://github.com/primer/css/commit/2efafdb2007687d8ab0a4c8c2b5467af84fa7713)
- [Fix PageLayout storybook example imports](https://github.com/primer/css/commit/ec387ad7b7a043f27e8112ff9c00ed399c9067c8)

### What approach did you choose and why?

PageLayout has two wrapping elements: `PageLayout-wrapper` and `PageLayout-columns`. `wrapper` takes care of vertical stack (header, content+pane, footer), while `columns` handles the horizontal the stack (content + pane).

For single column layouts, I've removed `PageLayout-columns` from the markup, leaving `content` as a direct sibling of `header` and `footer`.

Note that the `hasPane` prop from Storybook shouldn't translate 1:1 to ViewComponent or React APIs; the presence of compound components or slots should determine the region existence.

<!-- Here you can explain your approach and reasoning in more detail. -->

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [ ] No, this PR should be ok to ship as is. 🚢 
