### PR TITLE
Marketing: Bump font size of large buttons

### DIFF
--- a/.changeset/plenty-windows-brush.md
+++ b/.changeset/plenty-windows-brush.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Marketing: Bump font size of large buttons

--- a/src/marketing/buttons/button.scss
+++ b/src/marketing/buttons/button.scss
@@ -158,7 +158,7 @@
 
 .btn-large-mktg {
   // stylelint-disable-next-line primer/spacing
-  padding: 20px 30px 23px !important;
+  padding: 16px 30px 20px !important;
   // stylelint-disable-next-line primer/typography
   font-size: 1.25rem;
 }

--- a/src/marketing/buttons/button.scss
+++ b/src/marketing/buttons/button.scss
@@ -159,4 +159,6 @@
 .btn-large-mktg {
   // stylelint-disable-next-line primer/spacing
   padding: 20px 30px 23px !important;
+  // stylelint-disable-next-line primer/typography
+  font-size: 1.25rem;
 }


### PR DESCRIPTION
Bumps the font size from `16px` to `20px` for large marketing buttons, to align with how button's have been outlined in Figma.