### PR TITLE
Update CDN link with version 19

### DIFF
--- a/docs/content/getting-started/index.md
+++ b/docs/content/getting-started/index.md
@@ -122,5 +122,5 @@ Since GitHub pages is currently [locked to version `1.5.2` of `jekyll-sass-conve
 You won't need to install any node modules or Sass compilers for a static site; you can use the built CSS. The best thing to do is to [download the built CSS](https://unpkg.com/@primer/css/dist/primer.css) from the [unpkg.com](https://unpkg.com) and host it yourself. If that's not an option, you can include a CDN link in your HTML:
 
 ```html
-<link href="https://unpkg.com/@primer/css@^16.0.0/dist/primer.css" rel="stylesheet" />
+<link href="https://unpkg.com/@primer/css@^19.0.0/dist/primer.css" rel="stylesheet" />
 ```


### PR DESCRIPTION
The documentation for installation has the CDN link pointing to version 16 which is outdated. The current one is 19.