### PR TITLE
Fix headings with an anchor in a summary

### DIFF
--- a/.changeset/hip-readers-press.md
+++ b/.changeset/hip-readers-press.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fix headings with an anchor in a summary

--- a/src/markdown/headings.scss
+++ b/src/markdown/headings.scss
@@ -80,6 +80,10 @@
     h5,
     h6 {
       display: inline-block;
+
+      .anchor {
+        margin-left: -40px;
+      }
     }
 
     h1,

--- a/src/markdown/headings.scss
+++ b/src/markdown/headings.scss
@@ -82,6 +82,7 @@
       display: inline-block;
 
       .anchor {
+        // stylelint-disable-next-line primer/spacing
         margin-left: -40px;
       }
     }


### PR DESCRIPTION
### What are you trying to accomplish?

This is a follow-up to https://github.com/primer/css/pull/1949 and fixes https://github.com/primer/css/pull/1949#issuecomment-1111589587 where the `.anchor` overlaps the summary triangle.

Before | After
--- | ---
![Screen Shot 2022-04-28 at 16 34 25](https://user-images.githubusercontent.com/378023/165702563-d09e0b19-1589-46e8-a771-56ea181bb56c.png) | ![Screen Shot 2022-04-28 at 16 34 01](https://user-images.githubusercontent.com/378023/165702556-f5269285-0491-48c6-82a4-6d1263be3c22.png)

### What approach did you choose and why?

The `.anchor` gets positioned with https://github.com/primer/css/blob/75dfecc3be3def65ffb5c3ef146f6bc75301e5f8/src/markdown/markdown-body.scss#L53

But when adding a `<summary>` there is that expand triangle that pushes the heading to the right. So this PR increases the negative margin to  `-40px`:



### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
