### PR TITLE
Add `.text-capitalize` utility class

### DIFF
--- a/.changeset/four-dancers-dress.md
+++ b/.changeset/four-dancers-dress.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Add `.text-capitalize` utility class

--- a/docs/content/utilities/typography.md
+++ b/docs/content/utilities/typography.md
@@ -105,6 +105,7 @@ Change the font weight, styles, and alignment with these utilities.
 <p class="lead">Bacon ipsum dolor amet tri-tip chicken kielbasa, cow swine beef corned beef ground round prosciutto hamburger porchetta sausage alcatra tail.</p>
 <p class="text-mono">Monospace</p>
 <p class="user-select-none">User Select None</p>
+<p class="text-capitalize">capitalize</p>
 ```
 
 ## Word-break

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -243,3 +243,8 @@
 .user-select-none {
   user-select: none !important;
 }
+
+/* Make text capitalized (transforms first character to uppercase) */
+.text-capitalize {
+  text-transform: capitalize !important;
+}


### PR DESCRIPTION
### What are you trying to accomplish?

Adds the `.text-capitalize` utility class!

### What approach did you choose and why?

There are some cases where capitalizing text just can't be done in its initial rendering (ex: on the server), so CSS text transformation becomes the easiest approach. This PR adds the `.text-capitalize` class - similar to `text-uppercase` et al, it sets `text-transform: capitalize`.

### What should reviewers focus on?

Nothing!

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 
