### PR TITLE
Force production docs to deploy on each push to main

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -3,11 +3,6 @@ on:
   push:
     branches:
       - 'main'
-    paths:
-      - 'src/**'
-      - 'docs/**'
-      - '.github/workflows/deploy*.yml'
-      - 'package.json'
 
 permissions:
   contents: write


### PR DESCRIPTION
https://primer.style/css/ is not showing the expected production deployment.

This is because GitHub Pages resets the production environment on each push to `main`, which happens outside of our control

This PR will fix this by ensuring that _all_ pushes to `main` branch deploy the docs each time, by removing the the file/folder pattern matching.