### PR TITLE
Fix layout sticky pane modifier name

### DIFF
--- a/.changeset/nine-dragons-wave.md
+++ b/.changeset/nine-dragons-wave.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Changing `PageLayout--isPaneSticky` to `PageLayout--sticky`.

--- a/docs/src/stories/components/Layout/LayoutBeta.stories.jsx
+++ b/docs/src/stories/components/Layout/LayoutBeta.stories.jsx
@@ -371,7 +371,6 @@ export const LayoutTemplate = ({
           paneWidth && layoutClassName + '--paneWidth-' + `${paneWidth}`,
           panePosition && layoutClassName + '--panePos-' + `${panePosition}`,
           hasPaneDivider && layoutClassName + '--hasPaneDivider',
-          paneIsSticky && layoutClassName + '--isPaneSticky',
 
           layoutClassName + '--responsive-' + `${responsiveVariant}`,
           responsiveVariant === 'separateRegions' && layoutClassName + '--responsive-primary-' + `${primaryRegion}`,
@@ -403,6 +402,7 @@ export const LayoutTemplate = ({
                   className={clsx(
                     layoutClassName + '-region',
                     layoutClassName + '-pane',
+                    paneIsSticky && layoutClassName + '-pane--sticky',
                     paneDividerWhenNarrow &&
                       layoutClassName +
                         '-region--dividerNarrow-' +
@@ -433,6 +433,7 @@ export const LayoutTemplate = ({
                   className={clsx(
                     layoutClassName + '-region',
                     layoutClassName + '-pane',
+                    paneIsSticky && layoutClassName + '-pane--sticky',
                     paneDividerWhenNarrow &&
                       layoutClassName +
                         '-region--dividerNarrow-' +

--- a/docs/src/stories/components/Layout/SplitPageLayout.stories.jsx
+++ b/docs/src/stories/components/Layout/SplitPageLayout.stories.jsx
@@ -163,6 +163,7 @@ Playground.args = {
   // Pane
   hasPane: true,
   paneWidth: 'wide',
+  paneIsSticky: true,
 
   // Content
   contentWidth: 'full',

--- a/src/layout/page-layout.scss
+++ b/src/layout/page-layout.scss
@@ -111,12 +111,15 @@ $Layout-responsive-variant-max-breakpoint: 'md' !default;
 
     // sticky pane
 
-    &.PageLayout--isPaneSticky {
-      .PageLayout-pane {
-        position: sticky;
-        top: 0;
-        max-height: 100vh;
-        overflow: auto;
+    .PageLayout-pane--sticky {
+      position: sticky;
+      top: 0;
+      max-height: 100vh;
+      overflow: auto;
+      scrollbar-width: thin;
+
+      @supports (max-height: 100dvh) {
+        max-height: 100dvh;
       }
     }
 


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes the name of the `sticky` pane modifier from an incorrect "isPaneSticky" format in the top-level element, into a specific `--sticky` modifier, to match with Primer's [BEM-style naming and structure](https://primer.style/css/principles#bem-style-naming-and-structure).

This modifier class will be consumed by SplitPageLayout directly, as a style base for sticky pane regions. This issue being being internally tracked at https://github.com/github/primer/issues/1013 (only available for hubbers)

### Can these changes ship as is?

It doesn't look like any page relies on this class. An [internal search](https://cs.github.com/github/github?q=isPaneSticky) (only available for hubbers) doesn't show any results.

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
