### PR TITLE
Revert "Bump eslint-plugin-jest from 26.1.5 to 26.4.6"

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "cssstats": "4.0.5",
     "eslint": "8.14.0",
     "eslint-plugin-github": "4.3.6",
-    "eslint-plugin-jest": "26.4.6",
+    "eslint-plugin-jest": "26.1.5",
     "eslint-plugin-prettier": "4.0.0",
     "filesize": "8.0.7",
     "front-matter": "4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,10 +2315,10 @@ eslint-plugin-import@^2.25.2:
     resolve "^1.20.0"
     tsconfig-paths "^3.11.0"
 
-eslint-plugin-jest@26.4.6:
-  version "26.4.6"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.4.6.tgz#9d8184c1ecf077722a20cc236c7e14f4e263606f"
-  integrity sha512-R3mq1IepnhtsukHQsWxdyKra3OVwYB+N4k8i45ndqSfr8p9KZV6G+EIUt1Z7hzAh4KlsbXG+nCTlNeGFLFLNvA==
+eslint-plugin-jest@26.1.5:
+  version "26.1.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.1.5.tgz#6cfca264818d6d6aa120b019dab4d62b6aa8e775"
+  integrity sha512-su89aDuljL9bTjEufTXmKUMSFe2kZUL9bi7+woq+C2ukHZordhtfPm4Vg+tdioHBaKf8v3/FXW9uV0ksqhYGFw==
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 


### PR DESCRIPTION
Reverts primer/css#2113

Seems to cause an [issue](https://github.com/primer/css/runs/6723775658?check_suite_focus=true) with deploying.