### PR TITLE
Add support for inline, stack label in autocomplete

### DIFF
--- a/.changeset/breezy-jeans-boil.md
+++ b/.changeset/breezy-jeans-boil.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Add support for inline, stack label in autocomplete

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -32,6 +32,8 @@ A list of items used to show autocompleted results. Use the [`<auto-complete>`](
 
 ## Inline label
 
+**Note**: On smaller screen sizes, the labels will be stacked.
+
 ```html live
 <div class="position-relative">
   <label class="autocomplete-label-inline">Search by team</label>
@@ -51,8 +53,6 @@ A list of items used to show autocompleted results. Use the [`<auto-complete>`](
   }
 </style>
 ```
-
-On smaller screen sizes, the labels will be stacked.
 
 ## Embedded icon with visible label
 

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -12,7 +12,7 @@ A list of items used to show autocompleted results. Use the [`<auto-complete>`](
 
 ```html live
 <div class="position-relative">
-  <label>Search by user</label>
+  <label class="autocomplete-label-stacked">Search by user</label>
   <span class="autocomplete-body">
     <input class="form-control" type="text">
     <ul class="autocomplete-results">
@@ -64,9 +64,26 @@ On smaller viewport, we switch to stacking.
 
 ## Embedded icon with visible label
 
+Stacked label
+
 ```html live
 <div class="position-relative">
-  <label>Search by org</label>
+  <label class="autocomplete-label-stacked">Search by org</label>
+  <span class="autocomplete-body">
+    <svg class="octicon autocomplete-embedded-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path></svg>
+    <input class="form-control" type="text">
+    <ul class="autocomplete-results autocomplete-results--embedded-icon">
+      <li class="autocomplete-item" aria-selected="true">Option 1</li>
+      <li class="autocomplete-item">Option 2</li>
+      <li class="autocomplete-item">Option 3</li>
+    </ul>
+  </span>
+</div>
+
+Inline label
+```html live
+<div class="position-relative">
+  <label class="autocomplete-label-inline">Search by org</label>
   <span class="autocomplete-body">
     <svg class="octicon autocomplete-embedded-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path></svg>
     <input class="form-control" type="text">
@@ -85,7 +102,7 @@ On smaller viewport, we switch to stacking.
 
 ```html live
 <div class="position-relative">
-  <label class="sr-only">Search by org</label>
+  <label class="autocomplete-label-stacked sr-only">Search by org</label>
   <span class="autocomplete-body">
     <svg aria-hidden="true" class="octicon autocomplete-embedded-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path></svg>
     <input class="form-control" type="text">

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -10,24 +10,84 @@ bundle: autocomplete
 
 A list of items used to show autocompleted results. Use the [`<auto-complete>`](https://github.com/github/auto-complete-element) element to add functionality.
 
+### Default (stacked label)
+
 ```html live
 <div class="position-relative">
-  <input class="form-control input-block" type="text" aria-label="Search" placeholder="Search">
-  <ul class="autocomplete-results">
-    <li class="autocomplete-item" aria-selected="true">Option 1</li>
-    <li class="autocomplete-item">Option 2</li>
-    <li class="autocomplete-item">Option 3</li>
-  </ul>
+  <label>Search by user</label>
+  <span class="autocomplete-body">
+    <input class="form-control" type="text">
+    <ul class="autocomplete-results">
+      <li class="autocomplete-item" aria-selected="true">Option 1</li>
+      <li class="autocomplete-item">Option 2</li>
+      <li class="autocomplete-item">Option 3</li>
+    </ul>
+  </span>
 </div>
 
-<style>.frame-example {width:300px;height:160px;}</style>
+<style>.frame-example {height:160px;}</style>
 ```
 
+### Inline label
+
+```html live
+<div class="position-relative">
+  <label class="autocomplete-label-inline">Search by team</label>
+  <span class="autocomplete-body">
+    <input class="form-control" type="text">
+    <ul class="autocomplete-results">
+      <li class="autocomplete-item" aria-selected="true">Option 1</li>
+      <li class="autocomplete-item">Option 2</li>
+      <li class="autocomplete-item">Option 3</li>
+    </ul>
+  </span>
+</div>
+
+<style>.frame-example {height:160px;}</style>
+```
+
+On smaller viewport, we switch to stacking.
+
+```html live
+<div class="position-relative">
+  <label class="autocomplete-label-inline">Search by team</label>
+  <span class="autocomplete-body">
+    <input class="form-control" type="text">
+    <ul class="autocomplete-results">
+      <li class="autocomplete-item" aria-selected="true">Option 1</li>
+      <li class="autocomplete-item">Option 2</li>
+      <li class="autocomplete-item">Option 3</li>
+    </ul>
+  </span>
+</div>
+
+<style>.frame-example {height:160px;width:300px;}</style>
+```
+
+### Embedded icon with hidden label
+
+```html live
+<div class="position-relative">
+  <label class="sr-only">Search by org</label>
+  <span class="autocomplete-body">
+    <input class="form-control" type="text">
+    <ul class="autocomplete-results">
+      <li class="autocomplete-item" aria-selected="true">Option 1</li>
+      <li class="autocomplete-item">Option 2</li>
+      <li class="autocomplete-item">Option 3</li>
+    </ul>
+  </span>
+</div>
+
+<style>.frame-example {height:160px;}</style>
+```
+
+### Additional content
 Autocomplete items can contain additional content, like an `.avatar`. Or use utility classes to customize the text style.
 
 ```html live
 <div class="position-relative">
-  <input class="form-control input-block" type="text" aria-label="Search by user" placeholder="Search by user">
+  <input class="form-control" type="text" aria-label="Search by user" placeholder="Search by user">
   <ul class="autocomplete-results">
     <li class="autocomplete-item" aria-selected="true">
       <img src="https://github.com/github.png" width="20" class="avatar mr-1" alt="">

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -62,14 +62,34 @@ On smaller viewport, we switch to stacking.
 <style>.frame-example {height:160px;width:300px;}</style>
 ```
 
+## Embedded icon with visible label
+
+```html live
+<div class="position-relative">
+  <label>Search by org</label>
+  <span class="autocomplete-body">
+    <svg class="octicon autocomplete-embedded-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path></svg>
+    <input class="form-control" type="text">
+    <ul class="autocomplete-results autocomplete-results--embedded-icon">
+      <li class="autocomplete-item" aria-selected="true">Option 1</li>
+      <li class="autocomplete-item">Option 2</li>
+      <li class="autocomplete-item">Option 3</li>
+    </ul>
+  </span>
+</div>
+
+<style>.frame-example {height:160px;}</style>
+```
+
 ## Embedded icon with hidden label
 
 ```html live
 <div class="position-relative">
   <label class="sr-only">Search by org</label>
   <span class="autocomplete-body">
+    <svg aria-hidden="true" class="octicon autocomplete-embedded-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path></svg>
     <input class="form-control" type="text">
-    <ul class="autocomplete-results">
+    <ul class="autocomplete-results autocomplete-results--embedded-icon">
       <li class="autocomplete-item" aria-selected="true">Option 1</li>
       <li class="autocomplete-item">Option 2</li>
       <li class="autocomplete-item">Option 3</li>

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -52,28 +52,7 @@ A list of items used to show autocompleted results. Use the [`<auto-complete>`](
 </style>
 ```
 
-On smaller viewport, we switch to stacking.
-
-```html live
-<div class="position-relative">
-  <label class="autocomplete-label-inline">Search by team</label>
-  <span class="autocomplete-body">
-    <input class="form-control" type="text" />
-    <ul class="autocomplete-results">
-      <li class="autocomplete-item" aria-selected="true">Team 1 (works on Ruby architecture)</li>
-      <li class="autocomplete-item">Team 2 (works on frontend JS architecture)</li>
-      <li class="autocomplete-item">Team 3 (this team works on design systems)</li>
-    </ul>
-  </span>
-</div>
-
-<style>
-  .frame-example {
-    height: 160px;
-    width: 300px;
-  }
-</style>
-```
+On smaller screen sizes, the labels will be stacked.
 
 ## Embedded icon with visible label
 

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -6,11 +6,9 @@ source: 'https://github.com/primer/css/tree/main/src/autocomplete'
 bundle: autocomplete
 ---
 
-## Autocomplete
-
 A list of items used to show autocompleted results. Use the [`<auto-complete>`](https://github.com/github/auto-complete-element) element to add functionality.
 
-### Default (stacked label)
+## Default (stacked label)
 
 ```html live
 <div class="position-relative">
@@ -28,7 +26,7 @@ A list of items used to show autocompleted results. Use the [`<auto-complete>`](
 <style>.frame-example {height:160px;}</style>
 ```
 
-### Inline label
+## Inline label
 
 ```html live
 <div class="position-relative">
@@ -36,9 +34,9 @@ A list of items used to show autocompleted results. Use the [`<auto-complete>`](
   <span class="autocomplete-body">
     <input class="form-control" type="text">
     <ul class="autocomplete-results">
-      <li class="autocomplete-item" aria-selected="true">Option 1</li>
-      <li class="autocomplete-item">Option 2</li>
-      <li class="autocomplete-item">Option 3</li>
+      <li class="autocomplete-item" aria-selected="true">Team 1 (works on Ruby architecture)</li>
+      <li class="autocomplete-item">Team 2 (works on frontend JS architecture) </li>
+      <li class="autocomplete-item">Team 3 (this team works on design systems)</li>
     </ul>
   </span>
 </div>
@@ -54,9 +52,9 @@ On smaller viewport, we switch to stacking.
   <span class="autocomplete-body">
     <input class="form-control" type="text">
     <ul class="autocomplete-results">
-      <li class="autocomplete-item" aria-selected="true">Option 1</li>
-      <li class="autocomplete-item">Option 2</li>
-      <li class="autocomplete-item">Option 3</li>
+      <li class="autocomplete-item" aria-selected="true">Team 1 (works on Ruby architecture)</li>
+      <li class="autocomplete-item">Team 2 (works on frontend JS architecture) </li>
+      <li class="autocomplete-item">Team 3 (this team works on design systems)</li>
     </ul>
   </span>
 </div>
@@ -64,7 +62,7 @@ On smaller viewport, we switch to stacking.
 <style>.frame-example {height:160px;width:300px;}</style>
 ```
 
-### Embedded icon with hidden label
+## Embedded icon with hidden label
 
 ```html live
 <div class="position-relative">
@@ -82,7 +80,7 @@ On smaller viewport, we switch to stacking.
 <style>.frame-example {height:160px;}</style>
 ```
 
-### Additional content
+## Additional content
 Autocomplete items can contain additional content, like an `.avatar`. Or use utility classes to customize the text style.
 
 ```html live

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -83,20 +83,22 @@ Stacked label
 <div class="position-relative">
   <label class="autocomplete-label-stacked">Search by org</label>
   <span class="autocomplete-body">
-    <svg
-      class="octicon autocomplete-embedded-icon"
-      aria-hidden="true"
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 16 16"
-      width="16"
-      height="16"
-    >
-      <path
-        fill-rule="evenodd"
-        d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"
-      ></path>
-    </svg>
-    <input class="form-control" type="text" />
+    <div class="form-control autocomplete-embedded-icon-wrap">
+      <svg
+        class="octicon"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        width="16"
+        height="16"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"
+        ></path>
+      </svg>
+      <input class="form-control" type="text" />
+    </div>
     <ul class="autocomplete-results">
       <li class="autocomplete-item" aria-selected="true">Option 1</li>
       <li class="autocomplete-item">Option 2</li>
@@ -118,20 +120,22 @@ Inline label
 <div class="position-relative">
   <label class="autocomplete-label-inline">Search by org</label>
   <span class="autocomplete-body">
-    <svg
-      class="octicon autocomplete-embedded-icon"
-      aria-hidden="true"
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 16 16"
-      width="16"
-      height="16"
-    >
-      <path
-        fill-rule="evenodd"
-        d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"
-      ></path>
-    </svg>
-    <input class="form-control" type="text" />
+    <div class="form-control autocomplete-embedded-icon-wrap">
+      <svg
+        class="octicon autocomplete-embedded-icon"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        width="16"
+        height="16"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"
+        ></path>
+      </svg>
+      <input class="form-control" type="text" />
+    </div>
     <ul class="autocomplete-results">
       <li class="autocomplete-item" aria-selected="true">Option 1</li>
       <li class="autocomplete-item">Option 2</li>
@@ -153,20 +157,22 @@ Inline label
 <div class="position-relative">
   <label class="autocomplete-label-stacked sr-only">Search by org</label>
   <span class="autocomplete-body">
-    <svg
-      aria-hidden="true"
-      class="octicon autocomplete-embedded-icon"
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 16 16"
-      width="16"
-      height="16"
-    >
-      <path
-        fill-rule="evenodd"
-        d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"
-      ></path>
-    </svg>
-    <input class="form-control" type="text" />
+    <div class="form-control autocomplete-embedded-icon-wrap">
+      <svg
+        aria-hidden="true"
+        class="octicon autocomplete-embedded-icon"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        width="16"
+        height="16"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"
+        ></path>
+      </svg>
+      <input class="form-control" type="text" />
+    </div>
     <ul class="autocomplete-results">
       <li class="autocomplete-item" aria-selected="true">Option 1</li>
       <li class="autocomplete-item">Option 2</li>

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -14,7 +14,7 @@ A list of items used to show autocompleted results. Use the [`<auto-complete>`](
 <div class="position-relative">
   <label class="autocomplete-label-stacked">Search by user</label>
   <span class="autocomplete-body">
-    <input class="form-control" type="text">
+    <input class="form-control" type="text" />
     <ul class="autocomplete-results">
       <li class="autocomplete-item" aria-selected="true">Option 1</li>
       <li class="autocomplete-item">Option 2</li>
@@ -23,7 +23,11 @@ A list of items used to show autocompleted results. Use the [`<auto-complete>`](
   </span>
 </div>
 
-<style>.frame-example {height:160px;}</style>
+<style>
+  .frame-example {
+    height: 160px;
+  }
+</style>
 ```
 
 ## Inline label
@@ -32,16 +36,20 @@ A list of items used to show autocompleted results. Use the [`<auto-complete>`](
 <div class="position-relative">
   <label class="autocomplete-label-inline">Search by team</label>
   <span class="autocomplete-body">
-    <input class="form-control" type="text">
+    <input class="form-control" type="text" />
     <ul class="autocomplete-results">
       <li class="autocomplete-item" aria-selected="true">Team 1 (works on Ruby architecture)</li>
-      <li class="autocomplete-item">Team 2 (works on frontend JS architecture) </li>
+      <li class="autocomplete-item">Team 2 (works on frontend JS architecture)</li>
       <li class="autocomplete-item">Team 3 (this team works on design systems)</li>
     </ul>
   </span>
 </div>
 
-<style>.frame-example {height:160px;}</style>
+<style>
+  .frame-example {
+    height: 160px;
+  }
+</style>
 ```
 
 On smaller viewport, we switch to stacking.
@@ -50,16 +58,21 @@ On smaller viewport, we switch to stacking.
 <div class="position-relative">
   <label class="autocomplete-label-inline">Search by team</label>
   <span class="autocomplete-body">
-    <input class="form-control" type="text">
+    <input class="form-control" type="text" />
     <ul class="autocomplete-results">
       <li class="autocomplete-item" aria-selected="true">Team 1 (works on Ruby architecture)</li>
-      <li class="autocomplete-item">Team 2 (works on frontend JS architecture) </li>
+      <li class="autocomplete-item">Team 2 (works on frontend JS architecture)</li>
       <li class="autocomplete-item">Team 3 (this team works on design systems)</li>
     </ul>
   </span>
 </div>
 
-<style>.frame-example {height:160px;width:300px;}</style>
+<style>
+  .frame-example {
+    height: 160px;
+    width: 300px;
+  }
+</style>
 ```
 
 ## Embedded icon with visible label
@@ -70,9 +83,21 @@ Stacked label
 <div class="position-relative">
   <label class="autocomplete-label-stacked">Search by org</label>
   <span class="autocomplete-body">
-    <svg class="octicon autocomplete-embedded-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path></svg>
-    <input class="form-control" type="text">
-    <ul class="autocomplete-results autocomplete-results--embedded-icon">
+    <svg
+      class="octicon autocomplete-embedded-icon"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+      width="16"
+      height="16"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"
+      ></path>
+    </svg>
+    <input class="form-control" type="text" />
+    <ul class="autocomplete-results">
       <li class="autocomplete-item" aria-selected="true">Option 1</li>
       <li class="autocomplete-item">Option 2</li>
       <li class="autocomplete-item">Option 3</li>
@@ -80,14 +105,34 @@ Stacked label
   </span>
 </div>
 
+<style>
+  .frame-example {
+    height: 180px;
+  }
+</style>
+```
+
 Inline label
+
 ```html live
 <div class="position-relative">
   <label class="autocomplete-label-inline">Search by org</label>
   <span class="autocomplete-body">
-    <svg class="octicon autocomplete-embedded-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path></svg>
-    <input class="form-control" type="text">
-    <ul class="autocomplete-results autocomplete-results--embedded-icon">
+    <svg
+      class="octicon autocomplete-embedded-icon"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+      width="16"
+      height="16"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"
+      ></path>
+    </svg>
+    <input class="form-control" type="text" />
+    <ul class="autocomplete-results">
       <li class="autocomplete-item" aria-selected="true">Option 1</li>
       <li class="autocomplete-item">Option 2</li>
       <li class="autocomplete-item">Option 3</li>
@@ -95,7 +140,11 @@ Inline label
   </span>
 </div>
 
-<style>.frame-example {height:160px;}</style>
+<style>
+  .frame-example {
+    height: 160px;
+  }
+</style>
 ```
 
 ## Embedded icon with hidden label
@@ -104,9 +153,21 @@ Inline label
 <div class="position-relative">
   <label class="autocomplete-label-stacked sr-only">Search by org</label>
   <span class="autocomplete-body">
-    <svg aria-hidden="true" class="octicon autocomplete-embedded-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path></svg>
-    <input class="form-control" type="text">
-    <ul class="autocomplete-results autocomplete-results--embedded-icon">
+    <svg
+      aria-hidden="true"
+      class="octicon autocomplete-embedded-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+      width="16"
+      height="16"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"
+      ></path>
+    </svg>
+    <input class="form-control" type="text" />
+    <ul class="autocomplete-results">
       <li class="autocomplete-item" aria-selected="true">Option 1</li>
       <li class="autocomplete-item">Option 2</li>
       <li class="autocomplete-item">Option 3</li>
@@ -114,35 +175,45 @@ Inline label
   </span>
 </div>
 
-<style>.frame-example {height:160px;}</style>
+<style>
+  .frame-example {
+    height: 160px;
+  }
+</style>
 ```
 
 ## Additional content
+
 Autocomplete items can contain additional content, like an `.avatar`. Or use utility classes to customize the text style.
 
 ```html live
 <div class="position-relative">
-  <input class="form-control" type="text" aria-label="Search by user" placeholder="Search by user">
+  <input class="form-control" type="text" aria-label="Search by user" placeholder="Search by user" />
   <ul class="autocomplete-results">
     <li class="autocomplete-item" aria-selected="true">
-      <img src="https://github.com/github.png" width="20" class="avatar mr-1" alt="">
+      <img src="https://github.com/github.png" width="20" class="avatar mr-1" alt="" />
       <span>GitHub Inc.</span>
       <span class="text-normal">@github</span>
     </li>
     <li class="autocomplete-item">
-      <img src="https://github.com/hubot.png" width="20" class="avatar mr-1" alt="">
+      <img src="https://github.com/hubot.png" width="20" class="avatar mr-1" alt="" />
       <span>Hubot</span>
       <span class="text-normal">@hubot</span>
     </li>
     <li class="autocomplete-item">
-      <img src="https://github.com/octocat.png" width="20" class="avatar mr-1" alt="">
+      <img src="https://github.com/octocat.png" width="20" class="avatar mr-1" alt="" />
       <span>Monalisa Octocat</span>
       <span class="text-normal">@octocat</span>
     </li>
   </ul>
 </div>
 
-<style>.frame-example {width:300px;height:160px;}</style>
+<style>
+  .frame-example {
+    width: 300px;
+    height: 160px;
+  }
+</style>
 ```
 
 ## Suggester
@@ -151,30 +222,75 @@ The `.suggester` component is meant for showing suggestions while typing in a la
 
 ```html live
 <div class="form-group position-relative">
-  <textarea class="form-control width-full" placeholder="Leave a comment" aria-label="Comment body">This is on top of #</textarea>
+  <textarea class="form-control width-full" placeholder="Leave a comment" aria-label="Comment body">
+This is on top of #</textarea
+  >
   <ul class="suggester suggester-container" role="listbox" style="top: 4px; left: 125px;">
     <li aria-selected="true">
-      <svg class="octicon color-fg-subtle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"></path></svg>
+      <svg
+        class="octicon color-fg-subtle"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        width="16"
+        height="16"
+      >
+        <path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path>
+        <path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"></path>
+      </svg>
       <small>#924</small> <span>Markdown tables are inaccessible</span>
     </li>
     <li>
-      <svg class="octicon color-fg-success" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"></path></svg>
+      <svg
+        class="octicon color-fg-success"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        width="16"
+        height="16"
+      >
+        <path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path>
+        <path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"></path>
+      </svg>
       <small>#980</small> <span>Use actual book emoji in Flexbox docs</span>
     </li>
     <li>
-      <svg class="octicon color-fg-attention" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"></path></svg>
+      <svg
+        class="octicon color-fg-attention"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        width="16"
+        height="16"
+      >
+        <path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path>
+        <path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"></path>
+      </svg>
       <small>#979</small> <span>Add `.radio-group` component</span>
     </li>
     <li>
-      <svg class="octicon color-fg-danger" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"></path></svg>
+      <svg
+        class="octicon color-fg-danger"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        width="16"
+        height="16"
+      >
+        <path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path>
+        <path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"></path>
+      </svg>
       <small>#925</small> <span>Release 14.0.0</span>
     </li>
     <li>
-      <svg class="octicon color-fg-done" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"></path></svg>
+      <svg class="octicon color-fg-done" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+        <path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path>
+        <path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"></path>
+      </svg>
       <small>#978</small> <span>Add `.css-truncate-overflow`</span>
     </li>
   </ul>
 </div>
 
-<style>.frame-example {height:260px;}</style>
+<style>
+  .frame-example {
+    height: 260px;
+  }
+</style>
 ```

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -46,10 +46,6 @@
   box-shadow: var(--color-shadow-medium);
 }
 
-.autocomplete-results--embedded-icon {
-  // to do: define
-}
-
 // One of the items that appears within an autocomplete group
 // Bold black text on white background
 

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -8,8 +8,11 @@
 .autocomplete-label-inline {
   display: inline;
   margin-right: $spacer-2 * 0.75;
+}
 
-  @media (max-width: $width-sm) {
+// Switch to stacked at smaller viewport
+@media (max-width: $width-sm) {
+  .autocomplete-label-inline {
     display: block;
     margin-bottom: $spacer-2 * 0.75;
   }

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -1,6 +1,7 @@
 // Stacked label (default)
 .autocomplete-label-stacked {
   display: block;
+  margin-bottom: $spacer-2 * .75;
 }
 
 // Inline label (non-default)

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -20,7 +20,12 @@
 // Embedded icon
 .autocomplete-embedded-icon {
   position: absolute;
-  left: 0;
+  left: 5%;
+  top: 15%;
+
+  + input {
+    padding-left: 30px;
+  }
 }
 
 // A pop up list of items used to show autocompleted results

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -26,8 +26,8 @@
 
 // Wrapper and conditional styles for when an icon is added
 .autocomplete-embedded-icon-wrap {
-  padding: 4px 12px;
   display: inline-flex;
+  padding: $spacer-1 $spacer-2;
   align-items: center;
 
   &:focus-within {
@@ -37,10 +37,11 @@
   }
 
   .form-control {
-    border: none;
-    box-shadow: none;
     padding: 0;
     margin-left: $spacer-2;
+    // stylelint-disable-next-line
+    border: none;
+    box-shadow: none;
 
     &:focus {
       box-shadow: none;

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -1,6 +1,20 @@
+// label
+.autocomplete-label-inline {
+  display: inline;
+
+  @media (max-width: $width-sm) {
+    display: block;
+  }
+}
+
+.autocomplete-body {
+  position: relative;
+}
+
 // A pop up list of items used to show autocompleted results
 .autocomplete-results {
   position: absolute;
+  left: 0;
   z-index: 99;
   width: 100%;
   max-height: 20em;

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -20,11 +20,11 @@
 // Embedded icon
 .autocomplete-embedded-icon {
   position: absolute;
-  left: 5%;
   top: 15%;
+  left: 5%;
 
-  + input {
-    padding-left: 30px;
+  + .form-control {
+    padding-left: $spacer-5;
   }
 }
 

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -11,7 +11,7 @@
 
   @media (max-width: $width-sm) {
     display: block;
-     margin-bottom: $spacer-2 * .75;
+    margin-bottom: $spacer-2 * 0.75;
   }
 }
 

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -12,6 +12,12 @@
   position: relative;
 }
 
+// Embedded icon
+.autocomplete-embedded-icon { 
+  position: absolute;
+  left: 0;
+}
+
 // A pop up list of items used to show autocompleted results
 .autocomplete-results {
   position: absolute;
@@ -28,6 +34,10 @@
   border: $border-width $border-style var(--color-border-default);
   border-radius: $border-radius;
   box-shadow: var(--color-shadow-medium);
+}
+
+.autocomplete-results--embedded-icon {
+ // to do: define
 }
 
 // One of the items that appears within an autocomplete group

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -1,3 +1,8 @@
+// Stacked label (default)
+.autocomplete-label-stacked {
+  display: block;
+}
+
 // Inline label (non-default)
 .autocomplete-label-inline {
   display: inline;

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -17,6 +17,7 @@
   position: absolute;
   left: 0;
   z-index: 99;
+  min-width: 100%;
   width: max-content;
   max-height: 20em;
   overflow-y: auto;

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -1,4 +1,4 @@
-// label
+// Inline label (non-default)
 .autocomplete-label-inline {
   display: inline;
 
@@ -7,6 +7,7 @@
   }
 }
 
+// Wrapper for the input and result elements to ensure alignment
 .autocomplete-body {
   position: relative;
 }
@@ -16,7 +17,7 @@
   position: absolute;
   left: 0;
   z-index: 99;
-  width: 100%;
+  width: max-content;
   max-height: 20em;
   overflow-y: auto;
   // stylelint-disable-next-line primer/typography

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -18,7 +18,7 @@
 }
 
 // Embedded icon
-.autocomplete-embedded-icon { 
+.autocomplete-embedded-icon {
   position: absolute;
   left: 0;
 }
@@ -28,8 +28,8 @@
   position: absolute;
   left: 0;
   z-index: 99;
-  min-width: 100%;
   width: max-content;
+  min-width: 100%;
   max-height: 20em;
   overflow-y: auto;
   // stylelint-disable-next-line primer/typography
@@ -42,7 +42,7 @@
 }
 
 .autocomplete-results--embedded-icon {
- // to do: define
+  // to do: define
 }
 
 // One of the items that appears within an autocomplete group

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -20,8 +20,8 @@
 
 // Wrapper for the input and result elements to ensure alignment
 .autocomplete-body {
-  display: inline-block;
   position: relative;
+  display: inline-block;
 }
 
 // Wrapper and conditional styles for when an icon is added

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -7,7 +7,8 @@
 // Inline label (non-default)
 .autocomplete-label-inline {
   display: inline;
- margin-right: $spacer-2 * .75;
+  margin-right: $spacer-2 * 0.75;
+
   @media (max-width: $width-sm) {
     display: block;
      margin-bottom: $spacer-2 * .75;

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -7,7 +7,7 @@
 // Inline label (non-default)
 .autocomplete-label-inline {
   display: inline;
-
+ margin-right: $spacer-2 * .75;
   @media (max-width: $width-sm) {
     display: block;
   }

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -1,7 +1,7 @@
 // Stacked label (default)
 .autocomplete-label-stacked {
   display: block;
-  margin-bottom: $spacer-2 * .75;
+  margin-bottom: $spacer-2 * 0.75;
 }
 
 // Inline label (non-default)

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -20,6 +20,7 @@
 
 // Wrapper for the input and result elements to ensure alignment
 .autocomplete-body {
+  display: inline-block;
   position: relative;
 }
 

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -10,6 +10,7 @@
  margin-right: $spacer-2 * .75;
   @media (max-width: $width-sm) {
     display: block;
+     margin-bottom: $spacer-2 * .75;
   }
 }
 

--- a/src/autocomplete/autocomplete.scss
+++ b/src/autocomplete/autocomplete.scss
@@ -23,14 +23,27 @@
   position: relative;
 }
 
-// Embedded icon
-.autocomplete-embedded-icon {
-  position: absolute;
-  top: 15%;
-  left: 5%;
+// Wrapper and conditional styles for when an icon is added
+.autocomplete-embedded-icon-wrap {
+  padding: 4px 12px;
+  display: inline-flex;
+  align-items: center;
 
-  + .form-control {
-    padding-left: $spacer-5;
+  &:focus-within {
+    border-color: var(--color-accent-emphasis);
+    outline: none;
+    box-shadow: var(--color-primer-shadow-focus);
+  }
+
+  .form-control {
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    margin-left: $spacer-2;
+
+    &:focus {
+      box-shadow: none;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/github/accessibility/issues/897, https://github.com/github/accessibility/issues/924
[Design reference](https://github.com/github/accessibility/issues/897#issuecomment-1069326590)

### What are you trying to accomplish?

We're making [changes to the autocomplete API ](https://github.com/primer/view_components/pull/1050) which includes changes to the markup and styles.
In order to support the styles recommended by @alliethu in [Design reference](https://github.com/github/accessibility/issues/897#issuecomment-1069326590), we must make some CSS changes.

We want to support:

- [x] Stack label (default) (https://github.com/github/accessibility/issues/897)
- [x] Inline label (but switch to stacking on smaller viewport) (https://github.com/github/accessibility/issues/897)
- [x] Embedded icon with visible label (https://github.com/github/accessibility/issues/924)
- [x] Embedded icon with hidden label (https://github.com/github/accessibility/issues/924)

We should make sure:

- [ ] The autocomplete results are aligned to the input field.
- [ ] The icon positioning looks ok.
- [ ] Accessible examples

This introduces the following new classes:

- `autocomplete-body` to wrap the input field and results for correct positioning
- `autocomplete-label-stacked` to support stacked label position
- `autocomplete-label-inline` to support inline label position (which switches to stacking on smaller viewport)
- `autocomplete-embedded-icon` to support an embedded icon in the input field

### What should reviewers focus on?

When this is ready for review, let's get @alliethu eyes on the Preview.

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [ ] No, this PR should be ok to ship as is. 🚢 
