### PR TITLE
Fix preview deploys

### DIFF
--- a/.changeset/fuzzy-ladybugs-jog.md
+++ b/.changeset/fuzzy-ladybugs-jog.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fix preview deploys

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -43,10 +43,9 @@ jobs:
         uses: chrnorm/deployment-status@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          environment_url: '${{ needs.deploy.outputs.deployment_url }}/storybook'
-          target_url: '${{ needs.deploy.outputs.deployment_url }}/storybook'
+          environment-url: '${{ needs.deploy.outputs.deployment_url }}/storybook'
           state: 'success'
-          deployment_id: ${{ steps.storybook.outputs.deployment_id }}
+          deployment-id: ${{ steps.storybook.outputs.deployment_id }}
 
       - name: Update storybook deployment status (failure)
         if: failure()
@@ -54,4 +53,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           state: 'failure'
-          deployment_id: ${{ steps.storybook.outputs.deployment_id }}
+          deployment-id: ${{ steps.storybook.outputs.deployment_id }}


### PR DESCRIPTION
### What are you trying to accomplish?

Preview deploys are currently broken.

![image](https://user-images.githubusercontent.com/575280/174407768-e0aa977d-0776-49e7-ba3a-407651096c76.png)

### What approach did you choose and why?

It looks like a couple of the keys for the deployment-status action changed in v2.0.

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 
