### PR TITLE
Fix select mask

### DIFF
--- a/.changeset/grumpy-balloons-nail.md
+++ b/.changeset/grumpy-balloons-nail.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Use -webkit- vendor prefix for mask-\* properties

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -43,10 +43,9 @@ jobs:
         uses: chrnorm/deployment-status@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          environment_url: '${{ needs.deploy.outputs.deployment_url }}/storybook'
-          target_url: '${{ needs.deploy.outputs.deployment_url }}/storybook'
+          environment-url: '${{ needs.deploy.outputs.deployment_url }}/storybook'
           state: 'success'
-          deployment_id: ${{ steps.storybook.outputs.deployment_id }}
+          deployment-id: ${{ steps.storybook.outputs.deployment_id }}
 
       - name: Update storybook deployment status (failure)
         if: failure()
@@ -54,4 +53,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           state: 'failure'
-          deployment_id: ${{ steps.storybook.outputs.deployment_id }}
+          deployment-id: ${{ steps.storybook.outputs.deployment_id }}

--- a/src/forms/FormControl.scss
+++ b/src/forms/FormControl.scss
@@ -114,7 +114,7 @@
   height: var(--primer-control-medium-size, 32px);
   background-color: var(--color-canvas-default);
   border-radius: var(--primer-borderRadius-medium, 6px);
-  box-shadow: var(--primer-borderInset-thin, 1px) var(--color-border-default);
+  box-shadow: var(--primer-borderInset-thin, inset 0 0 0 max(1px, 0.0625rem)) var(--color-border-default);
   grid-template-rows: auto;
   gap: var(--primer-controlStack-medium-gap-condensed, 8px);
   align-items: center;
@@ -143,7 +143,7 @@
   }
 
   &.FormControl-fieldWrap--invalid:not(:focus-within) {
-    box-shadow: var(--primer-borderInset-thin, 1px) var(--color-danger-emphasis);
+    box-shadow: var(--primer-borderInset-thin, inset 0 0 0 max(1px, 0.0625rem)) var(--color-danger-emphasis);
   }
 
   // if leadingVisual is present
@@ -262,7 +262,12 @@
     pointer-events: none;
     content: '';
     background-color: var(--color-fg-muted);
-    mask: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0iIzU4NjA2OSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNNC40MjcgOS40MjdsMy4zOTYgMy4zOTZhLjI1MS4yNTEgMCAwMC4zNTQgMGwzLjM5Ni0zLjM5NkEuMjUuMjUgMCAwMDExLjM5NiA5SDQuNjA0YS4yNS4yNSAwIDAwLS4xNzcuNDI3ek00LjQyMyA2LjQ3TDcuODIgMy4wNzJhLjI1LjI1IDAgMDEuMzU0IDBMMTEuNTcgNi40N2EuMjUuMjUgMCAwMS0uMTc3LjQyN0g0LjZhLjI1LjI1IDAgMDEtLjE3Ny0uNDI3eiIgLz48L3N2Zz4=');
+    // webkit only supports mask properties with the -webkit- prefix
+    // stylelint-disable-next-line property-no-vendor-prefix
+    -webkit-mask-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0iIzU4NjA2OSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNNC40MjcgOS40MjdsMy4zOTYgMy4zOTZhLjI1MS4yNTEgMCAwMC4zNTQgMGwzLjM5Ni0zLjM5NkEuMjUuMjUgMCAwMDExLjM5NiA5SDQuNjA0YS4yNS4yNSAwIDAwLS4xNzcuNDI3ek00LjQyMyA2LjQ3TDcuODIgMy4wNzJhLjI1LjI1IDAgMDEuMzU0IDBMMTEuNTcgNi40N2EuMjUuMjUgMCAwMS0uMTc3LjQyN0g0LjZhLjI1LjI1IDAgMDEtLjE3Ny0uNDI3eiIgLz48L3N2Zz4=');
+    // stylelint-disable-next-line property-no-vendor-prefix
+    -webkit-mask-size: cover;
+    mask-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0iIzU4NjA2OSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNNC40MjcgOS40MjdsMy4zOTYgMy4zOTZhLjI1MS4yNTEgMCAwMC4zNTQgMGwzLjM5Ni0zLjM5NkEuMjUuMjUgMCAwMDExLjM5NiA5SDQuNjA0YS4yNS4yNSAwIDAwLS4xNzcuNDI3ek00LjQyMyA2LjQ3TDcuODIgMy4wNzJhLjI1LjI1IDAgMDEuMzU0IDBMMTEuNTcgNi40N2EuMjUuMjUgMCAwMS0uMTc3LjQyN0g0LjZhLjI1LjI1IDAgMDEtLjE3Ny0uNDI3eiIgLz48L3N2Zz4=');
     mask-size: cover;
     grid-column: 2;
     grid-row: 1;


### PR DESCRIPTION
### What are you trying to accomplish?

The new `.FormControl` styles work nicely, but the SVG mask used for select lists appears as a gray box in Webkit browsers like Chrome:

![image](https://user-images.githubusercontent.com/575280/174405654-1bd52660-d431-44f7-a61a-0d2e22fb7fba.png)

### What approach did you choose and why?

According to [caniuse](https://caniuse.com/css-masks), `mask-*` properties are only supported via the `-webkit-` vendor prefix. Adding the prefix appears to fix the problem:

![image](https://user-images.githubusercontent.com/575280/174405879-cff8da9d-b09b-4666-a04f-0151c994bf9d.png)

### What should reviewers focus on?

I had to tell stylelint to ignore the `-webkit-` prefix here, which feels dirty but I don't think there's another way.

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 
