### PR TITLE
Fix `hasPane` default value for Layout stories

### DIFF
--- a/docs/src/stories/components/Layout/LayoutBeta.stories.jsx
+++ b/docs/src/stories/components/Layout/LayoutBeta.stories.jsx
@@ -326,6 +326,7 @@ export const LayoutTemplate = ({
   innerSpacing = innerSpacing ?? 'none'
   columnGap = columnGap ?? 'normal'
   rowGap = rowGap ?? 'normal'
+  hasPane = hasPane ?? true
   panePosition = panePosition ?? 'end'
   panePositionWhenNarrow = panePositionWhenNarrow ?? 'inherit'
   responsiveVariant = responsiveVariant ?? 'stackRegions'

--- a/docs/src/stories/components/Layout/SplitPageLayout.stories.jsx
+++ b/docs/src/stories/components/Layout/SplitPageLayout.stories.jsx
@@ -34,6 +34,13 @@ export default {
 
     // Pane
 
+    hasPane: {
+      control: {type: 'boolean'},
+      table: {
+        category: 'Pane'
+      }
+    },
+
     paneWidth: {
       options: ['default', 'narrow', 'wide'],
       control: {
@@ -98,6 +105,7 @@ export const SplitPageLayoutTemplate = ({
   _debug,
   padding,
   primaryRegion,
+  hasPane,
   paneWidth,
   paneIsSticky,
   contentWidth,
@@ -119,6 +127,7 @@ export const SplitPageLayoutTemplate = ({
         rowGap="none"
         responsiveVariant="separateRegions"
         primaryRegion={primaryRegion}
+        hasPane={hasPane}
         paneWidth={paneWidth}
         paneIsSticky={paneIsSticky}
         panePosition="start"
@@ -152,6 +161,7 @@ Playground.args = {
   primaryRegion: 'content',
 
   // Pane
+  hasPane: true,
   paneWidth: 'wide',
 
   // Content


### PR DESCRIPTION
### What are you trying to accomplish?

A quick fix for layout component stories. A follow-up of https://github.com/primer/css/pull/1989.

This update makes sure `hasPane` default value is true and is exposed as part of the SplitPageLayout story.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
