### PR TITLE
Add Tritanopia theme

### DIFF
--- a/.changeset/healthy-zoos-play.md
+++ b/.changeset/healthy-zoos-play.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Add Tritanopia theme

--- a/docs/src/stories/playground/ColorPlayground.stories.jsx
+++ b/docs/src/stories/playground/ColorPlayground.stories.jsx
@@ -2,11 +2,13 @@ import React from 'react'
 import clsx from 'clsx'
 import ColorBlock from '../helpers/ColorBlock'
 import DarkColorblind from '@primer/primitives/dist/json/colors/dark_colorblind.json'
+import DarkTritanopia from '@primer/primitives/dist/json/colors/dark_tritanopia.json'
 import DarkDimmed from '@primer/primitives/dist/json/colors/dark_dimmed.json'
 import DarkHighContrast from '@primer/primitives/dist/json/colors/dark_high_contrast.json'
 import Dark from '@primer/primitives/dist/json/colors/dark.json'
 import Light from '@primer/primitives/dist/json/colors/light.json'
 import LightColorblind from '@primer/primitives/dist/json/colors/light_colorblind.json'
+import LightTritanopia from '@primer/primitives/dist/json/colors/light_tritanopia.json'
 
 /*
 * Welcome to the Primer CSS Playground!
@@ -54,6 +56,10 @@ Color.parameters = {
         palette: DarkColorblind
       },
       {
+        name: 'dark_tritanopia',
+        palette: DarkTritanopia
+      },
+      {
         name: 'dark_dimmed',
         palette: DarkDimmed
       },
@@ -72,6 +78,10 @@ Color.parameters = {
       {
         name: 'light_colorblind',
         palette: LightColorblind
+      },
+      {
+        name: 'light_tritanopia',
+        palette: LightTritanopia
       }
     ]
   }

--- a/docs/src/stories/playground/Playground.stories.jsx
+++ b/docs/src/stories/playground/Playground.stories.jsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import clsx from 'clsx'
 import DarkColorblind from '@primer/primitives/dist/json/colors/dark_colorblind.json'
+import DarkTritanopia from '@primer/primitives/dist/json/colors/dark_tritanopia.json'
 import DarkDimmed from '@primer/primitives/dist/json/colors/dark_dimmed.json'
 import DarkHighContrast from '@primer/primitives/dist/json/colors/dark_high_contrast.json'
 import Dark from '@primer/primitives/dist/json/colors/dark.json'
 import Light from '@primer/primitives/dist/json/colors/light.json'
 import LightColorblind from '@primer/primitives/dist/json/colors/light_colorblind.json'
+import LightTritanopia from '@primer/primitives/dist/json/colors/light_tritanopia.json'
 // import useToggle from '../helpers/useToggle.jsx'
 // import ColorBlock from '../helpers/ColorBlock'
 // import { StoryTemplateName } from './OtherStoryFile.stories' // import stories for component compositions
@@ -87,6 +89,10 @@ Playground.parameters = {
         palette: DarkColorblind
       },
       {
+        name: 'dark_tritanopia',
+        palette: DarkTritanopia
+      },
+      {
         name: 'dark_dimmed',
         palette: DarkDimmed
       },
@@ -105,6 +111,10 @@ Playground.parameters = {
       {
         name: 'light_colorblind',
         palette: LightColorblind
+      },
+      {
+        name: 'light_tritanopia',
+        palette: LightTritanopia
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "storybook": "cd docs && yarn && yarn storybook"
   },
   "dependencies": {
-    "@primer/primitives": "0.0.0-20222256269"
+    "@primer/primitives": "^7.7.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "storybook": "cd docs && yarn && yarn storybook"
   },
   "dependencies": {
-    "@primer/primitives": "^7.5.1"
+    "@primer/primitives": "0.0.0-20222256269"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.3",

--- a/src/color-modes/index.scss
+++ b/src/color-modes/index.scss
@@ -3,8 +3,10 @@
 @import './themes/light.scss';
 @import './themes/light_colorblind.scss';
 @import './themes/light_high_contrast.scss';
+@import './themes/light_tritanopia.scss';
 @import './themes/dark.scss';
 @import './themes/dark_dimmed.scss';
 @import './themes/dark_high_contrast.scss';
 @import './themes/dark_colorblind.scss';
+@import './themes/dark_tritanopia.scss';
 @import './native.scss';

--- a/src/color-modes/themes/dark_tritanopia.scss
+++ b/src/color-modes/themes/dark_tritanopia.scss
@@ -1,0 +1,6 @@
+@import '../../support/index.scss';
+@import '@primer/primitives/dist/scss/colors/_dark_tritanopia.scss';
+
+@include color-mode-theme(dark_tritanopia) {
+  @include primer-colors-dark_tritanopia;
+}

--- a/src/color-modes/themes/light_tritanopia.scss
+++ b/src/color-modes/themes/light_tritanopia.scss
@@ -1,0 +1,6 @@
+@import '../../support/index.scss';
+@import '@primer/primitives/dist/scss/colors/_light_tritanopia.scss';
+
+@include color-mode-theme(light_tritanopia) {
+  @include primer-colors-light_tritanopia;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,10 +1148,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@primer/primitives@^7.5.1":
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.5.1.tgz#18aa8a0f3a3f7fd49fcad31a7efb86688bffb9de"
-  integrity sha512-1pFKR+FcYRPXJ+zK/qtidrCJB7WmTaAX4sG7zE5LvGWjS5latue4pzZrK0FxxGGBdAU3HpoabANsGjv7T7sRRg==
+"@primer/primitives@0.0.0-20222256269":
+  version "0.0.0-20222256269"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-0.0.0-20222256269.tgz#1c6d4955890dbf6295767c913612f77af2c0aa58"
+  integrity sha512-7tVjDsj9WotLX3IwnXb6fSUtqBjuv+aEM7qPy2OvLT3TQt2Zd2LOqtEi5w4Iv6POzjZlMuIGe1nr5EOBAuejFA==
 
 "@primer/stylelint-config@^12.3.3":
   version "12.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,10 +1148,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@primer/primitives@0.0.0-20222256269":
-  version "0.0.0-20222256269"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-0.0.0-20222256269.tgz#1c6d4955890dbf6295767c913612f77af2c0aa58"
-  integrity sha512-7tVjDsj9WotLX3IwnXb6fSUtqBjuv+aEM7qPy2OvLT3TQt2Zd2LOqtEi5w4Iv6POzjZlMuIGe1nr5EOBAuejFA==
+"@primer/primitives@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.7.0.tgz#4e838afaf997036720a43ebab0211d2de77b1606"
+  integrity sha512-LSd96U2/A70obilbdYiEKI8D/wXUtZnKmUI/ScLOlGDju4iuwd3pJsmFoBwM1Us6vV23V6mapIG+lh27RzauaA==
 
 "@primer/stylelint-config@^12.3.3":
   version "12.3.3"


### PR DESCRIPTION
### What are you trying to accomplish?

This is in support of https://github.com/github/primer/issues/844.

- [x] Bump `primer/primitives` to [`^7.7.0`](https://github.com/primer/primitives/pull/311)
- [x] Add 2 new (`light_tritanopia` and `dark_tritanopia`) themes.

Light colorblind | Light Tritanopia (✨  new)
--- | ---
<img width="93" alt="Screen Shot 2022-03-24 at 18 23 40" src="https://user-images.githubusercontent.com/378023/160065873-1f05f15a-eea9-4a90-b58d-f2e6f9d043c1.png"> | <img width="92" alt="Screen Shot 2022-03-24 at 18 23 55" src="https://user-images.githubusercontent.com/378023/160065881-071de6eb-6d8a-4f48-a6ca-251453f0ab96.png">

### What approach did you choose and why?

Duplicate anything with `colorblind` and replace it with `tritanopia`. For reasoning see https://github.com/github/design-infrastructure/issues/2154.

### What should reviewers focus on?

Anything missing? Any concerns?

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. 
-->

- [x] No, this PR should be ok to ship as is. 🚢 
