### PR TITLE
Fix ActionList-item hover border on contrast themes

### DIFF
--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -37,7 +37,7 @@
           outline: $border-style $border-width transparent;
           outline-offset: -$border-width;
           // stylelint-disable-next-line primer/box-shadow
-          box-shadow: inset 0 0 0 2px var(--color-action-list-item-default-active-border);
+          box-shadow: inset 0 0 0 $border-width var(--color-action-list-item-default-active-border);
         }
       }
     }
@@ -50,7 +50,7 @@
         outline: $border-style $border-width transparent;
         outline-offset: -$border-width;
         // stylelint-disable-next-line primer/box-shadow
-        box-shadow: inset 0 0 0 2px var(--color-action-list-item-default-active-border);
+        box-shadow: inset 0 0 0 $border-width var(--color-action-list-item-default-active-border);
       }
 
       @media screen and (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
### What are you trying to accomplish?

This is a quick fix for ActionList item borders. In contrast themes, they appeared with a 2px border-width on hover. 

Before:
![Before](https://user-images.githubusercontent.com/293280/171463259-d3e8c43a-9924-4c0c-a8e5-1bbad59ab6d1.png)

After:
![After](https://user-images.githubusercontent.com/293280/171463393-a06a1d92-7b19-4a9f-a474-1d42a484400c.png)


<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->
### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
