### PR TITLE
Fix `btn-primary` in flash alerts

### DIFF
--- a/.changeset/cuddly-mugs-peel.md
+++ b/.changeset/cuddly-mugs-peel.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fix `btn-primary` in flash alerts

--- a/src/alerts/flash.scss
+++ b/src/alerts/flash.scss
@@ -63,8 +63,12 @@
     color: var(--color-fg-muted);
   }
 
-  &.btn-primary .octicon {
-    color: inherit;
+  &.btn-primary {
+    background-clip: border-box;
+
+    .octicon {
+      color: inherit;
+    }
   }
 }
 


### PR DESCRIPTION
### What are you trying to accomplish?

This makes sure that the semi-transparent border of a `btn-primary` in a `flash` alert is on top of the button's background and not the flash's background:

Before | After
--- | ---
![Screen Shot 2022-03-22 at 12 10 37](https://user-images.githubusercontent.com/378023/159400785-7215c938-943b-4eb5-bed4-8f7c6ef3d9d6.png) | ![Screen Shot 2022-03-22 at 12 11 16](https://user-images.githubusercontent.com/378023/159400787-405fa65d-f304-48e3-8dde-dc30ec6917a3.png)

### What approach did you choose and why?

Resetting the `background-clip` back to `border-box` for `.flash-action.btn-primary` combos.

### What should reviewers focus on?

Fixes https://github.com/github/primer/issues/791

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 
