### PR TITLE
Add missing ToggleSwitch--checked styles

### DIFF
--- a/.changeset/dirty-mails-stare.md
+++ b/.changeset/dirty-mails-stare.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Add missing ToggleSwitch--checked styles

--- a/src/toggle-switch/toggle-switch.scss
+++ b/src/toggle-switch/toggle-switch.scss
@@ -16,6 +16,18 @@
   }
 }
 
+.ToggleSwitch--checked {
+  .ToggleSwitch-statusOn {
+    height: auto;
+    visibility: visible;
+  }
+
+  .ToggleSwitch-statusOff {
+    height: 0;
+    visibility: hidden;
+  }
+}
+
 .ToggleSwitch-track {
   position: relative;
   display: block;

--- a/src/toggle-switch/toggle-switch.scss
+++ b/src/toggle-switch/toggle-switch.scss
@@ -1,3 +1,9 @@
+// Catalyst in dotcom applies a display: block to all web component elements. This
+// rule overrides it so the status label and toggle switch are laid out correctly.
+.ToggleSwitch.ToggleSwitch {
+  display: inline-flex;
+}
+
 .ToggleSwitch {
   align-items: center;
   display: inline-flex;


### PR DESCRIPTION
### What are you trying to accomplish?

Somewhere along the line I accidentally removed the styles for the `.ToggleSwitch--checked` selector. Oops.

### What approach did you choose and why?

Add them back in.

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 
