### PR TITLE
Add undocumented border radius value

### DIFF
--- a/docs/content/utilities/borders.mdx
+++ b/docs/content/utilities/borders.mdx
@@ -64,7 +64,7 @@ Use `border-dashed` to give an element a dashed border.
 
 ## Rounded corners
 
-Use the following utilities to add or remove rounded corners: `rounded-0` removes rounded corners, `rounded-1` applies a border radius of 4px, `rounded-2` applies a border radius of 6px. `.circle` applies a border radius of 50%, which turns square elements into perfect circles.
+Use the following utilities to add or remove rounded corners: `rounded-0` removes rounded corners, `rounded-1` applies a border radius of 4px, `rounded-2` applies a border radius of 6px, and `rounded-3` applies a border radius of 8px. `.circle` applies a border radius of 50%, which turns square elements into perfect circles.
 
 ```html live
 <div class="border rounded-0 p-2 mb-2">


### PR DESCRIPTION
`rounded-3` appears in the rendered examples but its value wasn't explicit in the preceding written documentation.