### PR TITLE
Remove note and example about role

### DIFF
--- a/docs/content/components/buttons.md
+++ b/docs/content/components/buttons.md
@@ -12,6 +12,12 @@ Buttons are used for **actions**, like in forms, while textual hyperlinks are us
 <button class="btn" type="button">Button</button>
 ```
 
+Note: When using a `<button>` element, **always specify a `type`**.
+
+```html live
+<button class="btn mr-2" type="button">Button button</button>
+```
+
 ## Button types
 
 ### Default

--- a/docs/content/components/buttons.md
+++ b/docs/content/components/buttons.md
@@ -12,13 +12,6 @@ Buttons are used for **actions**, like in forms, while textual hyperlinks are us
 <button class="btn" type="button">Button</button>
 ```
 
-Note: When using a `<button>` element, **always specify a `type`**. When using a `<a>` element, **always add `role="button"` for accessibility**.
-
-```html live
-<button class="btn mr-2" type="button">Button button</button>
-<a class="btn" href="#url" role="button">Link button</a>
-```
-
 ## Button types
 
 ### Default


### PR DESCRIPTION
Removing the text about role and example. If you're using `<button>` from HTML semantics, no role is needed. If you're using an `<a>` element, it should not be overridden with `role=button`, it needs to stay as a link if it is truly a link.