### PR TITLE
AppFrame component

### DIFF
--- a/.changeset/lovely-rivers-bow.md
+++ b/.changeset/lovely-rivers-bow.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Add AppFrame component

--- a/docs/src/stories/components/Layout/AppFrame.stories.jsx
+++ b/docs/src/stories/components/Layout/AppFrame.stories.jsx
@@ -1,0 +1,142 @@
+import React from 'react'
+import clsx from 'clsx'
+//import { AppHeaderTemplate as AppHeader } from '../App/AppHeader.stories'
+
+export default {
+  title: 'Components/Layout/AppFrame',
+  parameters: {
+    layout: 'fullscreen'
+  },
+
+  excludeStories: ['AppFrameTemplate'],
+  argTypes: {
+
+    // Debug
+
+    _debug: {
+      control: {
+        type: 'boolean',
+      }
+    },
+
+    a11yNavItems: {
+      type: 'array',
+    },
+
+    // Children
+
+    headerChildren: {
+      description: 'creates a slot for header children',
+      table: {
+        category: 'HTML'
+      }
+    },
+    subheaderChildren: {
+      description: 'creates a slot for subheader children',
+      table: {
+        category: 'HTML'
+      }
+    },
+    bodyChildren: {
+      description: 'creates a slot for body children',
+      table: {
+        category: 'HTML'
+      }
+    },
+    footerChildren: {
+      description: 'creates a slot for footer children',
+      table: {
+        category: 'HTML'
+      }
+    },
+  },
+}
+
+export const AppFrameTemplate = ({
+  _debug,
+  a11yNavItems,
+  headerChildren,
+  subheaderChildren,
+  bodyChildren,
+  footerChildren,
+}) => {
+
+  // Default values
+  a11yNavItems = a11yNavItems ?? [
+    {url: '#start-of-content', label: 'Skip to content'},
+    {url: '/', label: 'GitHub homepage'},
+  ];
+
+  return (
+    <>
+      <div className={clsx('AppFrame')}>
+
+        <div className={clsx('AppFrame-a11yNav')}>
+          {a11yNavItems.map(link => (
+            <a className={clsx('AppFrame-a11yLink')} href={link.url}>{link.label}</a>
+          ))}
+        </div>
+
+        <div className={clsx('AppFrame-main')}>
+
+          <div className={clsx('AppFrame-header-wrapper')}>
+
+            <div className={clsx('AppFrame-header')}>
+              {headerChildren}
+            </div>
+
+            <div id="start-of-content"></div>
+
+            {subheaderChildren && (
+              <div className={clsx('AppFrame-subheader')}>
+                {subheaderChildren}
+                </div>
+            )}
+
+          </div>
+          <div className={clsx('AppFrame-body')}>
+            {bodyChildren}
+          </div>
+        </div>
+        <div className={clsx('AppFrame-footer')}>
+          {footerChildren}
+        </div>
+      </div>
+
+      {_debug && (
+        <>
+          <style type="text/css">{`
+            .AppFrame {
+
+            }
+            .AppFrame-header,
+            .AppFrame-subheader,
+            .AppFrame-body,
+            .AppFrame-footer {
+              padding: 16px;
+            }
+            .AppFrame-header {
+              background: pink;
+            }
+            .AppFrame-subheader {
+              background: lightblue;
+            }
+            .AppFrame-footer {
+              background: pink;
+            }
+          `}</style>
+        </>
+      )}
+    </>
+  );
+};
+
+export const Playground = AppFrameTemplate.bind({})
+
+Playground.args = {
+  _debug: true,
+  headerChildren: "Header slot",
+  subheaderChildren: "Subheader slot",
+  bodyChildren: "Body slot",
+  footerChildren: "Footer slot",
+};

--- a/src/layout/app-frame.scss
+++ b/src/layout/app-frame.scss
@@ -1,0 +1,153 @@
+// stylelint-disable max-nesting-depth
+// stylelint-disable selector-max-specificity
+// stylelint-disable no-duplicate-selectors
+
+.AppFrame {
+
+  // AppFrame structure
+  // ===================
+  // 
+  // .AppFrame
+  // ├─ .AppFrame-a11yNav
+  // │  ├─ .AppFrame-a11yLink
+  // │
+  // ├─ .AppFrame-main
+  // │  ├─ .AppFrame-header-wrapper
+  // │  │   ├─ .AppFrame-header
+  // │  │   ├─ .AppFrame-subheader
+  // │  │
+  // │  ├─ #start-of-content
+  // │  ├─ .AppFrame-body
+  // │  ├─ .AppFrame-footer
+
+  
+  // Accessibility navigation
+
+  .AppFrame-a11yNav {
+    position: absolute;
+    padding: var(--base-size-16, 16px);
+    padding-block-end: calc(var(--base-size-16, 16px) - var(--primer-borderWidth-thin, 1px));
+    background: var(--color-canvas-inset);
+    isolation: isolate;
+    z-index: 1000;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--base-size-8, 8px);
+
+    &:not(:focus-within) {
+      clip: rect(1px, 1px, 1px, 1px);
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      border: 0;
+      padding: 0;
+      overflow: hidden;
+    }
+
+    &:focus-within {
+      top: 0;
+      left: 0;
+
+      // Narrow viewport
+      @media (max-width: #{map-get($breakpoints, 'md') - 0.02px}) {
+        justify-content: center;
+      }
+    }
+  }
+
+  .AppFrame-a11yLink {
+    transition: none;
+
+    &:not(:focus) {
+      width: var(--base-size-8, 8px);
+      height: var(--base-size-8, 8px);
+      display: block;
+      overflow: hidden;
+      text-indent: var(--base-size-128);
+      border-radius: 100%;
+      background: var(--color-border-default);
+      pointer-events: none;
+    }
+
+    &:focus {
+      display: grid;
+      z-index: 20;
+      width: auto;
+      height: auto;
+      overflow: auto;
+      border-radius: var(--primer-borderRadius-full, 100vh);
+      min-height: var(--primer-control-medium-size, 32px);
+      align-items: center;
+      padding: 0 var(--primer-control-medium-paddingInline-spacious, 16px);
+      background: var(--color-accent-emphasis);
+      color: var(--color-fg-on-emphasis);
+
+      @media (pointer: coarse) {
+        &:after {
+          @include minTouchTarget(var(--primer-control-minTarget-coarse, 44px));
+        }
+      }
+
+      @media (prefers-reduced-motion: no-preference) {
+        animation: AppFrame-a11yLink-focus 200ms ease-out;
+      }
+
+      @keyframes AppFrame-a11yLink-focus {
+        0% {
+          transform: scale(0.3, 0.25);
+          color: var(--color-accent-emphasis);
+        }
+        50% {
+          transform: scale(1, 1);
+          color: var(--color-accent-emphasis);
+        }
+        55% {
+          color: var(--color-fg-on-emphasis);
+        }
+        100% {
+          transform: scaleX(1);
+        }
+      }
+    }
+  }
+
+  .AppFrame-main {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+
+    @supports (height: 100dvh) {
+      min-height: 100dvh;
+    }
+  }
+
+  .AppFrame-header-wrapper {
+    position: relative;
+    overflow: visible; 
+    height: min-content;
+
+    .AppFrame-header {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+  }
+
+  .AppFrame-header {
+    flex: 0 0 auto;
+  }
+
+  .AppFrame-subheader {
+    flex: 0 0 auto;
+  }
+
+  .AppFrame-body {
+    flex: 1 0;
+    height: 100%;
+  }
+
+  .AppFrame-footer {
+    flex: 0 0 auto;
+  }
+}

--- a/src/layout/app-frame.scss
+++ b/src/layout/app-frame.scss
@@ -66,7 +66,7 @@
       text-indent: var(--base-size-128, 128px);
       pointer-events: none;
       background: var(--color-border-default);
-      border-radius: 50%;
+      border-radius: var(--primer-borderRadius-full, 100vh);
     }
 
     &:focus {

--- a/src/layout/app-frame.scss
+++ b/src/layout/app-frame.scss
@@ -63,7 +63,7 @@
       width: var(--base-size-8, 8px);
       height: var(--base-size-8, 8px);
       overflow: hidden;
-      text-indent: var(--base-size-128);
+      text-indent: var(--base-size-128, 128px);
       pointer-events: none;
       background: var(--color-border-default);
       border-radius: 50%;

--- a/src/layout/app-frame.scss
+++ b/src/layout/app-frame.scss
@@ -1,12 +1,12 @@
 // stylelint-disable max-nesting-depth
-// stylelint-disable selector-max-specificity
-// stylelint-disable no-duplicate-selectors
+// stylelint-disable primer/spacing
+// stylelint-disable primer/borders
 
 .AppFrame {
 
   // AppFrame structure
   // ===================
-  // 
+  //
   // .AppFrame
   // ├─ .AppFrame-a11yNav
   // │  ├─ .AppFrame-a11yLink
@@ -20,29 +20,28 @@
   // │  ├─ .AppFrame-body
   // │  ├─ .AppFrame-footer
 
-  
   // Accessibility navigation
 
   .AppFrame-a11yNav {
     position: absolute;
-    padding: var(--base-size-16, 16px);
-    padding-block-end: calc(var(--base-size-16, 16px) - var(--primer-borderWidth-thin, 1px));
-    background: var(--color-canvas-inset);
-    isolation: isolate;
     z-index: 1000;
-    width: 100%;
     display: flex;
+    width: 100%;
+    padding: var(--base-size-16, 16px);
+    background: var(--color-canvas-inset);
+    padding-block-end: calc(var(--base-size-16, 16px) - var(--primer-borderWidth-thin, 1px));
+    isolation: isolate;
     align-items: center;
     gap: var(--base-size-8, 8px);
 
     &:not(:focus-within) {
-      clip: rect(1px, 1px, 1px, 1px);
       width: 1px;
       height: 1px;
-      margin: -1px;
-      border: 0;
       padding: 0;
+      margin: -1px;
       overflow: hidden;
+      clip: rect(1px, 1px, 1px, 1px);
+      border: 0;
     }
 
     &:focus-within {
@@ -60,31 +59,31 @@
     transition: none;
 
     &:not(:focus) {
+      display: block;
       width: var(--base-size-8, 8px);
       height: var(--base-size-8, 8px);
-      display: block;
       overflow: hidden;
       text-indent: var(--base-size-128);
-      border-radius: 100%;
-      background: var(--color-border-default);
       pointer-events: none;
+      background: var(--color-border-default);
+      border-radius: 50%;
     }
 
     &:focus {
-      display: grid;
       z-index: 20;
+      display: grid;
       width: auto;
       height: auto;
-      overflow: auto;
-      border-radius: var(--primer-borderRadius-full, 100vh);
       min-height: var(--primer-control-medium-size, 32px);
-      align-items: center;
       padding: 0 var(--primer-control-medium-paddingInline-spacious, 16px);
-      background: var(--color-accent-emphasis);
+      overflow: auto;
       color: var(--color-fg-on-emphasis);
+      background: var(--color-accent-emphasis);
+      border-radius: var(--primer-borderRadius-full, 100vh);
+      align-items: center;
 
       @media (pointer: coarse) {
-        &:after {
+        &::after {
           @include minTouchTarget(var(--primer-control-minTarget-coarse, 44px));
         }
       }
@@ -95,16 +94,19 @@
 
       @keyframes AppFrame-a11yLink-focus {
         0% {
+          color: var(--color-accent-emphasis);
           transform: scale(0.3, 0.25);
-          color: var(--color-accent-emphasis);
         }
+
         50% {
-          transform: scale(1, 1);
           color: var(--color-accent-emphasis);
+          transform: scale(1, 1);
         }
+
         55% {
           color: var(--color-fg-on-emphasis);
         }
+
         100% {
           transform: scaleX(1);
         }
@@ -114,8 +116,8 @@
 
   .AppFrame-main {
     display: flex;
-    flex-direction: column;
     min-height: 100vh;
+    flex-direction: column;
 
     @supports (height: 100dvh) {
       min-height: 100dvh;
@@ -124,8 +126,8 @@
 
   .AppFrame-header-wrapper {
     position: relative;
-    overflow: visible; 
     height: min-content;
+    overflow: visible;
 
     .AppFrame-header {
       position: sticky;

--- a/src/layout/index.scss
+++ b/src/layout/index.scss
@@ -1,4 +1,5 @@
 @import '../support/index.scss';
+@import './app-frame.scss';
 @import './mixins.scss';
 @import './container.scss';
 @import './grid.scss';


### PR DESCRIPTION
AppFrame is a thin wrapper that holds the page together, while making sure that the page's global footer is always visible "after the fold". This guarantees that loading states won't show the footer temporarily, and allows the footer to include richer interactions without obfuscating or competing with the page contents.

### Features
- Accessible navigation with "Skip to content"-style anchors
- Unopinionated generic slots/regions for:
  - `header`
  - `subheader`
  - `body`
  - `footer`

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
