### PR TITLE
Fix focus outline on selected UnderlineNav-item

### DIFF
--- a/src/navigation/underline-nav.scss
+++ b/src/navigation/underline-nav.scss
@@ -85,7 +85,6 @@ $nav-height: $spacer-3 * 3 !default; // 48px
     font-weight: $font-weight-bold;
     color: var(--color-fg-default);
     border-bottom-color: var(--color-primer-border-active);
-    outline-offset: -8px;
 
     // current/selected underline
     &::after {


### PR DESCRIPTION
### What are you trying to accomplish?

This is a quick fix to make the selected UnderlineNav item inherit the default `outline-offset`, as seen in the repo tabs, or directly in [Storybook](https://primer.style/css/storybook/?path=/story/components-navigation-underlinenav--playground).

Before:
![Incorrect outline](https://user-images.githubusercontent.com/293280/174348421-80b2cd9b-1991-4c9d-8297-6229dd8fa5a1.png)


After:
> ![Outline correctly aligned](https://user-images.githubusercontent.com/293280/174348366-f0f83a50-23c3-41c5-a3a1-d005d6720589.png)


### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 

c/c @langermank 