### PR TITLE
Always break long `branch-name`s

### DIFF
--- a/.changeset/early-spoons-greet.md
+++ b/.changeset/early-spoons-greet.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Always break long `branch-name`s

--- a/src/branch-name/branch-name.scss
+++ b/src/branch-name/branch-name.scss
@@ -10,6 +10,7 @@
   color: var(--color-fg-muted);
   background-color: var(--color-accent-subtle);
   border-radius: $border-radius;
+  word-break: break-all;
 
   .octicon {
     // stylelint-disable-next-line primer/spacing

--- a/src/branch-name/branch-name.scss
+++ b/src/branch-name/branch-name.scss
@@ -8,9 +8,9 @@
   padding: 2px 6px;
   font: 12px $mono-font;
   color: var(--color-fg-muted);
+  word-break: break-all;
   background-color: var(--color-accent-subtle);
   border-radius: $border-radius;
-  word-break: break-all;
 
   .octicon {
     // stylelint-disable-next-line primer/spacing


### PR DESCRIPTION
### What are you trying to accomplish?

This fixes https://github.com/github/primer/issues/788 and makes sure that long `branch-name` wrap also when using `_` or `.` as separators.

### What approach did you choose and why?

Add `word-break: break-all;`

### What should reviewers focus on?

One concern with this is that words separated with a dash (`-`) will wrap whenever there is no space and not after the dash. See https://github.com/github/primer/issues/788#issuecomment-1072309002.

<img width="321" alt="line awkwardly cut mid-word" src="https://user-images.githubusercontent.com/1863771/158992394-69f31c3e-5e5e-43f8-a691-27fe7c16a5f3.png">
 
### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] No, this PR should be ok to ship as is. 🚢 
