### PR TITLE
Add Stack component

### DIFF
--- a/.changeset/thick-coats-yawn.md
+++ b/.changeset/thick-coats-yawn.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Add Stack component

--- a/docs/src/stories/components/Layout/Stack.stories.js
+++ b/docs/src/stories/components/Layout/Stack.stories.js
@@ -1,0 +1,209 @@
+import React from 'react'
+import clsx from 'clsx'
+
+export default {
+  title: 'Components/Layout/Stack',
+  excludeStories: ['StackTemplate'],
+  argTypes: {
+
+    // Debug
+
+    _debug: {
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        category: 'Debug'
+      },
+    },
+
+    // Direction
+
+    direction: {
+      options: ['inline', 'block'],
+      control: {
+        type: 'inline-radio',
+      },
+    },
+    narrow_direction: {
+      options: ['inline', 'block'],
+      control: {
+        type: 'inline-radio',
+      },
+      table: {
+        category: 'Narrow viewport'
+      },
+    },
+
+    // Gap
+
+    gap: {
+      options: ['none', 'condensed', 'normal', 'spacious', 'custom'],
+      control: {
+        type: 'inline-radio',
+      },
+    },
+    narrow_gap: {
+      options: ['none', 'condensed', 'normal', 'custom'],
+      control: {
+        type: 'inline-radio',
+      },
+      table: {
+        category: 'Narrow viewport'
+      },
+    },
+    gap_custom: {
+      control: {
+        type: 'string'
+      },
+    },
+    narrow_gap_custom: {
+      control: {
+        type: 'string'
+      },
+      table: {
+        category: 'Narrow viewport'
+      },
+    },
+
+    // Align
+
+    align: {
+      options: ['start', 'center', 'end'],
+      control: {
+        type: 'inline-radio'
+      },
+    },
+    narrow_align: {
+      options: ['start', 'center', 'end'],
+      control: {
+        type: 'inline-radio'
+      },
+      table: {
+        category: 'Narrow viewport'
+      },
+    },
+
+    // Wrap
+
+    wrap: {
+      options: ['wrap', 'nowrap'],
+      control: {
+        type: 'inline-radio'
+      },
+    },
+    narrow_wrap: {
+      options: ['wrap', 'nowrap'],
+      control: {
+        type: 'inline-radio'
+      },
+      table: {
+        category: 'Narrow viewport'
+      },
+    },
+
+    // Divider
+
+    divider: {
+      control: {
+        type: 'boolean'
+      },
+    },
+    narrow_divider: {
+      control: {
+        type: 'boolean'
+      },
+      table: {
+        category: 'Narrow viewport'
+      },
+    },
+  },
+};
+
+export const StackTemplate = ({
+  _debug,
+  direction,
+  gap,
+  gap_custom,
+  align,
+  wrap,
+  divider,
+
+  narrow_direction,
+  narrow_gap,
+  narrow_gap_custom,
+  narrow_align,
+  narrow_wrap,
+  narrow_divider
+}) => {
+
+
+
+  return (
+    <>
+      <div className={clsx(
+          'Stack',
+          direction && 'Stack--' + `${direction}`,
+          gap && 'Stack--' + `${gap}`,
+          align && 'Stack--' + `${align}`,
+          wrap && 'Stack--' + `${wrap}`,
+        )}
+      >
+        
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+        <div>4</div>
+        <div>5</div>
+        <div>6</div>
+      </div>
+
+      {_debug && (
+        <>
+          <style type="text/css">{`
+            .Stack {
+              background: beige;
+            }
+            .Stack > * {
+              padding: 8px;
+              border-radius: 6px;
+            }
+            .Stack :nth-child(1) {
+              background: lightblue;
+              width: 6ch;
+            }
+            .Stack :nth-child(2) {
+              background: coral;
+              width: 9ch;
+            }
+            .Stack :nth-child(3) {
+              background: darkseagreen;
+              width: 8ch;
+            }
+            .Stack :nth-child(4) {
+              background: khaki;
+              width: 7ch;
+            }
+            .Stack :nth-child(5) {
+              background: lightpink;
+              width: 10ch;
+            }
+            .Stack :nth-child(6) {
+              background: lightsalmon;
+              width: 6ch;
+            }
+          `}</style>
+        </>
+      )}
+    </>
+  );
+};
+
+export const Playground = StackTemplate.bind({})
+
+Playground.args = {
+  _debug: true,
+  direction: "block",
+  gap: "normal",
+  align: "start",
+};

--- a/docs/src/stories/components/Layout/Stack.stories.js
+++ b/docs/src/stories/components/Layout/Stack.stories.js
@@ -24,6 +24,11 @@ export default {
       control: {
         type: 'inline-radio',
       },
+      table: {
+        defaultValue: {
+          summary: 'block',
+        }
+      }
     },
     narrow_direction: {
       options: ['inline', 'block'],
@@ -42,6 +47,11 @@ export default {
       control: {
         type: 'inline-radio',
       },
+      table: {
+        defaultValue: {
+          summary: 'normal',
+        }
+      }
     },
     narrow_gap: {
       options: ['none', 'condensed', 'normal', 'custom'],
@@ -54,12 +64,12 @@ export default {
     },
     gap_custom: {
       control: {
-        type: 'string'
+        type: 'text'
       },
     },
     narrow_gap_custom: {
       control: {
-        type: 'string'
+        type: 'text'
       },
       table: {
         category: 'Narrow viewport'
@@ -69,10 +79,15 @@ export default {
     // Align
 
     align: {
-      options: ['start', 'center', 'end'],
+      options: ['normal', 'start', 'center', 'end'],
       control: {
         type: 'inline-radio'
       },
+      table: {
+        defaultValue: {
+          summary: 'normal',
+        }
+      }
     },
     narrow_align: {
       options: ['start', 'center', 'end'],
@@ -91,6 +106,11 @@ export default {
       control: {
         type: 'inline-radio'
       },
+      table: {
+        defaultValue: {
+          summary: 'nowrap',
+        }
+      }
     },
     narrow_wrap: {
       options: ['wrap', 'nowrap'],
@@ -108,6 +128,22 @@ export default {
       control: {
         type: 'boolean'
       },
+      table: {
+        defaultValue: {
+          summary: 'false',
+        }
+      }
+    },
+    divider_role: {
+      options: ['presentation', 'separator', 'none'],
+      control: {
+        type: 'inline-radio'
+      },
+      table: {
+        defaultValue: {
+          summary: 'presentation',
+        }
+      }
     },
     narrow_divider: {
       control: {
@@ -137,25 +173,53 @@ export const StackTemplate = ({
   narrow_divider
 }) => {
 
+  let custom_styles  = {};
 
+  // Gap
+  if (gap === 'custom') {
+    custom_styles['--Stack-gap'] = gap_custom;
+  }
+  if (narrow_gap === 'custom') {
+    custom_styles['--Stack-gap-whenNarrow'] = narrow_gap_custom;
+  }
+
+  // Null values for states that don't require a modifier class
+  align = align === 'normal' ? null : align
 
   return (
     <>
-      <div className={clsx(
+      <div
+        className={clsx(
           'Stack',
-          direction && 'Stack--' + `${direction}`,
-          gap && 'Stack--' + `${gap}`,
-          align && 'Stack--' + `${align}`,
+          direction && 'Stack--dir-' + `${direction}`,
+          narrow_direction && 'Stack--dir-' + `${narrow_direction}-whenNarrow`,
+
+          gap && 'Stack--gap-' + `${gap}`,
+          narrow_gap && 'Stack--gap-' + `${narrow_gap}-whenNarrow`,
+
+          align && 'Stack--align-' + `${align}`,
+          narrow_align && 'Stack--align-' + `${narrow_align}-whenNarrow`,
+
           wrap && 'Stack--' + `${wrap}`,
+          narrow_wrap && 'Stack--' + `${narrow_wrap}-whenNarrow`,
+
+          divider && 'Stack--showDividers',
+          narrow_divider && 'Stack--showDividers-whenNarrow' // Todo: how about hide dividers when narrow?
+
         )}
+        style={custom_styles}
       >
-        
-        <div>1</div>
-        <div>2</div>
-        <div>3</div>
-        <div>4</div>
-        <div>5</div>
-        <div>6</div>
+        <div className="_debug _debug-item-1">1</div>
+        {divider && ( <><hr className="Stack-divider" role="presentation" /></> )}
+        <div className="_debug _debug-item-2">2</div>
+        {divider && ( <><hr className="Stack-divider" role="presentation" /></> )}
+        <div className="_debug _debug-item-3">3</div>
+        {divider && ( <><hr className="Stack-divider" role="presentation" /></> )}
+        <div className="_debug _debug-item-4">4</div>
+        {divider && ( <><hr className="Stack-divider" role="presentation" /></> )}
+        <div className="_debug _debug-item-5">5</div>
+        {divider && ( <><hr className="Stack-divider" role="presentation" /></> )}
+        <div className="_debug _debug-item-6">6</div>
       </div>
 
       {_debug && (
@@ -164,33 +228,39 @@ export const StackTemplate = ({
             .Stack {
               background: beige;
             }
-            .Stack > * {
+            .Stack ._debug {
               padding: 8px;
               border-radius: 6px;
             }
-            .Stack :nth-child(1) {
+            .Stack ._debug-item-1 {
               background: lightblue;
-              width: 6ch;
+              min-inline-size: 6ch;
+              font-size: 1rem;
             }
-            .Stack :nth-child(2) {
+            .Stack ._debug-item-2 {
               background: coral;
-              width: 9ch;
+              min-inline-size: 9ch;
+              font-size: 1.25rem;
             }
-            .Stack :nth-child(3) {
+            .Stack ._debug-item-3 {
               background: darkseagreen;
-              width: 8ch;
+              inline-size: 8ch;
+              font-size: 1rem;
             }
-            .Stack :nth-child(4) {
+            .Stack ._debug-item-4 {
               background: khaki;
-              width: 7ch;
+              inline-size: 7ch;
+              font-size: 1.25rem;
             }
-            .Stack :nth-child(5) {
+            .Stack ._debug-item-5 {
               background: lightpink;
-              width: 10ch;
+              inline-size: 10ch;
+              font-size: 1rem;
             }
-            .Stack :nth-child(6) {
+            .Stack ._debug-item-6 {
               background: lightsalmon;
-              width: 6ch;
+              inline-size: 6ch;
+              font-size: 1.25rem;
             }
           `}</style>
         </>
@@ -205,5 +275,6 @@ Playground.args = {
   _debug: true,
   direction: "block",
   gap: "normal",
-  align: "start",
+  gap_custom: undefined,
+  align: "normal",
 };

--- a/docs/src/stories/components/Layout/Stack.stories.jsx
+++ b/docs/src/stories/components/Layout/Stack.stories.jsx
@@ -73,10 +73,10 @@ export default {
       },
       description: `Sets the spacing gap between items. All sizes are rendered in \`rem\` units.
 - \`none\`: 0
-- \`condensed\`: 8px
-- \`normal\`: 16px (default)
-- \`spacious\`: 24px (on regular viewports, otherwise 16px on narrow viewports)
-- \`custom\`: set a custom size. In ViewComponent or React, a custom value can be passed directly.
+- \`condensed\`: \`var(--primer-stack-gap-condensed, 8px)\`,
+- \`normal\`: \`var(--primer-stack-gap-normal, 16px)\` (default)
+- \`spacious\`: \`var(--primer-stack-gap-spacious, 24px)\` (on regular viewports, otherwise it appears as \`normal\` on narrow viewports)
+- \`custom\`: set a custom size. When using with a framework such as ViewComponent or React, a custom value can be passed directly to the property.
  `,
       table: {
         category: 'Properties',
@@ -123,7 +123,7 @@ export default {
         type: 'inline-radio'
       },
       description: `Sets the alignment between items in the cross-axis of the specified direction. For example:
-- If \`direction\` is set to \`block\` (stacks vertically), it controls the horizontal aligment (left, center, right).
+- If \`direction\` is set to \`block\` (stacks vertically), it controls the horizontal alignment (left, center, right).
 - If \`direction\` is set to \`inline\` (stacks horizontally), it controls the vertical alignment (top, center, bottom).
 
 This property behavior is equivalent to the \`align-items\` Flexbox property.`,

--- a/docs/src/stories/components/Layout/Stack.stories.jsx
+++ b/docs/src/stories/components/Layout/Stack.stories.jsx
@@ -24,19 +24,21 @@ export default {
       control: {
         type: 'inline-radio',
       },
+      description: 'Sets how elements inside `Stack` are placed, either horizontally (`inline`) or vertically (`block`).',
       table: {
+        category: 'Properties',
         defaultValue: {
           summary: 'block',
         }
       }
     },
     narrow_direction: {
-      options: ['inline', 'block'],
+      options: ['inherit', 'inline', 'block'],
       control: {
         type: 'inline-radio',
       },
       table: {
-        category: 'Narrow viewport'
+        category: 'Narrow viewport properties'
       },
     },
 
@@ -47,24 +49,36 @@ export default {
       control: {
         type: 'inline-radio',
       },
+      description: `Sets the spacing gap between elements inside \`Stack\`. All sizes are rendered in \`rem\` units.
+- \`none\`: 0
+- \`condensed\`: 8px
+- \`normal\`: 16px (default)
+- \`spacious\`: 24px (on regular viewports, otherwise 16px on narrow viewports)
+- \`custom\`: set a custom size. In ViewComponent or React, a custom value can be passed directly.
+ `,
       table: {
+        category: 'Properties',
         defaultValue: {
           summary: 'normal',
         }
       }
     },
     narrow_gap: {
-      options: ['none', 'condensed', 'normal', 'custom'],
+      options: ['inherit', 'none', 'condensed', 'normal', 'custom'],
       control: {
         type: 'inline-radio',
       },
       table: {
-        category: 'Narrow viewport'
+        category: 'Narrow viewport properties'
       },
     },
     gap_custom: {
       control: {
         type: 'text'
+      },
+      description: 'A custom value to `gap`. Refer to [Primer Primitives](https://primer.style/primitives/spacing) for other spacing tokens. Example: `var(--base-size-12, 12px)`.',
+      table: {
+        category: 'Properties',
       },
     },
     narrow_gap_custom: {
@@ -72,7 +86,7 @@ export default {
         type: 'text'
       },
       table: {
-        category: 'Narrow viewport'
+        category: 'Narrow viewport properties'
       },
     },
 
@@ -84,18 +98,22 @@ export default {
         type: 'inline-radio'
       },
       table: {
+        category: 'Properties',
         defaultValue: {
           summary: 'normal',
         }
       }
     },
     narrow_align: {
-      options: ['start', 'center', 'end'],
+      options: ['inherit', 'normal', 'start', 'center', 'end'],
       control: {
         type: 'inline-radio'
       },
       table: {
-        category: 'Narrow viewport'
+        category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit',
+        }
       },
     },
 
@@ -107,18 +125,19 @@ export default {
         type: 'inline-radio'
       },
       table: {
+        category: 'Properties',
         defaultValue: {
           summary: 'nowrap',
         }
       }
     },
     narrow_wrap: {
-      options: ['wrap', 'nowrap'],
+      options: ['inherit', 'wrap', 'nowrap'],
       control: {
         type: 'inline-radio'
       },
       table: {
-        category: 'Narrow viewport'
+        category: 'Narrow viewport properties'
       },
     },
 
@@ -129,6 +148,7 @@ export default {
         type: 'boolean'
       },
       table: {
+        category: 'Properties',
         defaultValue: {
           summary: 'false',
         }
@@ -140,6 +160,7 @@ export default {
         type: 'inline-radio'
       },
       table: {
+        category: 'Properties',
         defaultValue: {
           summary: 'presentation',
         }
@@ -150,9 +171,14 @@ export default {
         type: 'boolean'
       },
       table: {
-        category: 'Narrow viewport'
+        category: 'Narrow viewport properties'
       },
     },
+
+    // Children
+    children: {
+      description: 'A slot for children elements.'
+    }
   },
 };
 
@@ -170,10 +196,17 @@ export const StackTemplate = ({
   narrow_gap_custom,
   narrow_align,
   narrow_wrap,
-  narrow_divider
+  narrow_divider,
+
+  children
 }) => {
 
   let custom_styles  = {};
+  const hasDividers = divider || narrow_divider;
+
+  // Default values
+  direction = direction ?? 'block'
+  gap = gap ?? 'normal'
 
   // Gap
   if (gap === 'custom') {
@@ -183,8 +216,15 @@ export const StackTemplate = ({
     custom_styles['--Stack-gap-whenNarrow'] = narrow_gap_custom;
   }
 
-  // Null values for states that don't require a modifier class
+  // Null value for states that don't require a modifier class
   align = align === 'normal' ? null : align
+
+  // Null value for inherit responsive values
+  narrow_direction = narrow_direction === 'inherit' ? null : narrow_direction;
+  narrow_gap = narrow_gap === 'inherit' ? null : narrow_gap;
+  narrow_align = narrow_align === 'inherit' ? null : narrow_align;
+  narrow_wrap = narrow_wrap === 'inherit' ? null : narrow_wrap;
+  narrow_divider = narrow_divider === 'inherit' ? null : narrow_divider;
 
   return (
     <>
@@ -204,22 +244,29 @@ export const StackTemplate = ({
           narrow_wrap && 'Stack--' + `${narrow_wrap}-whenNarrow`,
 
           divider && 'Stack--showDividers',
-          narrow_divider && 'Stack--showDividers-whenNarrow' // Todo: how about hide dividers when narrow?
+          narrow_divider === true && 'Stack--showDividers-whenNarrow',
+          narrow_divider === false && 'Stack--hideDividers-whenNarrow',
 
         )}
         style={custom_styles}
       >
-        <div className="_debug _debug-item-1">1</div>
-        {divider && ( <><hr className="Stack-divider" role="presentation" /></> )}
-        <div className="_debug _debug-item-2">2</div>
-        {divider && ( <><hr className="Stack-divider" role="presentation" /></> )}
-        <div className="_debug _debug-item-3">3</div>
-        {divider && ( <><hr className="Stack-divider" role="presentation" /></> )}
-        <div className="_debug _debug-item-4">4</div>
-        {divider && ( <><hr className="Stack-divider" role="presentation" /></> )}
-        <div className="_debug _debug-item-5">5</div>
-        {divider && ( <><hr className="Stack-divider" role="presentation" /></> )}
-        <div className="_debug _debug-item-6">6</div>
+        {children}
+        
+        {!children && (
+          <>
+            <div className="_debug _debug-item-1">1</div>
+            {hasDividers && ( <><hr className="Stack-divider" role="presentation" /></> )}
+            <div className="_debug _debug-item-2">2</div>
+            {hasDividers && ( <><hr className="Stack-divider" role="presentation" /></> )}
+            <div className="_debug _debug-item-3">3</div>
+            {hasDividers && ( <><hr className="Stack-divider" role="presentation" /></> )}
+            <div className="_debug _debug-item-4">4</div>
+            {hasDividers && ( <><hr className="Stack-divider" role="presentation" /></> )}
+            <div className="_debug _debug-item-5">5</div>
+            {hasDividers && ( <><hr className="Stack-divider" role="presentation" /></> )}
+            <div className="_debug _debug-item-6">6</div>
+          </>
+        )}
       </div>
 
       {_debug && (
@@ -270,7 +317,6 @@ export const StackTemplate = ({
 };
 
 export const Playground = StackTemplate.bind({})
-
 Playground.args = {
   _debug: true,
   direction: "block",

--- a/docs/src/stories/components/Layout/Stack.stories.jsx
+++ b/docs/src/stories/components/Layout/Stack.stories.jsx
@@ -38,7 +38,10 @@ export default {
         type: 'inline-radio',
       },
       table: {
-        category: 'Narrow viewport properties'
+        category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit'
+        }
       },
     },
 
@@ -69,7 +72,10 @@ export default {
         type: 'inline-radio',
       },
       table: {
-        category: 'Narrow viewport properties'
+        category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit'
+        }
       },
     },
     gap_custom: {
@@ -90,22 +96,20 @@ export default {
       },
     },
 
-    // Align
-
     align: {
-      options: ['normal', 'start', 'center', 'end'],
+      options: ['stretch', 'start', 'center', 'end', 'baseline'],
       control: {
         type: 'inline-radio'
       },
       table: {
         category: 'Properties',
         defaultValue: {
-          summary: 'normal',
+          summary: 'stretch',
         }
       }
     },
     narrow_align: {
-      options: ['inherit', 'normal', 'start', 'center', 'end'],
+      options: ['inherit', 'stretch', 'start', 'center', 'end', 'baseline'],
       control: {
         type: 'inline-radio'
       },
@@ -113,6 +117,62 @@ export default {
         category: 'Narrow viewport properties',
         defaultValue: {
           summary: 'inherit',
+        }
+      },
+    },
+
+    // Align wrap
+
+    alignWrap: {
+      options: ['start', 'center', 'end', 'distribute', 'distributeEvenly'],
+      control: {
+        type: 'inline-radio'
+      },
+      table: {
+        category: 'Properties',
+        defaultValue: {
+          summary: 'start',
+        }
+      }
+    },
+
+    narrow_alignWrap: {
+      options: ['inherit', 'start', 'center', 'end', 'distribute', 'distributeEvenly'],
+      control: {
+        type: 'inline-radio'
+      },
+      table: {
+        category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit',
+        }
+      },
+    },
+
+    // Spread
+
+    spread: {
+      options: ['start', 'center', 'end', 'distribute', 'distributeEvenly'],
+      control: {
+        type: 'inline-radio',
+      },
+      table: {
+        category: 'Properties',
+        defaultValue: {
+          summary: 'start',
+        },
+      },
+    },
+
+    narrow_spread: {
+      options: ['inherit', 'start', 'center', 'end', 'distribute', 'distributeEvenly'],
+      control: {
+        type: 'inline-radio',
+      },
+      table: {
+        category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit'
         }
       },
     },
@@ -137,13 +197,16 @@ export default {
         type: 'inline-radio'
       },
       table: {
-        category: 'Narrow viewport properties'
+        category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit'
+        }
       },
     },
 
     // Divider
 
-    divider: {
+    showDividers: {
       control: {
         type: 'boolean'
       },
@@ -154,7 +217,7 @@ export default {
         }
       }
     },
-    divider_role: {
+    dividerAriaRole: {
       options: ['presentation', 'separator', 'none'],
       control: {
         type: 'inline-radio'
@@ -166,18 +229,24 @@ export default {
         }
       }
     },
-    narrow_divider: {
+    narrow_showDividers: {
       control: {
         type: 'boolean'
       },
       table: {
-        category: 'Narrow viewport properties'
+        category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit'
+        }
       },
     },
 
     // Children
     children: {
-      description: 'A slot for children elements.'
+      description: 'A slot for children elements.',
+      table: {
+        category: 'HTML'
+      }
     }
   },
 };
@@ -188,25 +257,31 @@ export const StackTemplate = ({
   gap,
   gap_custom,
   align,
+  alignWrap,
+  spread,
   wrap,
-  divider,
+  showDividers,
+  dividerAriaRole,
 
   narrow_direction,
   narrow_gap,
   narrow_gap_custom,
   narrow_align,
+  narrow_alignWrap,
+  narrow_spread,
   narrow_wrap,
-  narrow_divider,
+  narrow_showDividers,
 
   children
 }) => {
 
   let custom_styles  = {};
-  const hasDividers = divider || narrow_divider;
+  const hasDividers = showDividers || narrow_showDividers;
 
   // Default values
   direction = direction ?? 'block'
   gap = gap ?? 'normal'
+  dividerAriaRole = dividerAriaRole ?? 'presentation'
 
   // Gap
   if (gap === 'custom') {
@@ -217,14 +292,17 @@ export const StackTemplate = ({
   }
 
   // Null value for states that don't require a modifier class
-  align = align === 'normal' ? null : align
+  align = align === 'stretch' ? null : align;
+  spread = spread === 'start' ? null : spread;
 
   // Null value for inherit responsive values
   narrow_direction = narrow_direction === 'inherit' ? null : narrow_direction;
   narrow_gap = narrow_gap === 'inherit' ? null : narrow_gap;
   narrow_align = narrow_align === 'inherit' ? null : narrow_align;
+  narrow_alignWrap = narrow_alignWrap === 'inherit' ? null : narrow_alignWrap;
+  narrow_spread = narrow_spread === 'inherit' ? null : narrow_spread;
   narrow_wrap = narrow_wrap === 'inherit' ? null : narrow_wrap;
-  narrow_divider = narrow_divider === 'inherit' ? null : narrow_divider;
+  narrow_showDividers = narrow_showDividers === 'inherit' ? null : narrow_showDividers;
 
   return (
     <>
@@ -238,14 +316,18 @@ export const StackTemplate = ({
           narrow_gap && 'Stack--gap-' + `${narrow_gap}-whenNarrow`,
 
           align && 'Stack--align-' + `${align}`,
+          alignWrap && 'Stack--alignWrap-' + `${alignWrap}`,
           narrow_align && 'Stack--align-' + `${narrow_align}-whenNarrow`,
+          narrow_align && 'Stack--alignWrap-' + `${narrow_align}-whenNarrow`,
+          spread && 'Stack--spread-' + `${spread}`,
+          narrow_spread && 'Stack--spread-' + `${spread}-whenNarrow`,
 
           wrap && 'Stack--' + `${wrap}`,
           narrow_wrap && 'Stack--' + `${narrow_wrap}-whenNarrow`,
 
-          divider && 'Stack--showDividers',
-          narrow_divider === true && 'Stack--showDividers-whenNarrow',
-          narrow_divider === false && 'Stack--hideDividers-whenNarrow',
+          showDividers && 'Stack--showDividers',
+          narrow_showDividers === true && 'Stack--showDividers-whenNarrow',
+          narrow_showDividers === false && 'Stack--hideDividers-whenNarrow',
 
         )}
         style={custom_styles}
@@ -255,15 +337,15 @@ export const StackTemplate = ({
         {!children && (
           <>
             <div className="_debug _debug-item-1">1</div>
-            {hasDividers && ( <><hr className="Stack-divider" role="presentation" /></> )}
+            {hasDividers && ( <><hr className="Stack-divider" role={dividerAriaRole} /></> )}
             <div className="_debug _debug-item-2">2</div>
-            {hasDividers && ( <><hr className="Stack-divider" role="presentation" /></> )}
+            {hasDividers && ( <><hr className="Stack-divider" role={dividerAriaRole} /></> )}
             <div className="_debug _debug-item-3">3</div>
-            {hasDividers && ( <><hr className="Stack-divider" role="presentation" /></> )}
+            {hasDividers && ( <><hr className="Stack-divider" role={dividerAriaRole} /></> )}
             <div className="_debug _debug-item-4">4</div>
-            {hasDividers && ( <><hr className="Stack-divider" role="presentation" /></> )}
+            {hasDividers && ( <><hr className="Stack-divider" role={dividerAriaRole} /></> )}
             <div className="_debug _debug-item-5">5</div>
-            {hasDividers && ( <><hr className="Stack-divider" role="presentation" /></> )}
+            {hasDividers && ( <><hr className="Stack-divider" role={dividerAriaRole} /></> )}
             <div className="_debug _debug-item-6">6</div>
           </>
         )}

--- a/docs/src/stories/components/Layout/Stack.stories.jsx
+++ b/docs/src/stories/components/Layout/Stack.stories.jsx
@@ -250,7 +250,7 @@ _Note: the presence of a divider duplicates the \`gap\` between items._`,
       }
     },
     dividerAriaRole: {
-      options: ['presentation', 'separator', 'none'],
+      options: ['presentation', 'separator'],
       control: {
         type: 'inline-radio'
       },

--- a/docs/src/stories/components/Layout/Stack.stories.jsx
+++ b/docs/src/stories/components/Layout/Stack.stories.jsx
@@ -17,6 +17,24 @@ export default {
       },
     },
 
+    _height: {
+      control: {
+        type: 'number',
+      },
+      table: {
+        category: 'Debug'
+      },
+    },
+
+    _width: {
+      control: {
+        type: 'number',
+      },
+      table: {
+        category: 'Debug'
+      },
+    },
+
     // Direction
 
     direction: {
@@ -24,7 +42,7 @@ export default {
       control: {
         type: 'inline-radio',
       },
-      description: 'Sets how elements inside `Stack` are placed, either horizontally (`inline`) or vertically (`block`).',
+      description: 'Sets how elements inside `Stack` are placed, either horizontally (`inline`) or vertically (`block`). This property follows the writing mode.',
       table: {
         category: 'Properties',
         defaultValue: {
@@ -53,7 +71,7 @@ export default {
       control: {
         type: 'inline-radio',
       },
-      description: `Sets the spacing gap between direct children of \`Stack\`. All sizes are rendered in \`rem\` units.
+      description: `Sets the spacing gap between items. All sizes are rendered in \`rem\` units.
 - \`none\`: 0
 - \`condensed\`: 8px
 - \`normal\`: 16px (default)
@@ -104,7 +122,11 @@ export default {
       control: {
         type: 'inline-radio'
       },
-      description: 'Sets the alignment between direct children of a `Stack`. ',
+      description: `Sets the alignment between items in the cross-axis of the specified direction. For example:
+- If \`direction\` is set to \`block\` (stacks vertically), it controls the horizontal aligment (left, center, right).
+- If \`direction\` is set to \`inline\` (stacks horizontally), it controls the vertical alignment (top, center, bottom).
+
+This property behavior is equivalent to the \`align-items\` Flexbox property.`,
       table: {
         category: 'Properties',
         defaultValue: {
@@ -132,6 +154,7 @@ export default {
       control: {
         type: 'inline-radio'
       },
+      description: 'Sets how stack lines are distributed, if they `wrap` into multiple lines. This has equivalent behavior to the `align-content` Flexbox property.',
       table: {
         category: 'Properties',
         defaultValue: {
@@ -160,6 +183,7 @@ export default {
       control: {
         type: 'inline-radio',
       },
+      description: 'Sets how items will be distributed in the stacking direction.', 
       table: {
         category: 'Properties',
         defaultValue: {
@@ -188,6 +212,7 @@ export default {
       control: {
         type: 'inline-radio'
       },
+      description: 'Sets whether items are forced onto one line or can wrap onto multiple lines.',
       table: {
         category: 'Properties',
         defaultValue: {
@@ -214,6 +239,9 @@ export default {
       control: {
         type: 'boolean'
       },
+      description: `Whether a divider between items is shown or not.
+
+_Note: the presence of a divider duplicates the \`gap\` between items._`,
       table: {
         category: 'Properties',
         defaultValue: {
@@ -226,6 +254,7 @@ export default {
       control: {
         type: 'inline-radio'
       },
+      description: 'Sets which ARIA role will be used for the divider.',
       table: {
         category: 'Properties',
         defaultValue: {
@@ -257,6 +286,8 @@ export default {
 
 export const StackTemplate = ({
   _debug,
+  _height,
+  _width,
   direction,
   gap,
   gap_custom,
@@ -280,12 +311,12 @@ export const StackTemplate = ({
 }) => {
 
   let custom_styles  = {};
-  const hasDividers = showDividers || narrow_showDividers;
 
   // Default values
-  direction = direction ?? 'block'
-  gap = gap ?? 'normal'
-  dividerAriaRole = dividerAriaRole ?? 'presentation'
+  direction = direction ?? 'block';
+  gap = gap ?? 'normal';
+  alignWrap = alignWrap ?? 'start';
+  dividerAriaRole = dividerAriaRole ?? 'presentation';
 
   // Default narrow values
   narrow_direction = narrow_direction ?? 'inherit';
@@ -306,9 +337,10 @@ export const StackTemplate = ({
 
   // Null value for states that don't require a modifier class
   align = align === 'stretch' ? null : align;
+  alignWrap = alignWrap === 'start' ? null : alignWrap;
   spread = spread === 'start' ? null : spread;
   wrap = wrap === 'nowrap' ? null : wrap;
-  gap = gap === 'normal' ? null : wrap;
+  gap = gap === 'normal' ? null : gap;
 
   // Null value for inherit responsive values
   narrow_direction = narrow_direction === 'inherit' ? direction : narrow_direction;
@@ -318,6 +350,12 @@ export const StackTemplate = ({
   narrow_spread = narrow_spread === 'inherit' ? spread : narrow_spread;
   narrow_wrap = narrow_wrap === 'inherit' ? wrap : narrow_wrap;
   narrow_showDividers = narrow_showDividers === 'inherit' ? showDividers : narrow_showDividers;
+
+  // Dividers logic
+  showDividers = wrap === 'wrap' ? false : showDividers;
+  narrow_showDividers = narrow_wrap === 'wrap' ? false : narrow_showDividers;
+
+  const hasDividers = showDividers || narrow_showDividers;
 
   return (
     <>
@@ -372,6 +410,8 @@ export const StackTemplate = ({
           <style type="text/css">{`
             .Stack {
               background: beige;
+              ${_height ? 'height: '+ _height + 'px;': ''}
+              ${_width ? 'width: '+ _width + 'px;': ''}
             }
             .Stack ._debug {
               padding: 8px;

--- a/docs/src/stories/components/Layout/Stack.stories.jsx
+++ b/docs/src/stories/components/Layout/Stack.stories.jsx
@@ -37,6 +37,7 @@ export default {
       control: {
         type: 'inline-radio',
       },
+      description: 'Override `direction` on narrow viewports',
       table: {
         category: 'Narrow viewport properties',
         defaultValue: {
@@ -52,7 +53,7 @@ export default {
       control: {
         type: 'inline-radio',
       },
-      description: `Sets the spacing gap between elements inside \`Stack\`. All sizes are rendered in \`rem\` units.
+      description: `Sets the spacing gap between direct children of \`Stack\`. All sizes are rendered in \`rem\` units.
 - \`none\`: 0
 - \`condensed\`: 8px
 - \`normal\`: 16px (default)
@@ -71,6 +72,7 @@ export default {
       control: {
         type: 'inline-radio',
       },
+      description: 'Override `gap` on narrow viewports',
       table: {
         category: 'Narrow viewport properties',
         defaultValue: {
@@ -91,6 +93,7 @@ export default {
       control: {
         type: 'text'
       },
+      description: 'Override a custom value for `gap` for narrow viewports',
       table: {
         category: 'Narrow viewport properties'
       },
@@ -101,6 +104,7 @@ export default {
       control: {
         type: 'inline-radio'
       },
+      description: 'Sets the alignment between direct children of a `Stack`. ',
       table: {
         category: 'Properties',
         defaultValue: {
@@ -316,11 +320,13 @@ export const StackTemplate = ({
           narrow_gap && 'Stack--gap-' + `${narrow_gap}-whenNarrow`,
 
           align && 'Stack--align-' + `${align}`,
-          alignWrap && 'Stack--alignWrap-' + `${alignWrap}`,
           narrow_align && 'Stack--align-' + `${narrow_align}-whenNarrow`,
-          narrow_align && 'Stack--alignWrap-' + `${narrow_align}-whenNarrow`,
+
+          alignWrap && 'Stack--alignWrap-' + `${alignWrap}`,
+          narrow_alignWrap && 'Stack--alignWrap-' + `${narrow_alignWrap}-whenNarrow`,
+          
           spread && 'Stack--spread-' + `${spread}`,
-          narrow_spread && 'Stack--spread-' + `${spread}-whenNarrow`,
+          narrow_spread && 'Stack--spread-' + `${narrow_spread}-whenNarrow`,
 
           wrap && 'Stack--' + `${wrap}`,
           narrow_wrap && 'Stack--' + `${narrow_wrap}-whenNarrow`,

--- a/docs/src/stories/components/Layout/Stack.stories.jsx
+++ b/docs/src/stories/components/Layout/Stack.stories.jsx
@@ -36,7 +36,6 @@ export default {
     },
 
     // Direction
-
     direction: {
       options: ['inline', 'block'],
       control: {
@@ -50,22 +49,8 @@ export default {
         }
       }
     },
-    narrow_direction: {
-      options: ['inherit', 'inline', 'block'],
-      control: {
-        type: 'inline-radio',
-      },
-      description: 'Override `direction` on narrow viewports',
-      table: {
-        category: 'Narrow viewport properties',
-        defaultValue: {
-          summary: 'inherit'
-        }
-      },
-    },
 
     // Gap
-
     gap: {
       options: ['none', 'condensed', 'normal', 'spacious', 'custom'],
       control: {
@@ -85,19 +70,6 @@ export default {
         }
       }
     },
-    narrow_gap: {
-      options: ['inherit', 'none', 'condensed', 'normal', 'custom'],
-      control: {
-        type: 'inline-radio',
-      },
-      description: 'Override `gap` on narrow viewports',
-      table: {
-        category: 'Narrow viewport properties',
-        defaultValue: {
-          summary: 'inherit'
-        }
-      },
-    },
     gap_custom: {
       control: {
         type: 'text'
@@ -107,16 +79,8 @@ export default {
         category: 'Properties',
       },
     },
-    narrow_gap_custom: {
-      control: {
-        type: 'text'
-      },
-      description: 'Override a custom value for `gap` for narrow viewports',
-      table: {
-        category: 'Narrow viewport properties'
-      },
-    },
 
+    // Align
     align: {
       options: ['stretch', 'start', 'center', 'end', 'baseline'],
       control: {
@@ -134,21 +98,8 @@ This property behavior is equivalent to the \`align-items\` Flexbox property.`,
         }
       }
     },
-    narrow_align: {
-      options: ['inherit', 'stretch', 'start', 'center', 'end', 'baseline'],
-      control: {
-        type: 'inline-radio'
-      },
-      table: {
-        category: 'Narrow viewport properties',
-        defaultValue: {
-          summary: 'inherit',
-        }
-      },
-    },
 
     // Align wrap
-
     alignWrap: {
       options: ['start', 'center', 'end', 'distribute', 'distributeEvenly'],
       control: {
@@ -163,21 +114,7 @@ This property behavior is equivalent to the \`align-items\` Flexbox property.`,
       }
     },
 
-    narrow_alignWrap: {
-      options: ['inherit', 'start', 'center', 'end', 'distribute', 'distributeEvenly'],
-      control: {
-        type: 'inline-radio'
-      },
-      table: {
-        category: 'Narrow viewport properties',
-        defaultValue: {
-          summary: 'inherit',
-        }
-      },
-    },
-
     // Spread
-
     spread: {
       options: ['start', 'center', 'end', 'distribute', 'distributeEvenly'],
       control: {
@@ -192,21 +129,7 @@ This property behavior is equivalent to the \`align-items\` Flexbox property.`,
       },
     },
 
-    narrow_spread: {
-      options: ['inherit', 'start', 'center', 'end', 'distribute', 'distributeEvenly'],
-      control: {
-        type: 'inline-radio',
-      },
-      table: {
-        category: 'Narrow viewport properties',
-        defaultValue: {
-          summary: 'inherit'
-        }
-      },
-    },
-
     // Wrap
-
     wrap: {
       options: ['wrap', 'nowrap'],
       control: {
@@ -220,21 +143,8 @@ This property behavior is equivalent to the \`align-items\` Flexbox property.`,
         }
       }
     },
-    narrow_wrap: {
-      options: ['inherit', 'wrap', 'nowrap'],
-      control: {
-        type: 'inline-radio'
-      },
-      table: {
-        category: 'Narrow viewport properties',
-        defaultValue: {
-          summary: 'inherit'
-        }
-      },
-    },
 
     // Divider
-
     showDividers: {
       control: {
         type: 'boolean'
@@ -262,12 +172,209 @@ _Note: the presence of a divider duplicates the \`gap\` between items._`,
         }
       }
     },
+
+    // Responsive properties / narrow
+
+    narrow_direction: {
+      options: ['inherit', 'inline', 'block'],
+      control: {
+        type: 'inline-radio',
+      },
+      description: 'Override `direction` on narrow viewports',
+      table: {
+        category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit'
+        }
+      },
+    },
+
+    narrow_gap: {
+      options: ['inherit', 'none', 'condensed', 'normal', 'custom'],
+      control: {
+        type: 'inline-radio',
+      },
+      description: 'Override `gap` on narrow viewports',
+      table: {
+        category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit'
+        }
+      },
+    },
+
+    narrow_gap_custom: {
+      control: {
+        type: 'text'
+      },
+      description: 'Override a custom value for `gap` for narrow viewports',
+      table: {
+        category: 'Narrow viewport properties'
+      },
+    },
+
+    narrow_align: {
+      options: ['inherit', 'stretch', 'start', 'center', 'end', 'baseline'],
+      control: {
+        type: 'inline-radio'
+      },
+      table: {
+        category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit',
+        }
+      },
+    },
+
+    narrow_alignWrap: {
+      options: ['inherit', 'start', 'center', 'end', 'distribute', 'distributeEvenly'],
+      control: {
+        type: 'inline-radio'
+      },
+      table: {
+        category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit',
+        }
+      },
+    },
+
+    narrow_spread: {
+      options: ['inherit', 'start', 'center', 'end', 'distribute', 'distributeEvenly'],
+      control: {
+        type: 'inline-radio',
+      },
+      table: {
+        category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit'
+        }
+      },
+    },
+
+    narrow_wrap: {
+      options: ['inherit', 'wrap', 'nowrap'],
+      control: {
+        type: 'inline-radio'
+      },
+      table: {
+        category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit'
+        }
+      },
+    },
+
     narrow_showDividers: {
       control: {
         type: 'boolean'
       },
       table: {
         category: 'Narrow viewport properties',
+        defaultValue: {
+          summary: 'inherit'
+        }
+      },
+    },
+
+    // Responsive properties / wide
+
+    wide_direction: {
+      options: ['inherit', 'inline', 'block'],
+      control: {
+        type: 'inline-radio',
+      },
+      description: 'Override `direction` on wide viewports',
+      table: {
+        category: 'wide viewport properties',
+        defaultValue: {
+          summary: 'inherit'
+        }
+      },
+    },
+
+    wide_gap: {
+      options: ['inherit', 'none', 'condensed', 'normal', 'spacious', 'custom'],
+      control: {
+        type: 'inline-radio',
+      },
+      description: 'Override `gap` on wide viewports',
+      table: {
+        category: 'wide viewport properties',
+        defaultValue: {
+          summary: 'inherit'
+        }
+      },
+    },
+
+    wide_gap_custom: {
+      control: {
+        type: 'text'
+      },
+      description: 'Override a custom value for `gap` for wide viewports',
+      table: {
+        category: 'wide viewport properties'
+      },
+    },
+
+    wide_align: {
+      options: ['inherit', 'stretch', 'start', 'center', 'end', 'baseline'],
+      control: {
+        type: 'inline-radio'
+      },
+      table: {
+        category: 'wide viewport properties',
+        defaultValue: {
+          summary: 'inherit',
+        }
+      },
+    },
+
+    wide_alignWrap: {
+      options: ['inherit', 'start', 'center', 'end', 'distribute', 'distributeEvenly'],
+      control: {
+        type: 'inline-radio'
+      },
+      table: {
+        category: 'wide viewport properties',
+        defaultValue: {
+          summary: 'inherit',
+        }
+      },
+    },
+
+    wide_spread: {
+      options: ['inherit', 'start', 'center', 'end', 'distribute', 'distributeEvenly'],
+      control: {
+        type: 'inline-radio',
+      },
+      table: {
+        category: 'wide viewport properties',
+        defaultValue: {
+          summary: 'inherit'
+        }
+      },
+    },
+
+    wide_wrap: {
+      options: ['inherit', 'wrap', 'nowrap'],
+      control: {
+        type: 'inline-radio'
+      },
+      table: {
+        category: 'wide viewport properties',
+        defaultValue: {
+          summary: 'inherit'
+        }
+      },
+    },
+
+    wide_showDividers: {
+      control: {
+        type: 'boolean'
+      },
+      table: {
+        category: 'wide viewport properties',
         defaultValue: {
           summary: 'inherit'
         }
@@ -307,6 +414,15 @@ export const StackTemplate = ({
   narrow_wrap,
   narrow_showDividers,
 
+  wide_direction,
+  wide_gap,
+  wide_gap_custom,
+  wide_align,
+  wide_alignWrap,
+  wide_spread,
+  wide_wrap,
+  wide_showDividers,
+
   children
 }) => {
 
@@ -327,12 +443,24 @@ export const StackTemplate = ({
   narrow_wrap = narrow_wrap ?? 'inherit';
   narrow_showDividers = narrow_showDividers ?? 'inherit';
 
+  // Default wide values
+  wide_direction = wide_direction ?? 'inherit';
+  wide_gap = wide_gap ?? 'inherit';
+  wide_align = wide_align ?? 'inherit';
+  wide_alignWrap = wide_alignWrap ?? 'inherit';
+  wide_spread = wide_spread ?? 'inherit';
+  wide_wrap = wide_wrap ?? 'inherit';
+  wide_showDividers = wide_showDividers ?? 'inherit';
+
   // Gap
   if (gap === 'custom') {
-    custom_styles['--Stack-gap'] = gap_custom;
+    custom_styles['--Stack-gap-whenRegular'] = gap_custom;
   }
   if (narrow_gap === 'custom') {
     custom_styles['--Stack-gap-whenNarrow'] = narrow_gap_custom;
+  }
+  if (wide_gap === 'custom') {
+    custom_styles['--Stack-gap-whenWide'] = wide_gap_custom;
   }
 
   // Null value for states that don't require a modifier class
@@ -351,11 +479,20 @@ export const StackTemplate = ({
   narrow_wrap = narrow_wrap === 'inherit' ? wrap : narrow_wrap;
   narrow_showDividers = narrow_showDividers === 'inherit' ? showDividers : narrow_showDividers;
 
+  wide_direction = wide_direction === 'inherit' ? null : wide_direction;
+  wide_gap = wide_gap === 'inherit' ? null : wide_gap;
+  wide_align = wide_align === 'inherit' ? null : wide_align;
+  wide_alignWrap = wide_alignWrap === 'inherit' ? null : wide_alignWrap;
+  wide_spread = wide_spread === 'inherit' ? null : wide_spread;
+  wide_wrap = wide_wrap === 'inherit' ? null : wide_wrap;
+  wide_showDividers = wide_showDividers === 'inherit' ? null : wide_showDividers;
+
   // Dividers logic
   showDividers = wrap === 'wrap' ? false : showDividers;
   narrow_showDividers = narrow_wrap === 'wrap' ? false : narrow_showDividers;
+  wide_showDividers = wide_wrap === 'wrap' ? false : wide_showDividers;
 
-  const hasDividers = showDividers || narrow_showDividers;
+  const hasDividers = showDividers || narrow_showDividers || wide_showDividers;
 
   return (
     <>
@@ -364,24 +501,31 @@ export const StackTemplate = ({
           'Stack',
           direction && `Stack--dir-${direction}-whenRegular`,
           narrow_direction && 'Stack--dir-' + `${narrow_direction}-whenNarrow`,
+          wide_direction && 'Stack--dir-' + `${wide_direction}-whenWide`,
 
           gap && 'Stack--gap-' + `${gap}-whenRegular`,
           narrow_gap && 'Stack--gap-' + `${narrow_gap}-whenNarrow`,
+          wide_gap && 'Stack--gap-' + `${wide_gap}-whenWide`,
 
           align && 'Stack--align-' + `${align}-whenRegular`,
           narrow_align && 'Stack--align-' + `${narrow_align}-whenNarrow`,
+          wide_align && 'Stack--align-' + `${wide_align}-whenWide`,
 
           alignWrap && 'Stack--alignWrap-' + `${alignWrap}-whenRegular`,
           narrow_alignWrap && 'Stack--alignWrap-' + `${narrow_alignWrap}-whenNarrow`,
+          wide_alignWrap && 'Stack--alignWrap-' + `${wide_alignWrap}-whenWide`,
           
           spread && 'Stack--spread-' + `${spread}-whenRegular`,
           narrow_spread && 'Stack--spread-' + `${narrow_spread}-whenNarrow`,
+          wide_spread && 'Stack--spread-' + `${wide_spread}-whenWide`,
 
           wrap && 'Stack--' + `${wrap}-whenRegular`,
           narrow_wrap && 'Stack--' + `${narrow_wrap}-whenNarrow`,
+          wide_wrap && 'Stack--' + `${wide_wrap}-whenWide`,
 
           showDividers && 'Stack--showDividers-whenRegular',
           narrow_showDividers && 'Stack--showDividers-whenNarrow',
+          wide_showDividers && 'Stack--showDividers-whenWide',
 
         )}
         style={custom_styles}

--- a/docs/src/stories/components/Layout/Stack.stories.jsx
+++ b/docs/src/stories/components/Layout/Stack.stories.jsx
@@ -52,7 +52,7 @@ export default {
 
     // Gap
     gap: {
-      options: ['none', 'condensed', 'normal', 'spacious', 'custom'],
+      options: ['none', 'condensed', 'normal', 'spacious'],
       control: {
         type: 'inline-radio',
       },
@@ -61,7 +61,7 @@ export default {
 - \`condensed\`: \`var(--primer-stack-gap-condensed, 8px)\`,
 - \`normal\`: \`var(--primer-stack-gap-normal, 16px)\` (default)
 - \`spacious\`: \`var(--primer-stack-gap-spacious, 24px)\` (on regular viewports, otherwise it appears as \`normal\` on narrow viewports)
-- \`custom\`: set a custom size. When using with a framework such as ViewComponent or React, a custom value can be passed directly to the property.
+<!-- - \`custom\`: set a custom size. When using with a framework such as ViewComponent or React, a custom value can be passed directly to the property. -->
  `,
       table: {
         category: 'Properties',
@@ -70,15 +70,15 @@ export default {
         }
       }
     },
-    gap_custom: {
-      control: {
-        type: 'text'
-      },
-      description: 'A custom value to `gap`. Refer to [Primer Primitives](https://primer.style/primitives/spacing) for other spacing tokens. Example: `var(--base-size-12, 12px)`.',
-      table: {
-        category: 'Properties',
-      },
-    },
+    // gap_custom: {
+    //   control: {
+    //     type: 'text'
+    //   },
+    //   description: 'A custom value to `gap`. Refer to [Primer Primitives](https://primer.style/primitives/spacing) for other spacing tokens. Example: `var(--base-size-12, 12px)`.',
+    //   table: {
+    //     category: 'Properties',
+    //   },
+    // },
 
     // Align
     align: {
@@ -190,7 +190,7 @@ _Note: the presence of a divider duplicates the \`gap\` between items._`,
     },
 
     narrow_gap: {
-      options: ['inherit', 'none', 'condensed', 'normal', 'custom'],
+      options: ['inherit', 'none', 'condensed', 'normal'],
       control: {
         type: 'inline-radio',
       },
@@ -203,15 +203,15 @@ _Note: the presence of a divider duplicates the \`gap\` between items._`,
       },
     },
 
-    narrow_gap_custom: {
-      control: {
-        type: 'text'
-      },
-      description: 'Override a custom value for `gap` for narrow viewports',
-      table: {
-        category: 'Narrow viewport properties'
-      },
-    },
+    // narrow_gap_custom: {
+    //   control: {
+    //     type: 'text'
+    //   },
+    //   description: 'Override a custom value for `gap` for narrow viewports',
+    //   table: {
+    //     category: 'Narrow viewport properties'
+    //   },
+    // },
 
     narrow_align: {
       options: ['inherit', 'stretch', 'start', 'center', 'end', 'baseline'],
@@ -294,7 +294,7 @@ _Note: the presence of a divider duplicates the \`gap\` between items._`,
     },
 
     wide_gap: {
-      options: ['inherit', 'none', 'condensed', 'normal', 'spacious', 'custom'],
+      options: ['inherit', 'none', 'condensed', 'normal', 'spacious'],
       control: {
         type: 'inline-radio',
       },
@@ -307,15 +307,15 @@ _Note: the presence of a divider duplicates the \`gap\` between items._`,
       },
     },
 
-    wide_gap_custom: {
-      control: {
-        type: 'text'
-      },
-      description: 'Override a custom value for `gap` for wide viewports',
-      table: {
-        category: 'wide viewport properties'
-      },
-    },
+    // wide_gap_custom: {
+    //   control: {
+    //     type: 'text'
+    //   },
+    //   description: 'Override a custom value for `gap` for wide viewports',
+    //   table: {
+    //     category: 'wide viewport properties'
+    //   },
+    // },
 
     wide_align: {
       options: ['inherit', 'stretch', 'start', 'center', 'end', 'baseline'],
@@ -397,7 +397,7 @@ export const StackTemplate = ({
   _width,
   direction,
   gap,
-  gap_custom,
+  //gap_custom,
   align,
   alignWrap,
   spread,
@@ -407,7 +407,7 @@ export const StackTemplate = ({
 
   narrow_direction,
   narrow_gap,
-  narrow_gap_custom,
+  //narrow_gap_custom,
   narrow_align,
   narrow_alignWrap,
   narrow_spread,
@@ -416,7 +416,7 @@ export const StackTemplate = ({
 
   wide_direction,
   wide_gap,
-  wide_gap_custom,
+  //wide_gap_custom,
   wide_align,
   wide_alignWrap,
   wide_spread,
@@ -452,16 +452,16 @@ export const StackTemplate = ({
   wide_wrap = wide_wrap ?? 'inherit';
   wide_showDividers = wide_showDividers ?? 'inherit';
 
-  // Gap
-  if (gap === 'custom') {
-    custom_styles['--Stack-gap-whenRegular'] = gap_custom;
-  }
-  if (narrow_gap === 'custom') {
-    custom_styles['--Stack-gap-whenNarrow'] = narrow_gap_custom;
-  }
-  if (wide_gap === 'custom') {
-    custom_styles['--Stack-gap-whenWide'] = wide_gap_custom;
-  }
+  // Custom gap - not available
+  // if (gap === 'custom') {
+  //   custom_styles['--Stack-gap-whenRegular'] = gap_custom;
+  // }
+  // if (narrow_gap === 'custom') {
+  //   custom_styles['--Stack-gap-whenNarrow'] = narrow_gap_custom;
+  // }
+  // if (wide_gap === 'custom') {
+  //   custom_styles['--Stack-gap-whenWide'] = wide_gap_custom;
+  // }
 
   // Null value for states that don't require a modifier class
   align = align === 'stretch' ? null : align;
@@ -528,7 +528,7 @@ export const StackTemplate = ({
           wide_showDividers && 'Stack--showDividers-whenWide',
 
         )}
-        style={custom_styles}
+        //style={custom_styles}
       >
         {children}
         
@@ -603,6 +603,5 @@ Playground.args = {
   _debug: true,
   direction: "block",
   gap: "normal",
-  gap_custom: undefined,
   align: "stretch",
 };

--- a/docs/src/stories/components/Layout/Stack.stories.jsx
+++ b/docs/src/stories/components/Layout/Stack.stories.jsx
@@ -390,17 +390,17 @@ export const StackTemplate = ({
         
         {!children && (
           <>
-            <div className="_debug _debug-item-1">1</div>
-            {hasDividers && ( <><hr className="Stack-divider" role={dividerAriaRole} /></> )}
-            <div className="_debug _debug-item-2">2</div>
-            {hasDividers && ( <><hr className="Stack-divider" role={dividerAriaRole} /></> )}
-            <div className="_debug _debug-item-3">3</div>
-            {hasDividers && ( <><hr className="Stack-divider" role={dividerAriaRole} /></> )}
-            <div className="_debug _debug-item-4">4</div>
-            {hasDividers && ( <><hr className="Stack-divider" role={dividerAriaRole} /></> )}
-            <div className="_debug _debug-item-5">5</div>
-            {hasDividers && ( <><hr className="Stack-divider" role={dividerAriaRole} /></> )}
-            <div className="_debug _debug-item-6">6</div>
+            <div className="Stack-item _debug _debug-item-1">1</div>
+            {hasDividers && ( <hr className="Stack-divider" role={dividerAriaRole} /> )}
+            <div className="Stack-item _debug _debug-item-2">2</div>
+            {hasDividers && ( <hr className="Stack-divider" role={dividerAriaRole} /> )}
+            <div className="Stack-item _debug _debug-item-3">3</div>
+            {hasDividers && ( <hr className="Stack-divider" role={dividerAriaRole} /> )}
+            <div className="Stack-item _debug _debug-item-4">4</div>
+            {hasDividers && ( <hr className="Stack-divider" role={dividerAriaRole} /> )}
+            <div className="Stack-item _debug _debug-item-5">5</div>
+            {hasDividers && ( <hr className="Stack-divider" role={dividerAriaRole} /> )}
+            <div className="Stack-item _debug _debug-item-6">6</div>
           </>
         )}
       </div>

--- a/docs/src/stories/components/Layout/Stack.stories.jsx
+++ b/docs/src/stories/components/Layout/Stack.stories.jsx
@@ -362,7 +362,7 @@ export const StackTemplate = ({
       <div
         className={clsx(
           'Stack',
-          direction && 'Stack--dir-' + `${direction}-whenRegular`,
+          direction && `Stack--dir-${direction}-whenRegular`,
           narrow_direction && 'Stack--dir-' + `${narrow_direction}-whenNarrow`,
 
           gap && 'Stack--gap-' + `${gap}-whenRegular`,

--- a/docs/src/stories/components/Layout/Stack.stories.jsx
+++ b/docs/src/stories/components/Layout/Stack.stories.jsx
@@ -287,6 +287,15 @@ export const StackTemplate = ({
   gap = gap ?? 'normal'
   dividerAriaRole = dividerAriaRole ?? 'presentation'
 
+  // Default narrow values
+  narrow_direction = narrow_direction ?? 'inherit';
+  narrow_gap = narrow_gap ?? 'inherit';
+  narrow_align = narrow_align ?? 'inherit';
+  narrow_alignWrap = narrow_alignWrap ?? 'inherit';
+  narrow_spread = narrow_spread ?? 'inherit';
+  narrow_wrap = narrow_wrap ?? 'inherit';
+  narrow_showDividers = narrow_showDividers ?? 'inherit';
+
   // Gap
   if (gap === 'custom') {
     custom_styles['--Stack-gap'] = gap_custom;
@@ -298,42 +307,43 @@ export const StackTemplate = ({
   // Null value for states that don't require a modifier class
   align = align === 'stretch' ? null : align;
   spread = spread === 'start' ? null : spread;
+  wrap = wrap === 'nowrap' ? null : wrap;
+  gap = gap === 'normal' ? null : wrap;
 
   // Null value for inherit responsive values
-  narrow_direction = narrow_direction === 'inherit' ? null : narrow_direction;
-  narrow_gap = narrow_gap === 'inherit' ? null : narrow_gap;
-  narrow_align = narrow_align === 'inherit' ? null : narrow_align;
-  narrow_alignWrap = narrow_alignWrap === 'inherit' ? null : narrow_alignWrap;
-  narrow_spread = narrow_spread === 'inherit' ? null : narrow_spread;
-  narrow_wrap = narrow_wrap === 'inherit' ? null : narrow_wrap;
-  narrow_showDividers = narrow_showDividers === 'inherit' ? null : narrow_showDividers;
+  narrow_direction = narrow_direction === 'inherit' ? direction : narrow_direction;
+  narrow_gap = narrow_gap === 'inherit' ? gap : narrow_gap;
+  narrow_align = narrow_align === 'inherit' ? align : narrow_align;
+  narrow_alignWrap = narrow_alignWrap === 'inherit' ? alignWrap : narrow_alignWrap;
+  narrow_spread = narrow_spread === 'inherit' ? spread : narrow_spread;
+  narrow_wrap = narrow_wrap === 'inherit' ? wrap : narrow_wrap;
+  narrow_showDividers = narrow_showDividers === 'inherit' ? showDividers : narrow_showDividers;
 
   return (
     <>
       <div
         className={clsx(
           'Stack',
-          direction && 'Stack--dir-' + `${direction}`,
+          direction && 'Stack--dir-' + `${direction}-whenRegular`,
           narrow_direction && 'Stack--dir-' + `${narrow_direction}-whenNarrow`,
 
-          gap && 'Stack--gap-' + `${gap}`,
+          gap && 'Stack--gap-' + `${gap}-whenRegular`,
           narrow_gap && 'Stack--gap-' + `${narrow_gap}-whenNarrow`,
 
-          align && 'Stack--align-' + `${align}`,
+          align && 'Stack--align-' + `${align}-whenRegular`,
           narrow_align && 'Stack--align-' + `${narrow_align}-whenNarrow`,
 
-          alignWrap && 'Stack--alignWrap-' + `${alignWrap}`,
+          alignWrap && 'Stack--alignWrap-' + `${alignWrap}-whenRegular`,
           narrow_alignWrap && 'Stack--alignWrap-' + `${narrow_alignWrap}-whenNarrow`,
           
-          spread && 'Stack--spread-' + `${spread}`,
+          spread && 'Stack--spread-' + `${spread}-whenRegular`,
           narrow_spread && 'Stack--spread-' + `${narrow_spread}-whenNarrow`,
 
-          wrap && 'Stack--' + `${wrap}`,
+          wrap && 'Stack--' + `${wrap}-whenRegular`,
           narrow_wrap && 'Stack--' + `${narrow_wrap}-whenNarrow`,
 
-          showDividers && 'Stack--showDividers',
-          narrow_showDividers === true && 'Stack--showDividers-whenNarrow',
-          narrow_showDividers === false && 'Stack--hideDividers-whenNarrow',
+          showDividers && 'Stack--showDividers-whenRegular',
+          narrow_showDividers && 'Stack--showDividers-whenNarrow',
 
         )}
         style={custom_styles}
@@ -410,5 +420,5 @@ Playground.args = {
   direction: "block",
   gap: "normal",
   gap_custom: undefined,
-  align: "normal",
+  align: "stretch",
 };

--- a/docs/src/stories/components/Layout/StackExamples.stories.jsx
+++ b/docs/src/stories/components/Layout/StackExamples.stories.jsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import {
+  StackTemplate
+} from './Stack.stories'
+
+export default {
+  title: 'Components/Layout/Stack/Examples'
+}
+
+export const ButtonInlineStack = StackTemplate.bind({})
+ButtonInlineStack.args = {
+  direction: "inline",
+  gap: "condensed",
+  children: (
+    <>
+      <button class="btn">Button</button>
+      <button class="btn">Button</button>
+      <button class="btn">Button</button>
+    </>
+  )
+};
+
+export const PageSections = StackTemplate.bind({})
+PageSections.args = {
+  direction: "block",
+  gap: "normal",
+  children: (
+    <>
+      <div className="Box p-2" style={{minHeight: '20ch'}}>Section 1</div>
+      <div className="Box p-2" style={{minHeight: '12ch'}}>Section 2</div>
+      <div className="Box p-2" style={{minHeight: '16ch'}}>Section 3</div>
+    </>
+  )
+};
+
+export const Composition = StackTemplate.bind({})
+Composition.args = {
+  direction: "block",
+  gap: "normal",
+  children: (
+    <>
+      <StackTemplate divider={true} children={(
+        <>
+          <StackTemplate gap="condensed" children={(
+            <>
+              <h4>Heading</h4>
+              <div>Lorem ipsum dolor sit amet avec consequer domulus sit lorem ipsum dolor sit amet.</div>
+              <StackTemplate direction="inline" wrap="wrap" gap="condensed" children={(
+                <>
+                  <span class="Label">Inline labels set to wrap</span>
+                  <span class="Label">Label 2</span>
+                  <span class="Label">Label 3</span>
+                  <span class="Label">Label 4</span>
+                  <span class="Label">Label 5</span>
+                </>
+              )} />
+            </>
+          )} />
+          <hr className="Stack-divider" />
+          <StackTemplate gap="condensed" children={(
+            <>
+              <h4>Heading</h4>
+              <div>Lorem ipsum dolor sit amet avec consequer domulus sit lorem ipsum dolor sit amet.</div>
+              <StackTemplate direction="inline" wrap="wrap" gap="condensed" children={(
+                <>
+                  <span class="Label">Inline labels set to wrap</span>
+                  <span class="Label">Label 2</span>
+                  <span class="Label">Label 3</span>
+                  <span class="Label">Label 4</span>
+                  <span class="Label">Label 5</span>
+                </>
+              )} />
+            </>
+          )} />
+        </>
+      )} />
+    </>
+  )
+};

--- a/docs/src/stories/components/Layout/StackFeatures.stories.jsx
+++ b/docs/src/stories/components/Layout/StackFeatures.stories.jsx
@@ -1,0 +1,151 @@
+import React from 'react'
+import {
+  StackTemplate
+} from './Stack.stories'
+
+export default {
+  title: 'Components/Layout/Stack/Features'
+}
+
+export const DirectChildren = StackTemplate.bind({})
+DirectChildren.args = {
+  direction: "block",
+  gap: "normal",
+  narrow_gap: "condensed",
+  children: (
+    <>
+      <div style={{backgroundColor: 'lightpink', padding: '16px'}}>Item 1</div>
+      <div style={{backgroundColor: 'orange', padding: '16px'}}>Item 2</div>
+      <div style={{backgroundColor: 'lightblue', padding: '16px'}}>Item 3</div>
+      <div style={{backgroundColor: 'darkseagreen', padding: '16px'}}>Item 4</div>
+      <div style={{backgroundColor: 'khaki', padding: '16px'}}>Item 5</div>
+    </>
+  )
+};
+
+export const StackItems = StackTemplate.bind({})
+StackItems.args = {
+  direction: "inline",
+  gap: "normal",
+  wrap: "wrap",
+  narrow_gap: "condensed",
+  children: (
+    <>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'lightpink', padding: '16px'}}>Item 1</div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'orange', padding: '16px'}}>Item 2</div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'lightblue', padding: '16px'}}>Item 3</div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'darkseagreen', padding: '16px'}}>Item 4</div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'khaki', padding: '16px'}}>Item 5</div>
+      </div>
+    </>
+  )
+};
+
+export const ExpandStackItem = StackTemplate.bind({})
+ExpandStackItem.args = {
+  direction: "inline",
+  wrap: "wrap",
+  gap: "normal",
+  narrow_gap: "condensed",
+  children: (
+    <>
+      <div className="Stack-item Stack-item--expand-whenRegular Stack-item--expand-whenNarrow">
+        <div style={{backgroundColor: 'lightpink', padding: '16px'}}>Item 1 (expand)</div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'orange', padding: '16px'}}>Item 2</div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'lightblue', padding: '16px'}}>Item 3</div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'darkseagreen', padding: '16px'}}>Item 4</div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'khaki', padding: '16px'}}>Item 5</div>
+      </div>
+    </>
+  )
+};
+
+export const ExpandStackItems = StackTemplate.bind({})
+ExpandStackItems.args = {
+  direction: "inline",
+  wrap: "wrap",
+  gap: "normal",
+  narrow_gap: "condensed",
+  children: (
+    <>
+      <div className="Stack-item Stack-item--expand-whenRegular Stack-item--expand-whenNarrow">
+        <div style={{backgroundColor: 'lightpink', padding: '16px'}}>Item 1 (expand)</div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'orange', padding: '16px'}}>Item 2</div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'lightblue', padding: '16px'}}>Item 3</div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'darkseagreen', padding: '16px'}}>Item 4</div>
+      </div>
+      <div className="Stack-item Stack-item--expand-whenRegular Stack-item--expand-whenNarrow">
+        <div style={{backgroundColor: 'khaki', padding: '16px'}}>Item 5 (expand)</div>
+      </div>
+    </>
+  )
+};
+
+export const ContentOverflow = StackTemplate.bind({})
+ContentOverflow.args = {
+  direction: "block",
+  gap: "normal",
+  narrow_gap: "condensed",
+  children: (
+    <>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'lightpink', padding: '16px'}}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id faucibus sapien. Nullam gravida tortor eget lacinia volutpat. Vestibulum efficitur lorem non ex ultricies accumsan. Vestibulum porttitor nunc non tellus auctor rutrum. Morbi nec augue turpis. Vestibulum pulvinar semper risus id fermentum. Nulla egestas metus id nulla ullamcorper ullamcorper nec in urna. Duis tincidunt finibus quam, quis pretium odio pulvinar nec. Nullam malesuada sodales ligula. Nunc varius arcu et tellus condimentum interdum.
+        </div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'orange', padding: '16px'}}>
+          Ut eu ligula tellus. Integer efficitur sit amet lorem nec hendrerit. In hac habitasse platea dictumst. Donec aliquam posuere leo iaculis efficitur. Curabitur malesuada placerat est, sit amet fermentum quam dignissim congue. Etiam interdum, leo sit amet molestie ornare, nisi ipsum cursus odio, a auctor turpis dolor in justo. Nulla molestie dolor sit amet lectus faucibus gravida. Maecenas ac ornare magna, in ultricies lectus. Nam venenatis porta pellentesque. Nullam odio nisl, accumsan id rutrum in, ultricies ac purus. Donec nec blandit risus.
+        </div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'lightblue', padding: '16px'}}>
+          Ut cursus elit leo. Curabitur in lorem eget sem ullamcorper tempor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent convallis vulputate turpis, fringilla congue felis laoreet tempus. Fusce tincidunt sodales lacus eu volutpat. Duis a semper neque. Aenean fermentum bibendum lectus, et aliquam ligula elementum vitae. Cras tempor lacus ipsum, vel sagittis sem laoreet et. Nulla vel tortor metus. Nullam euismod, dui non vulputate pulvinar, nisl sem malesuada dolor, vel malesuada nibh dui nec arcu. Nunc accumsan justo purus, non sodales massa blandit mattis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Aenean vel mollis orci, at consequat ante. Curabitur pharetra euismod condimentum. Pellentesque mauris lacus, ultricies sit amet lacus a, congue scelerisque dui.
+        </div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'darkseagreen', padding: '16px', textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden'}}>
+          Vestibulum faucibus luctus bibendum. Nunc sodales interdum dapibus. Nulla aliquet nibh ac est pellentesque eleifend. Praesent ultricies eu nunc vel dignissim. Cras tempus porttitor arcu porttitor condimentum. Nulla imperdiet turpis nec tincidunt luctus. Curabitur in congue urna. Nulla vehicula nunc hendrerit, tristique est porta, tristique erat. Duis vel neque sed eros eleifend feugiat non eget metus. Curabitur elit nunc, condimentum et mollis vitae, vestibulum et lorem. Duis luctus tortor eu vulputate volutpat. Fusce egestas volutpat ante et lobortis. Integer scelerisque neque vitae lorem pellentesque elementum. Sed fringilla lacus at hendrerit tincidunt. Vestibulum pretium, odio nec commodo imperdiet, nibh eros viverra mauris, eget pellentesque est nulla sit amet nunc. Cras mi metus, tristique et tincidunt at, tristique sed dolor.
+        </div>
+      </div>
+      <div className="Stack-item Stack-item--expand-whenRegular Stack-item--expand-whenNarrow">
+        <div style={{backgroundColor: 'khaki', padding: '16px'}}>
+          In tempus, urna eu egestas convallis, nunc nisi faucibus lectus, et tempor felis nisi nec nunc. Morbi porttitor libero ac ipsum efficitur ullamcorper. Praesent eget velit volutpat, gravida odio vel, aliquet lectus. Sed a lorem imperdiet, tempor ligula eget, rutrum lorem. Nulla magna purus, iaculis sit amet volutpat et, varius sed orci. Curabitur eu purus quis mi dictum faucibus sit amet in lectus. Nam egestas quis felis sit amet finibus. In congue elementum lorem, id molestie neque commodo nec. Maecenas vitae accumsan orci. Aenean imperdiet et tellus et tincidunt. Donec non porta justo, sit amet laoreet risus. Mauris in bibendum tellus, at lobortis tortor.
+        </div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'coral', padding: '16px'}}>
+          Item 6
+        </div>
+      </div>
+      <div className="Stack-item">
+        <div style={{backgroundColor: 'pink', padding: '16px'}}>
+          Item 7
+        </div>
+      </div>
+    </>
+  )
+};

--- a/src/layout/index.scss
+++ b/src/layout/index.scss
@@ -6,3 +6,4 @@
 @import './grid-offset.scss';
 @import './layout.scss';
 @import './page-layout.scss';
+@import './stack.scss';

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -4,7 +4,7 @@
   
   // A Stack component lays elements horizontally or vertically on the page.
   //
-  // Stack is a simple abstraction of CSS' Flexbox. Use it to structure elemets
+  // Stack is a simple abstraction of CSS' Flexbox. Use it to structure elements
   // that are visually grouped, following the same direction.
   //
   // Markup structure

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -48,7 +48,7 @@
 }
 
 @mixin Stack--modifiers($viewportRange: '') {
-  /* direction */
+  // direction
 
   .Stack--dir-inline#{$viewportRange} {
     flex-flow: row;
@@ -58,7 +58,7 @@
     flex-flow: column;
   }
 
-  /* gap */
+  // gap
 
   .Stack--gap-none#{$viewportRange} {
     --Stack-gap#{$viewportRange}: 0;
@@ -80,7 +80,7 @@
     }
   }
 
-  /* align */
+  // align
 
   .Stack--align-start#{$viewportRange} {
     align-items: flex-start;
@@ -98,7 +98,7 @@
     align-items: baseline;
   }
 
-  /* alignWrap */
+  // alignWrap
 
   .Stack--alignWrap-start#{$viewportRange} {
     align-content: flex-start;
@@ -120,7 +120,7 @@
     align-content: space-evenly;
   }
 
-  /* spread */
+  // spread
 
   .Stack--spread-start#{$viewportRange} {
     justify-content: flex-start;
@@ -142,7 +142,7 @@
     justify-content: space-evenly;
   }
 
-  /* wrap */
+  // wrap
 
   .Stack--wrap#{$viewportRange} {
     flex-wrap: wrap;
@@ -152,7 +152,7 @@
     flex-wrap: nowrap;
   }
 
-  /* showDividers */
+  // showDividers
 
   .Stack--showDividers#{$viewportRange} > .Stack-divider,
   .Stack--showDividers#{$viewportRange} > .Stack-item > .Stack-divider {
@@ -174,7 +174,7 @@
   }
 }
 
-/* Stack-divider */
+// Stack-divider
 
 .Stack-divider {
   display: none;
@@ -184,7 +184,7 @@
   align-self: stretch;
 }
 
-/* Stack-item */
+// Stack-item
 
 .Stack-item {
   flex: 0 1 auto;

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -18,6 +18,7 @@
 .Stack--inline {
   flex-flow: row;
 }
+
 .Stack--block {
   flex-flow: column;
 }
@@ -37,26 +38,30 @@
 .Stack--none {
   --Stack-gap: 0;
 }
+
 .Stack--condensed {
   --Stack-gap: var(--primer-stack-gap-condensed, 8px);
 }
+
 .Stack--normal {
   --Stack-gap: var(--primer-stack-gap-normal, 16px);
 }
-  
+
 @media ($viewport-regular) {
   .Stack--spacious {
     --Stack-gap: var(--primer-stack-gap-spacious, 24px);
-  } 
+  }
 }
 
 @media ($viewport-narrow) {
   .Stack--none-whenNarrow {
     --Stack-gap-whenNarrow: 0;
   }
+
   .Stack--condensed-whenNarrow {
     --Stack-gap-whenNarrow: var(--primer-stack-gap-condensed, 8px);
   }
+
   .Stack--normal-whenNarrow {
     --Stack-gap-whenNarrow: var(--primer-stack-gap-normal, 16px);
   }
@@ -68,10 +73,12 @@
   align-items: flex-start;
   justify-content: flex-start;
 }
+
 .Stack--center {
   align-items: center;
   justify-content: center;
 }
+
 .Stack--end {
   align-items: flex-end;
   justify-content: flex-end;
@@ -81,9 +88,11 @@
   .Stack--start-whenNarrow {
     align-items: flex-start;
   }
+
   .Stack--center-whenNarrow {
     align-items: center;
   }
+
   .Stack--end-whenNarrow {
     align-items: flex-end;
   }
@@ -94,6 +103,7 @@
 .Stack--wrap {
   flex-wrap: wrap;
 }
+
 .Stack--nowrap {
   flex-wrap: nowrap;
 }
@@ -102,6 +112,7 @@
   .Stack--wrap-whenNarrow {
     flex-wrap: wrap;
   }
+
   .Stack--nowrap-whenNarrow {
     flex-wrap: nowrap;
   }

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -1,11 +1,11 @@
 // Stack layout helper
 
 // Tasks:
-// - [ ] Storybook narrow values
-// - [ ] Storybook examples
+// - [x] Storybook narrow values
+// - [x] Storybook examples
 // - [x] Custom gap
 // - [ ] Figure out `align` prop for inline Stack
-// - [ ] Finish dividers (including narrow viewports configuration)
+// - [x] Finish dividers (including narrow viewports configuration)
 
 .Stack {
   --Stack-gap: var(--primer-stack-gap-normal, 16px);
@@ -131,6 +131,9 @@
 @media ($viewport-narrow) {
   .Stack--showDividers-whenNarrow .Stack-divider {
     display: block;
+  }
+  .Stack--hideDividers-whenNarrow .Stack-divider {
+    display: none;
   }
 }
 

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -1,8 +1,16 @@
 // Stack layout helper
 
+// Tasks:
+// - [ ] Storybook narrow values
+// - [ ] Storybook examples
+// - [x] Custom gap
+// - [ ] Figure out `align` prop for inline Stack
+// - [ ] Finish dividers (including narrow viewports configuration)
+
 .Stack {
   --Stack-gap: var(--primer-stack-gap-normal, 16px);
   --Stack-gap-whenNarrow: var(--Stack-gap);
+  --Stack-divider-color: var(--color-border-default);
 
   display: flex;
   flex-flow: column;
@@ -15,85 +23,82 @@
 
 /* Direction */
 
-.Stack--inline {
+.Stack--dir-inline {
   flex-flow: row;
 }
 
-.Stack--block {
+.Stack--dir-block {
   flex-flow: column;
 }
 
 @media ($viewport-narrow) {
-  .Stack--inline-whenNarrow {
+  .Stack--dir-inline-whenNarrow {
     flex-flow: row;
   }
 
-  .Stack--block-whenNarrow {
+  .Stack--dir-block-whenNarrow {
     flex-flow: column;
   }
 }
 
 /* Gap */
 
-.Stack--none {
+.Stack--gap-none {
   --Stack-gap: 0;
 }
 
-.Stack--condensed {
+.Stack--gap-condensed {
   --Stack-gap: var(--primer-stack-gap-condensed, 8px);
 }
 
-.Stack--normal {
+.Stack--gap-normal {
   --Stack-gap: var(--primer-stack-gap-normal, 16px);
 }
 
 @media ($viewport-regular) {
-  .Stack--spacious {
+  .Stack--gap-spacious {
     --Stack-gap: var(--primer-stack-gap-spacious, 24px);
   }
 }
 
 @media ($viewport-narrow) {
-  .Stack--none-whenNarrow {
+  .Stack--gap-none-whenNarrow {
     --Stack-gap-whenNarrow: 0;
   }
 
-  .Stack--condensed-whenNarrow {
+  .Stack--gap-condensed-whenNarrow {
     --Stack-gap-whenNarrow: var(--primer-stack-gap-condensed, 8px);
   }
 
-  .Stack--normal-whenNarrow {
+  .Stack--gap-normal-whenNarrow {
     --Stack-gap-whenNarrow: var(--primer-stack-gap-normal, 16px);
   }
 }
 
 /* Align */
 
-.Stack--start {
+.Stack--align-start {
   align-items: flex-start;
-  justify-content: flex-start;
 }
 
-.Stack--center {
+.Stack--align-center {
   align-items: center;
-  justify-content: center;
 }
 
-.Stack--end {
+.Stack--align-end {
   align-items: flex-end;
-  justify-content: flex-end;
 }
 
 @media ($viewport-narrow) {
-  .Stack--start-whenNarrow {
+  .Stack--align-start-whenNarrow {
     align-items: flex-start;
   }
 
-  .Stack--center-whenNarrow {
+  .Stack--align-center-whenNarrow {
     align-items: center;
   }
 
-  .Stack--end-whenNarrow {
+  .Stack--align-end-whenNarrow {
     align-items: flex-end;
   }
 }
@@ -115,5 +120,52 @@
 
   .Stack--nowrap-whenNarrow {
     flex-wrap: nowrap;
+  }
+}
+
+/* Divider */
+
+.Stack--showDividers .Stack-divider {
+  display: block;
+}
+@media ($viewport-narrow) {
+  .Stack--showDividers-whenNarrow .Stack-divider {
+    display: block;
+  }
+}
+
+.Stack-divider {
+  margin: 0;
+  padding: 0;
+  border: none;
+  display: none;
+}
+
+.Stack--dir-block .Stack-divider {
+  border-inline-end: none;
+  border-block-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
+  inline-size: auto;
+  block-size: 0;
+}
+
+.Stack--dir-inline .Stack-divider {
+  border-inline-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
+  border-block-end: none;
+  inline-size: 0;
+  block-size: auto;
+}
+
+@media ($viewport-narrow) {
+  .Stack--dir-block-whenNarrow .Stack-divider {
+    border-inline-end: none;
+    border-block-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
+    inline-size: auto;
+    block-size: 0;
+  }
+  .Stack--dir-inline-whenNarrow .Stack-divider {
+    border-inline-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
+    border-block-end: none;
+    inline-size: 0;
+    block-size: auto;
   }
 }

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -1,7 +1,7 @@
 // Stack layout helper component
 
 .Stack {
-  
+
   // A Stack component lays elements horizontally or vertically on the page.
   //
   // Stack is a simple abstraction of CSS' Flexbox. Use it to structure elements
@@ -65,11 +65,11 @@
   .Stack--gap-none-whenRegular {
     --Stack-gap: 0;
   }
-  
+
   .Stack--gap-condensed-whenRegular {
     --Stack-gap: var(--primer-stack-gap-condensed, 8px);
   }
-  
+
   .Stack--gap-normal-whenRegular {
     --Stack-gap: var(--primer-stack-gap-normal, 16px);
   }
@@ -128,6 +128,7 @@
   .Stack--align-end-whenNarrow {
     align-items: flex-end;
   }
+
   .Stack--align-baseline-whenNarrow {
     align-items: baseline;
   }
@@ -147,9 +148,11 @@
   .Stack--alignWrap-end-whenRegular {
     align-content: flex-end;
   }
+
   .Stack--alignWrap-distribute-whenRegular {
     align-content: space-between;
   }
+
   .Stack--alignWrap-distributeEvenly-whenRegular {
     align-content: space-evenly;
   }
@@ -159,17 +162,19 @@
   .Stack--alignWrap-start-whenNarrow {
     align-content: flex-start;
   }
-  
+
   .Stack--alignWrap-center-whenNarrow {
     align-content: center;
   }
-  
+
   .Stack--alignWrap-end-whenNarrow {
     align-content: flex-end;
   }
+
   .Stack--alignWrap-distribute-whenNarrow {
     align-content: space-between;
   }
+
   .Stack--alignWrap-distributeEvenly-whenNarrow {
     align-content: space-evenly;
   }
@@ -181,15 +186,19 @@
   .Stack--spread-start-whenRegular {
     justify-content: flex-start;
   }
+
   .Stack--spread-center-whenRegular {
     justify-content: center;
   }
+
   .Stack--spread-end-whenRegular {
     justify-content: flex-end;
   }
+
   .Stack--spread-distribute-whenRegular {
     justify-content: space-between;
   }
+
   .Stack--spread-distributeEvenly-whenRegular {
     justify-content: space-evenly;
   }
@@ -199,15 +208,19 @@
   .Stack--spread-start-whenNarrow {
     justify-content: flex-start;
   }
+
   .Stack--spread-center-whenNarrow {
     justify-content: center;
   }
+
   .Stack--spread-end-whenNarrow {
     justify-content: flex-end;
   }
+
   .Stack--spread-distribute-whenNarrow {
     justify-content: space-between;
   }
+
   .Stack--spread-distributeEvenly-whenNarrow {
     justify-content: space-evenly;
   }
@@ -242,6 +255,7 @@
     display: block;
   }
 }
+
 @media ($viewport-narrow) {
   .Stack--showDividers-whenNarrow .Stack-divider {
     display: block;
@@ -249,10 +263,10 @@
 }
 
 .Stack-divider {
-  margin: 0;
-  padding: 0;
-  border: none;
   display: none;
+  padding: 0;
+  margin: 0;
+  border: 0;
   align-self: stretch;
 }
 
@@ -276,6 +290,7 @@
     inline-size: auto;
     block-size: 0;
   }
+
   .Stack--dir-inline-whenNarrow .Stack-divider {
     border-inline-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
     inline-size: 0;

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -41,7 +41,6 @@
 }
 
 @mixin Stack--modifiers($viewportRange: '') {
-
   /* direction */
 
   .Stack--dir-inline#{$viewportRange} {
@@ -151,7 +150,7 @@
   .Stack--showDividers#{$viewportRange} > .Stack-divider {
     display: block;
   }
-  
+
   :not(.Stack--dir-inline#{$viewportRange}) > .Stack-divider {
     border-block-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
     inline-size: auto;
@@ -163,7 +162,6 @@
     inline-size: 0;
     block-size: auto;
   }
-
 }
 
 /* Stack-divider */
@@ -188,11 +186,10 @@
   .Stack-item--expand#{$viewportRange} {
     flex-grow: 1;
   }
-  
+
   .Stack-item--keepSize#{$viewportRange} {
     flex-shrink: 0;
   }
-
 }
 
 // Responsive composition

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -1,0 +1,108 @@
+// Stack layout helper
+
+.Stack {
+  --Stack-gap: var(--primer-stack-gap-normal, 16px);
+  --Stack-gap-whenNarrow: var(--Stack-gap);
+
+  display: flex;
+  flex-flow: column;
+  gap: var(--Stack-gap);
+
+  @media ($viewport-narrow) {
+    gap: var(--Stack-gap-whenNarrow);
+  }
+}
+
+/* Direction */
+
+.Stack--inline {
+  flex-flow: row;
+}
+.Stack--block {
+  flex-flow: column;
+}
+
+@media ($viewport-narrow) {
+  .Stack--inline-whenNarrow {
+    flex-flow: row;
+  }
+
+  .Stack--block-whenNarrow {
+    flex-flow: column;
+  }
+}
+
+/* Gap */
+
+.Stack--none {
+  --Stack-gap: 0;
+}
+.Stack--condensed {
+  --Stack-gap: var(--primer-stack-gap-condensed, 8px);
+}
+.Stack--normal {
+  --Stack-gap: var(--primer-stack-gap-normal, 16px);
+}
+  
+@media ($viewport-regular) {
+  .Stack--spacious {
+    --Stack-gap: var(--primer-stack-gap-spacious, 24px);
+  } 
+}
+
+@media ($viewport-narrow) {
+  .Stack--none-whenNarrow {
+    --Stack-gap-whenNarrow: 0;
+  }
+  .Stack--condensed-whenNarrow {
+    --Stack-gap-whenNarrow: var(--primer-stack-gap-condensed, 8px);
+  }
+  .Stack--normal-whenNarrow {
+    --Stack-gap-whenNarrow: var(--primer-stack-gap-normal, 16px);
+  }
+}
+
+/* Align */
+
+.Stack--start {
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+.Stack--center {
+  align-items: center;
+  justify-content: center;
+}
+.Stack--end {
+  align-items: flex-end;
+  justify-content: flex-end;
+}
+
+@media ($viewport-narrow) {
+  .Stack--start-whenNarrow {
+    align-items: flex-start;
+  }
+  .Stack--center-whenNarrow {
+    align-items: center;
+  }
+  .Stack--end-whenNarrow {
+    align-items: flex-end;
+  }
+}
+
+/* Wrap */
+
+.Stack--wrap {
+  flex-wrap: wrap;
+}
+.Stack--nowrap {
+  flex-wrap: nowrap;
+}
+
+@media ($viewport-narrow) {
+  .Stack--wrap-whenNarrow {
+    flex-wrap: wrap;
+  }
+  .Stack--nowrap-whenNarrow {
+    flex-wrap: nowrap;
+  }
+}

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -24,10 +24,11 @@
 
   display: flex;
   flex-flow: column;
+  flex-wrap: nowrap;
+  align-items: stretch;
   gap: var(--Stack-gap);
   min-block-size: fit-content;
   min-inline-size: fit-content;
-  align-items: stretch;
 
   @media ($viewport-narrow) {
     gap: var(--Stack-gap-whenNarrow);
@@ -36,12 +37,14 @@
 
 /* Direction */
 
-.Stack--dir-inline {
-  flex-flow: row;
-}
+@media ($viewport-regular) {
+  .Stack--dir-inline-whenRegular {
+    flex-flow: row;
+  }
 
-.Stack--dir-block {
-  flex-flow: column;
+  .Stack--dir-block-whenRegular {
+    flex-flow: column;
+  }
 }
 
 @media ($viewport-narrow) {
@@ -56,20 +59,20 @@
 
 /* Gap */
 
-.Stack--gap-none {
-  --Stack-gap: 0;
-}
-
-.Stack--gap-condensed {
-  --Stack-gap: var(--primer-stack-gap-condensed, 8px);
-}
-
-.Stack--gap-normal {
-  --Stack-gap: var(--primer-stack-gap-normal, 16px);
-}
-
 @media ($viewport-regular) {
-  .Stack--gap-spacious {
+  .Stack--gap-none-whenRegular {
+    --Stack-gap: 0;
+  }
+  
+  .Stack--gap-condensed-whenRegular {
+    --Stack-gap: var(--primer-stack-gap-condensed, 8px);
+  }
+  
+  .Stack--gap-normal-whenRegular {
+    --Stack-gap: var(--primer-stack-gap-normal, 16px);
+  }
+
+  .Stack--gap-spacious-whenRegular {
     --Stack-gap: var(--primer-stack-gap-spacious, 24px);
   }
 }
@@ -86,24 +89,29 @@
   .Stack--gap-normal-whenNarrow {
     --Stack-gap-whenNarrow: var(--primer-stack-gap-normal, 16px);
   }
+
+  // There's no .Stack--gap-spacious-whenNarrow
+  // Narrow viewports render `spacious` gap as `normal`
 }
 
 /* Align */
 
-.Stack--align-start {
-  align-items: flex-start;
-}
+@media ($viewport-regular) {
+  .Stack--align-start-whenRegular {
+    align-items: flex-start;
+  }
 
-.Stack--align-center {
-  align-items: center;
-}
+  .Stack--align-center-whenRegular {
+    align-items: center;
+  }
 
-.Stack--align-end {
-  align-items: flex-end;
-}
+  .Stack--align-end-whenRegular {
+    align-items: flex-end;
+  }
 
-.Stack--align-baseline {
-  align-items: baseline;
+  .Stack--align-baseline-whenRegular {
+    align-items: baseline;
+  }
 }
 
 @media ($viewport-narrow) {
@@ -125,22 +133,24 @@
 
 /* AlignWrap */
 
-.Stack--alignWrap-start {
-  align-content: flex-start;
-}
+@media ($viewport-regular) {
+  .Stack--alignWrap-start-whenRegular {
+    align-content: flex-start;
+  }
 
-.Stack--alignWrap-center {
-  align-content: center;
-}
+  .Stack--alignWrap-center-whenRegular {
+    align-content: center;
+  }
 
-.Stack--alignWrap-end {
-  align-content: flex-end;
-}
-.Stack--alignWrap-distribute {
-  align-content: space-between;
-}
-.Stack--alignWrap-distributeEvenly {
-  align-content: space-evenly;
+  .Stack--alignWrap-end-whenRegular {
+    align-content: flex-end;
+  }
+  .Stack--alignWrap-distribute-whenRegular {
+    align-content: space-between;
+  }
+  .Stack--alignWrap-distributeEvenly-whenRegular {
+    align-content: space-evenly;
+  }
 }
 
 @media ($viewport-narrow) {
@@ -165,20 +175,22 @@
 
 /* Spread */
 
-.Stack--spread-start {
-  justify-content: flex-start;
-}
-.Stack--spread-center {
-  justify-content: center;
-}
-.Stack--spread-end {
-  justify-content: flex-end;
-}
-.Stack--spread-distribute {
-  justify-content: space-between;
-}
-.Stack--spread-distributeEvenly {
-  justify-content: space-evenly;
+@media ($viewport-regular) {
+  .Stack--spread-start-whenRegular {
+    justify-content: flex-start;
+  }
+  .Stack--spread-center-whenRegular {
+    justify-content: center;
+  }
+  .Stack--spread-end-whenRegular {
+    justify-content: flex-end;
+  }
+  .Stack--spread-distribute-whenRegular {
+    justify-content: space-between;
+  }
+  .Stack--spread-distributeEvenly-whenRegular {
+    justify-content: space-evenly;
+  }
 }
 
 @media ($viewport-narrow) {
@@ -201,12 +213,14 @@
 
 /* Wrap */
 
-.Stack--wrap {
-  flex-wrap: wrap;
-}
+@media ($viewport-regular) {
+  .Stack--wrap-whenRegular {
+    flex-wrap: wrap;
+  }
 
-.Stack--nowrap {
-  flex-wrap: nowrap;
+  .Stack--nowrap-whenRegular {
+    flex-wrap: nowrap;
+  }
 }
 
 @media ($viewport-narrow) {
@@ -221,15 +235,14 @@
 
 /* Divider */
 
-.Stack--showDividers .Stack-divider {
-  display: block;
+@media ($viewport-regular) {
+  .Stack--showDividers-whenRegular .Stack-divider {
+    display: block;
+  }
 }
 @media ($viewport-narrow) {
   .Stack--showDividers-whenNarrow .Stack-divider {
     display: block;
-  }
-  .Stack--hideDividers-whenNarrow .Stack-divider {
-    display: none;
   }
 }
 
@@ -241,30 +254,28 @@
   align-self: stretch;
 }
 
-.Stack--dir-block .Stack-divider {
-  border-inline-end: none;
-  border-block-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
-  inline-size: auto;
-  block-size: 0;
-}
+@media ($viewport-regular) {
+  .Stack--dir-block-whenRegular .Stack-divider {
+    border-block-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
+    inline-size: auto;
+    block-size: 0;
+  }
 
-.Stack--dir-inline .Stack-divider {
-  border-inline-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
-  border-block-end: none;
-  inline-size: 0;
-  block-size: auto;
+  .Stack--dir-inline-whenRegular .Stack-divider {
+    border-inline-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
+    inline-size: 0;
+    block-size: auto;
+  }
 }
 
 @media ($viewport-narrow) {
   .Stack--dir-block-whenNarrow .Stack-divider {
-    border-inline-end: none;
     border-block-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
     inline-size: auto;
     block-size: 0;
   }
   .Stack--dir-inline-whenNarrow .Stack-divider {
     border-inline-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
-    border-block-end: none;
     inline-size: 0;
     block-size: auto;
   }

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -2,7 +2,12 @@
 
 .Stack {
   
-  // Structure
+  // A Stack component lays elements horizontally or vertically on the page.
+  //
+  // Stack is a simple abstraction of CSS' Flexbox. Use it to structure elemets
+  // that are visually grouped, following the same direction.
+  //
+  // Markup structure
   // =========
   //
   // .Stack
@@ -26,8 +31,8 @@
   flex-wrap: nowrap;
   align-items: stretch;
   gap: var(--Stack-gap);
-  min-block-size: fit-content;
-  min-inline-size: fit-content;
+  // min-block-size: fit-content;
+  // min-inline-size: fit-content;
 
   @media ($viewport-narrow) {
     gap: var(--Stack-gap-whenNarrow);

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -1,13 +1,23 @@
-// Stack layout helper
-
-// Tasks:
-// - [x] Storybook narrow values
-// - [x] Storybook examples
-// - [x] Custom gap
-// - [ ] Figure out `align` prop for inline Stack
-// - [x] Finish dividers (including narrow viewports configuration)
+// Stack layout helper component
 
 .Stack {
+  
+  // Structure
+  // =========
+  //
+  // .Stack
+  // ├─ &.Stack--dir-[ inline | block ] [ -whenNarrow ]
+  // ├─ &.Stack--gap-[ none | condensed | normal | spacious ] [ -whenNarrow ]
+  // ├─ &.Stack--align-[ start | center | end | baseline ] [ -whenNarrow ]
+  // ├─ &.Stack--alignWrap-[ start | center | end | distribute | distributeEvenly ] [ -whenNarrow ]
+  // ├─ &.Stack--spread-[ start | center | end | distribute | distributeEvenly ] [ -whenNarrow ]
+  // ├─ &.Stack--wrap [ -whenNarrow ]
+  // ├─ &.Stack--nowrap [ -whenNarrow ]
+  // ├─ &.Stack--showDividers [ -whenNarrow ]
+  // ├─ &.Stack--hideDividers-whenNarrow
+  // │
+  // ├─ .Stack-divider
+
   --Stack-gap: var(--primer-stack-gap-normal, 16px);
   --Stack-gap-whenNarrow: var(--Stack-gap);
   --Stack-divider-color: var(--color-border-default);
@@ -134,7 +144,23 @@
 }
 
 @media ($viewport-narrow) {
-  // Todo
+  .Stack--alignWrap-start-whenNarrow {
+    align-content: flex-start;
+  }
+  
+  .Stack--alignWrap-center-whenNarrow {
+    align-content: center;
+  }
+  
+  .Stack--alignWrap-end-whenNarrow {
+    align-content: flex-end;
+  }
+  .Stack--alignWrap-distribute-whenNarrow {
+    align-content: space-between;
+  }
+  .Stack--alignWrap-distributeEvenly-whenNarrow {
+    align-content: space-evenly;
+  }
 }
 
 /* Spread */
@@ -156,7 +182,21 @@
 }
 
 @media ($viewport-narrow) {
-  // Todo
+  .Stack--spread-start-whenNarrow {
+    justify-content: flex-start;
+  }
+  .Stack--spread-center-whenNarrow {
+    justify-content: center;
+  }
+  .Stack--spread-end-whenNarrow {
+    justify-content: flex-end;
+  }
+  .Stack--spread-distribute-whenNarrow {
+    justify-content: space-between;
+  }
+  .Stack--spread-distributeEvenly-whenNarrow {
+    justify-content: space-evenly;
+  }
 }
 
 /* Wrap */

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -8,7 +8,7 @@
   // that are visually grouped, following the same direction.
   //
   // Markup structure
-  // =========
+  // ================
   //
   // .Stack
   // ├─ &.Stack--dir-[ inline | block ]-[ whenRegular | whenNarrow ]
@@ -21,6 +21,9 @@
   // ├─ &.Stack--showDividers-[ whenRegular | whenNarrow ]
   // │
   // ├─ .Stack-divider
+  // ├─ .Stack-item
+  // │  ├─ &.Stack-item--expand-[ whenRegular | whenNarrow ]
+  // │  ├─ &.Stack-item--shrink-[ whenRegular | whenNarrow ]
 
   --Stack-gap: var(--primer-stack-gap-normal, 16px);
   --Stack-gap-whenNarrow: var(--Stack-gap);
@@ -28,8 +31,8 @@
 
   display: flex;
   flex-flow: column;
-  flex-wrap: nowrap;
   align-items: stretch;
+  align-content: start;
   gap: var(--Stack-gap);
 
   @media ($viewport-narrow) {
@@ -37,230 +40,133 @@
   }
 }
 
-/* Direction */
+@mixin Stack--modifiers($viewportRange: '') {
 
-@media ($viewport-regular) {
-  .Stack--dir-inline-whenRegular {
+  /* direction */
+
+  .Stack--dir-inline#{$viewportRange} {
     flex-flow: row;
   }
 
-  .Stack--dir-block-whenRegular {
+  .Stack--dir-block#{$viewportRange} {
     flex-flow: column;
   }
-}
 
-@media ($viewport-narrow) {
-  .Stack--dir-inline-whenNarrow {
-    flex-flow: row;
-  }
+  /* gap */
 
-  .Stack--dir-block-whenNarrow {
-    flex-flow: column;
-  }
-}
-
-/* Gap */
-
-@media ($viewport-regular) {
-  .Stack--gap-none-whenRegular {
+  .Stack--gap-none#{$viewportRange} {
     --Stack-gap: 0;
   }
 
-  .Stack--gap-condensed-whenRegular {
+  .Stack--gap-condensed#{$viewportRange} {
     --Stack-gap: var(--primer-stack-gap-condensed, 8px);
   }
 
-  .Stack--gap-normal-whenRegular {
+  .Stack--gap-normal#{$viewportRange} {
     --Stack-gap: var(--primer-stack-gap-normal, 16px);
-  }
-
-  .Stack--gap-spacious-whenRegular {
-    --Stack-gap: var(--primer-stack-gap-spacious, 24px);
-  }
-}
-
-@media ($viewport-narrow) {
-  .Stack--gap-none-whenNarrow {
-    --Stack-gap-whenNarrow: 0;
-  }
-
-  .Stack--gap-condensed-whenNarrow {
-    --Stack-gap-whenNarrow: var(--primer-stack-gap-condensed, 8px);
-  }
-
-  .Stack--gap-normal-whenNarrow {
-    --Stack-gap-whenNarrow: var(--primer-stack-gap-normal, 16px);
   }
 
   // There's no .Stack--gap-spacious-whenNarrow
   // Narrow viewports render `spacious` gap as `normal`
-}
+  @if $viewportRange != '-whenNarrow' {
+    .Stack--gap-spacious#{$viewportRange} {
+      --Stack-gap: var(--primer-stack-gap-spacious, 24px);
+    }
+  }
 
-/* Align */
+  /* align */
 
-@media ($viewport-regular) {
-  .Stack--align-start-whenRegular {
+  .Stack--align-start#{$viewportRange} {
     align-items: flex-start;
   }
 
-  .Stack--align-center-whenRegular {
+  .Stack--align-center#{$viewportRange} {
     align-items: center;
   }
 
-  .Stack--align-end-whenRegular {
+  .Stack--align-end#{$viewportRange} {
     align-items: flex-end;
   }
 
-  .Stack--align-baseline-whenRegular {
+  .Stack--align-baseline#{$viewportRange} {
     align-items: baseline;
   }
-}
 
-@media ($viewport-narrow) {
-  .Stack--align-start-whenNarrow {
-    align-items: flex-start;
-  }
+  /* alignWrap */
 
-  .Stack--align-center-whenNarrow {
-    align-items: center;
-  }
-
-  .Stack--align-end-whenNarrow {
-    align-items: flex-end;
-  }
-
-  .Stack--align-baseline-whenNarrow {
-    align-items: baseline;
-  }
-}
-
-/* AlignWrap */
-
-@media ($viewport-regular) {
-  .Stack--alignWrap-start-whenRegular {
+  .Stack--alignWrap-start#{$viewportRange} {
     align-content: flex-start;
   }
 
-  .Stack--alignWrap-center-whenRegular {
+  .Stack--alignWrap-center#{$viewportRange} {
     align-content: center;
   }
 
-  .Stack--alignWrap-end-whenRegular {
+  .Stack--alignWrap-end#{$viewportRange} {
     align-content: flex-end;
   }
 
-  .Stack--alignWrap-distribute-whenRegular {
+  .Stack--alignWrap-distribute#{$viewportRange} {
     align-content: space-between;
   }
 
-  .Stack--alignWrap-distributeEvenly-whenRegular {
+  .Stack--alignWrap-distributeEvenly#{$viewportRange} {
     align-content: space-evenly;
   }
-}
 
-@media ($viewport-narrow) {
-  .Stack--alignWrap-start-whenNarrow {
-    align-content: flex-start;
-  }
+  /* spread */
 
-  .Stack--alignWrap-center-whenNarrow {
-    align-content: center;
-  }
-
-  .Stack--alignWrap-end-whenNarrow {
-    align-content: flex-end;
-  }
-
-  .Stack--alignWrap-distribute-whenNarrow {
-    align-content: space-between;
-  }
-
-  .Stack--alignWrap-distributeEvenly-whenNarrow {
-    align-content: space-evenly;
-  }
-}
-
-/* Spread */
-
-@media ($viewport-regular) {
-  .Stack--spread-start-whenRegular {
+  .Stack--spread-start#{$viewportRange} {
     justify-content: flex-start;
   }
 
-  .Stack--spread-center-whenRegular {
+  .Stack--spread-center#{$viewportRange} {
     justify-content: center;
   }
 
-  .Stack--spread-end-whenRegular {
+  .Stack--spread-end#{$viewportRange} {
     justify-content: flex-end;
   }
 
-  .Stack--spread-distribute-whenRegular {
+  .Stack--spread-distribute#{$viewportRange} {
     justify-content: space-between;
   }
 
-  .Stack--spread-distributeEvenly-whenRegular {
+  .Stack--spread-distributeEvenly#{$viewportRange} {
     justify-content: space-evenly;
   }
-}
 
-@media ($viewport-narrow) {
-  .Stack--spread-start-whenNarrow {
-    justify-content: flex-start;
-  }
+  /* wrap */
 
-  .Stack--spread-center-whenNarrow {
-    justify-content: center;
-  }
-
-  .Stack--spread-end-whenNarrow {
-    justify-content: flex-end;
-  }
-
-  .Stack--spread-distribute-whenNarrow {
-    justify-content: space-between;
-  }
-
-  .Stack--spread-distributeEvenly-whenNarrow {
-    justify-content: space-evenly;
-  }
-}
-
-/* Wrap */
-
-@media ($viewport-regular) {
-  .Stack--wrap-whenRegular {
+  .Stack--wrap#{$viewportRange} {
     flex-wrap: wrap;
   }
 
-  .Stack--nowrap-whenRegular {
+  .Stack--nowrap#{$viewportRange} {
     flex-wrap: nowrap;
   }
-}
 
-@media ($viewport-narrow) {
-  .Stack--wrap-whenNarrow {
-    flex-wrap: wrap;
-  }
+  /* showDividers */
 
-  .Stack--nowrap-whenNarrow {
-    flex-wrap: nowrap;
-  }
-}
-
-/* Divider */
-
-@media ($viewport-regular) {
-  .Stack--showDividers-whenRegular .Stack-divider {
+  .Stack--showDividers#{$viewportRange} > .Stack-divider {
     display: block;
   }
+  
+  :not(.Stack--dir-inline#{$viewportRange}) > .Stack-divider {
+    border-block-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
+    inline-size: auto;
+    block-size: 0;
+  }
+
+  .Stack--dir-inline#{$viewportRange} > .Stack-divider {
+    border-inline-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
+    inline-size: 0;
+    block-size: auto;
+  }
+
 }
 
-@media ($viewport-narrow) {
-  .Stack--showDividers-whenNarrow .Stack-divider {
-    display: block;
-  }
-}
+/* Stack-divider */
 
 .Stack-divider {
   display: none;
@@ -270,30 +176,33 @@
   align-self: stretch;
 }
 
-@media ($viewport-regular) {
-  .Stack--dir-block-whenRegular .Stack-divider {
-    border-block-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
-    inline-size: auto;
-    block-size: 0;
-  }
+/* Stack-item */
 
-  .Stack--dir-inline-whenRegular .Stack-divider {
-    border-inline-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
-    inline-size: 0;
-    block-size: auto;
-  }
+.Stack-item {
+  flex: 0 1 auto;
+  min-inline-size: 0;
 }
 
-@media ($viewport-narrow) {
-  .Stack--dir-block-whenNarrow .Stack-divider {
-    border-block-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
-    inline-size: auto;
-    block-size: 0;
+@mixin Stack-item--modifiers($viewportRange: '') {
+
+  .Stack-item--expand#{$viewportRange} {
+    flex-grow: 1;
+  }
+  
+  .Stack-item--keepSize#{$viewportRange} {
+    flex-shrink: 0;
   }
 
-  .Stack--dir-inline-whenNarrow .Stack-divider {
-    border-inline-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
-    inline-size: 0;
-    block-size: auto;
-  }
+}
+
+// Responsive composition
+
+@media ($viewport-narrow) {
+  @include Stack--modifiers('-whenNarrow');
+  @include Stack-item--modifiers('-whenNarrow');
+}
+
+@media ($viewport-regular) {
+  @include Stack--modifiers('-whenRegular');
+  @include Stack-item--modifiers('-whenRegular');
 }

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -30,7 +30,6 @@
   --Stack-gap-whenRegular: #{$Stack-gap-default};
   --Stack-gap-whenNarrow: #{$Stack-gap-default};
   --Stack-gap-whenWide: var(--Stack-gap-whenRegular);
-  
   --Stack-divider-color: var(--color-border-default);
 
   display: flex;

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -15,6 +15,9 @@
   display: flex;
   flex-flow: column;
   gap: var(--Stack-gap);
+  min-block-size: fit-content;
+  min-inline-size: fit-content;
+  align-items: stretch;
 
   @media ($viewport-narrow) {
     gap: var(--Stack-gap-whenNarrow);
@@ -89,6 +92,10 @@
   align-items: flex-end;
 }
 
+.Stack--align-baseline {
+  align-items: baseline;
+}
+
 @media ($viewport-narrow) {
   .Stack--align-start-whenNarrow {
     align-items: flex-start;
@@ -101,6 +108,55 @@
   .Stack--align-end-whenNarrow {
     align-items: flex-end;
   }
+  .Stack--align-baseline-whenNarrow {
+    align-items: baseline;
+  }
+}
+
+/* AlignWrap */
+
+.Stack--alignWrap-start {
+  align-content: flex-start;
+}
+
+.Stack--alignWrap-center {
+  align-content: center;
+}
+
+.Stack--alignWrap-end {
+  align-content: flex-end;
+}
+.Stack--alignWrap-distribute {
+  align-content: space-between;
+}
+.Stack--alignWrap-distributeEvenly {
+  align-content: space-evenly;
+}
+
+@media ($viewport-narrow) {
+  // Todo
+}
+
+/* Spread */
+
+.Stack--spread-start {
+  justify-content: flex-start;
+}
+.Stack--spread-center {
+  justify-content: center;
+}
+.Stack--spread-end {
+  justify-content: flex-end;
+}
+.Stack--spread-distribute {
+  justify-content: space-between;
+}
+.Stack--spread-distributeEvenly {
+  justify-content: space-evenly;
+}
+
+@media ($viewport-narrow) {
+  // Todo
 }
 
 /* Wrap */
@@ -142,6 +198,7 @@
   padding: 0;
   border: none;
   display: none;
+  align-self: stretch;
 }
 
 .Stack--dir-block .Stack-divider {

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -6,15 +6,14 @@
   // =========
   //
   // .Stack
-  // ├─ &.Stack--dir-[ inline | block ] [ -whenNarrow ]
-  // ├─ &.Stack--gap-[ none | condensed | normal | spacious ] [ -whenNarrow ]
-  // ├─ &.Stack--align-[ start | center | end | baseline ] [ -whenNarrow ]
-  // ├─ &.Stack--alignWrap-[ start | center | end | distribute | distributeEvenly ] [ -whenNarrow ]
-  // ├─ &.Stack--spread-[ start | center | end | distribute | distributeEvenly ] [ -whenNarrow ]
-  // ├─ &.Stack--wrap [ -whenNarrow ]
-  // ├─ &.Stack--nowrap [ -whenNarrow ]
-  // ├─ &.Stack--showDividers [ -whenNarrow ]
-  // ├─ &.Stack--hideDividers-whenNarrow
+  // ├─ &.Stack--dir-[ inline | block ]-[ whenRegular | whenNarrow ]
+  // ├─ &.Stack--gap-[ none | condensed | normal | spacious ]-[ whenRegular | whenNarrow ]
+  // ├─ &.Stack--align-[ start | center | end | baseline ]-[ whenRegular | whenNarrow ]
+  // ├─ &.Stack--alignWrap-[ start | center | end | distribute | distributeEvenly ]-[ whenRegular | whenNarrow ]
+  // ├─ &.Stack--spread-[ start | center | end | distribute | distributeEvenly ]-[ whenRegular | whenNarrow ]
+  // ├─ &.Stack--wrap-[ whenRegular | whenNarrow ]
+  // ├─ &.Stack--nowrap-[ whenRegular | whenNarrow ]
+  // ├─ &.Stack--showDividers-[ whenRegular | whenNarrow ]
   // │
   // ├─ .Stack-divider
 

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -11,32 +11,40 @@
   // ================
   //
   // .Stack
-  // ├─ &.Stack--dir-[ inline | block ]-[ whenRegular | whenNarrow ]
-  // ├─ &.Stack--gap-[ none | condensed | normal | spacious ]-[ whenRegular | whenNarrow ]
-  // ├─ &.Stack--align-[ start | center | end | baseline ]-[ whenRegular | whenNarrow ]
-  // ├─ &.Stack--alignWrap-[ start | center | end | distribute | distributeEvenly ]-[ whenRegular | whenNarrow ]
-  // ├─ &.Stack--spread-[ start | center | end | distribute | distributeEvenly ]-[ whenRegular | whenNarrow ]
-  // ├─ &.Stack--wrap-[ whenRegular | whenNarrow ]
-  // ├─ &.Stack--nowrap-[ whenRegular | whenNarrow ]
-  // ├─ &.Stack--showDividers-[ whenRegular | whenNarrow ]
+  // ├─ &.Stack--dir-[ inline | block ]-[ whenNarrow | whenRegular | whenWide ]
+  // ├─ &.Stack--gap-[ none | condensed | normal | spacious ]-[ whenNarrow | whenRegular | whenWide ]
+  // ├─ &.Stack--align-[ start | center | end | baseline ]-[ whenNarrow | whenRegular | whenWide ]
+  // ├─ &.Stack--alignWrap-[ start | center | end | distribute | distributeEvenly ]-[ whenNarrow | whenRegular | whenWide ]
+  // ├─ &.Stack--spread-[ start | center | end | distribute | distributeEvenly ]-[ whenNarrow | whenRegular | whenWide ]
+  // ├─ &.Stack--wrap-[ whenNarrow | whenRegular | whenWide ]
+  // ├─ &.Stack--nowrap-[ whenNarrow | whenRegular | whenWide ]
+  // ├─ &.Stack--showDividers-[ whenNarrow | whenRegular | whenWide ]
   // │
   // ├─ .Stack-divider
   // ├─ .Stack-item
-  // │  ├─ &.Stack-item--expand-[ whenRegular | whenNarrow ]
-  // │  ├─ &.Stack-item--shrink-[ whenRegular | whenNarrow ]
+  // │  ├─ &.Stack-item--expand-[ whenNarrow | whenRegular | whenWide ]
+  // │  ├─ &.Stack-item--keepSize-[ whenNarrow | whenRegular | whenWide ]
 
-  --Stack-gap: var(--primer-stack-gap-normal, 16px);
-  --Stack-gap-whenNarrow: var(--Stack-gap);
+  $Stack-gap-default: var(--primer-stack-gap-normal, 16px);
+
+  --Stack-gap-whenRegular: #{$Stack-gap-default};
+  --Stack-gap-whenNarrow: #{$Stack-gap-default};
+  --Stack-gap-whenWide: var(--Stack-gap-whenRegular);
+  
   --Stack-divider-color: var(--color-border-default);
 
   display: flex;
   flex-flow: column;
   align-items: stretch;
   align-content: start;
-  gap: var(--Stack-gap);
+  gap: var(--Stack-gap-whenRegular);
 
   @media ($viewport-narrow) {
     gap: var(--Stack-gap-whenNarrow);
+  }
+
+  @media ($viewport-wide) {
+    gap: var(--Stack-gap-whenWide);
   }
 }
 
@@ -54,22 +62,22 @@
   /* gap */
 
   .Stack--gap-none#{$viewportRange} {
-    --Stack-gap: 0;
+    --Stack-gap#{$viewportRange}: 0;
   }
 
   .Stack--gap-condensed#{$viewportRange} {
-    --Stack-gap: var(--primer-stack-gap-condensed, 8px);
+    --Stack-gap#{$viewportRange}: var(--primer-stack-gap-condensed, 8px);
   }
 
   .Stack--gap-normal#{$viewportRange} {
-    --Stack-gap: var(--primer-stack-gap-normal, 16px);
+    --Stack-gap#{$viewportRange}: var(--primer-stack-gap-normal, 16px);
   }
 
   // There's no .Stack--gap-spacious-whenNarrow
   // Narrow viewports render `spacious` gap as `normal`
   @if $viewportRange != '-whenNarrow' {
     .Stack--gap-spacious#{$viewportRange} {
-      --Stack-gap: var(--primer-stack-gap-spacious, 24px);
+      --Stack-gap#{$viewportRange}: var(--primer-stack-gap-spacious, 24px);
     }
   }
 
@@ -147,17 +155,20 @@
 
   /* showDividers */
 
-  .Stack--showDividers#{$viewportRange} > .Stack-divider {
+  .Stack--showDividers#{$viewportRange} > .Stack-divider,
+  .Stack--showDividers#{$viewportRange} > .Stack-item > .Stack-divider {
     display: block;
   }
 
-  :not(.Stack--dir-inline#{$viewportRange}) > .Stack-divider {
+  :not(.Stack--dir-inline#{$viewportRange}) > .Stack-divider,
+  :not(.Stack--dir-inline#{$viewportRange}) > .Stack-item > .Stack-divider {
     border-block-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
     inline-size: auto;
     block-size: 0;
   }
 
-  .Stack--dir-inline#{$viewportRange} > .Stack-divider {
+  .Stack--dir-inline#{$viewportRange} > .Stack-divider,
+  .Stack--dir-inline#{$viewportRange} > .Stack-item > .Stack-divider {
     border-inline-end: var(--primer-borderWidth-thin, 1px) solid var(--Stack-divider-color);
     inline-size: 0;
     block-size: auto;
@@ -202,4 +213,9 @@
 @media ($viewport-regular) {
   @include Stack--modifiers('-whenRegular');
   @include Stack-item--modifiers('-whenRegular');
+}
+
+@media ($viewport-wide) {
+  @include Stack--modifiers('-whenWide');
+  @include Stack-item--modifiers('-whenWide');
 }

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -31,8 +31,6 @@
   flex-wrap: nowrap;
   align-items: stretch;
   gap: var(--Stack-gap);
-  // min-block-size: fit-content;
-  // min-inline-size: fit-content;
 
   @media ($viewport-narrow) {
     gap: var(--Stack-gap-whenNarrow);

--- a/src/support/variables/layout.scss
+++ b/src/support/variables/layout.scss
@@ -151,6 +151,7 @@ $breakpoints: (
 // https://github.com/primer/primitives/blob/main/tokens/functional/size/viewport.json
 $viewport-narrow: 'max-width: #{$width-md - 0.02px}' !default;
 $viewport-regular: 'min-width: #{$width-md}' !default;
+$viewport-wide: 'min-width: 1400px' !default;
 
 // This map in the form (breakpoint: variant) is used to iterate over
 // breakpoints and create both responsive and non-responsive classes in one

--- a/src/support/variables/layout.scss
+++ b/src/support/variables/layout.scss
@@ -146,6 +146,12 @@ $breakpoints: (
   xl: $width-xl
 ) !default;
 
+// Viewport ranges
+// Soon to be provided by Primer Primitives directly
+// https://github.com/primer/primitives/blob/main/tokens/functional/size/viewport.json
+$viewport-narrow: 'max-width: #{$width-md - 0.02px}' !default;
+$viewport-regular: 'min-width: #{$width-md}' !default;
+
 // This map in the form (breakpoint: variant) is used to iterate over
 // breakpoints and create both responsive and non-responsive classes in one
 // loop:


### PR DESCRIPTION
### What are you trying to accomplish?

This PR adds the `Stack` component to Primer CSS.

> A `Stack` component lays elements horizontally or vertically on the page.
>
> `Stack` is a simple abstraction of CSS’ Flexbox. Use it to structure elements that are visually grouped and follow the same direction.

## Overview

This is the first [Layout helper component](https://github.com/github/primer/discussions/807)[^1] to be designed and implemented following the new [Responsive API design guidelines](https://github.com/github/primer/blob/main/adrs/2022-04-15-responsive-design-api-guidelines.md#context)[^2].

Layout helper components have been proposed as a way to reduce our dependency on [utilities](https://primer.style/css/utilities), make it easier to implement responsive design, and support the new [Primer Primitives](https://github.com/primer/primitives) [design tokens](https://primer.style/primitives/spacing).

Layout helper components are designed in a platform-agnostic way. They will be available to both Primer ViewComponents and Primer React with the same behavior and API.

[^1]: [Discussion on Layout helper components](https://github.com/github/primer/discussions/807) (only available for Hubbers)
[^2]: [Responsive API design guidelines ADR](https://github.com/github/primer/blob/main/adrs/2022-04-15-responsive-design-api-guidelines.md#context) (only available for hubbers, but content will be made public in a future PR)

## Features

`Stack` makes it easy to group elements that follow a same direction (vertically or horizontally), with spacing gap, optional dividers, and optional wrapping.

### Responsive by design
All properties from this component are responsive, meaning different values can be passed depending on the viewport range.

For example, a `Stack` `direction` can be set to `inline` (horizontal) on `narrow`, and `block` (vertical) on `desktop`.

In CSS, we use `-whenNarrow`, `-whenRegular`, and `-whenWide` suffixes to target modifier classes to a specific range. This is how the team is planning to support any responsive properties going forward.

More information about [viewport ranges can be found here](https://github.com/github/primer/blob/main/adrs/2022-04-15-responsive-design-api-guidelines.md#2-update-nomenclature-for-creating-responsive-components-and-web-pages) (only available for Hubbers, documentation to be made public in a future PR).

### Alignment and distribution of stacking elements

`Stack` also allows aligning elements without relying on difficult Flexbox property names (`align-items`, `justify-content`, and `align-content`). For that, it uses simpler concepts such as `align` and `spread` (described in the _Properties_ section below).

```html
<!-- Vertical stacking, with elements aligned to the right -->
<Stack direction="block" align="end">
  <div class="Box">Element 1</div>
  <div class="Box">Element 2</div>
  <div class="Box">Element 3</div>
</Stack>
```

```html
<!-- Horizontal buttons, positioned to the right -->
<Stack direction="inline" spread="end">
  <button>Cancel</button>
  <button>Save</button>
</Stack>
```
<details>
<summary>Note on using inline Stack for buttons</summary>
<blockquote>

In the future we may have specialized stacking components for controls using the [UI control stack tokens](https://primer.style/primitives/spacing#ui-control-stack).

In the meantime, we can use these tokens with a custom gap:
```html
<Stack direction="inline" spread="end" gap="var(--primer-controlStack-medium-gap-auto)">
  <button>Cancel</button>
  <button>Save</button>
</Stack>
```

</blockquote>
</details>

## Properties

`Stack` has the following properties:

### `direction`
Sets how elements inside `Stack` are placed, either horizontally (`inline`) or vertically (`block`). This property follows the [writing mode](https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode).

### `gap`
Sets the spacing gap between items. All sizes use design tokens from the new Primer Primitives' [`UI Stack` pattern](https://primer.style/primitives/spacing#ui-stack).

Values:
  - `none`: `0`
  - `condensed`: `var(--primer-stack-gap-condensed, 8px)`,
  - `normal`: `var(--primer-stack-gap-normal, 16px)` (default)
  - `spacious`: `var(--primer-stack-gap-spacious, 24px)` (on regular viewports, otherwise it appears as `normal` on narrow viewports)

Custom values are not supported for now.

### `align`
Sets the alignment between items in the cross-axis of the specified direction. For example:
- If `direction` is set to `block` (stacks vertically), it controls the horizontal alignment (left, center, right).
- If `direction` is set to `inline` (stacks horizontally), it controls the vertical alignment (top, center, bottom).<br>
This property behavior is equivalent to the `align-items` Flexbox property.

Values:
- `stretch` (default)
- `start`
- `center`
- `end`
- `baseline`

### `alignWrap`
Sets how stack lines are distributed, if they `wrap` into multiple lines. This has equivalent behavior to the `align-content` Flexbox property.

(Most instances of `Stack` shouldn't require this property)

Values:
- `start` (default)
- `center`
- `end`
- `distribute` (equivalent behavior to Flexbox's `space-between`)
- `distributeEvenly` (equivalent behavior to Flexbox's `space-evenly`)

### `spread`

Sets how items will be distributed in the stacking direction.

Values:
- `start` (default)
- `center`
- `end`
- `distribute` (equivalent behavior to Flexbox's `space-between`)
- `distributeEvenly` (equivalent behavior to Flexbox's `space-evenly`)

### `wrap`

Sets whether items are forced onto one line or can wrap onto multiple lines.

Values:
- `wrap`
- `nowrap` (default)

### `showDividers`

Boolean. Whether dividers are present between items or not.

_Note: dividers are not compatible in wrapping stacks._

_Note 2: the presence of a divider duplicates the `gap` between items._

### `dividerAriaRole`

Sets which ARIA role will be used for the divider.

Values:
- `presentation` (default)
- `separator`

## Structure

```
.Stack
├─ &.Stack--dir-[ inline | block ]-[ whenNarrow | whenRegular | whenWide ]
├─ &.Stack--gap-[ none | condensed | normal | spacious ]-[ whenNarrow | whenRegular | whenWide ]
├─ &.Stack--align-[ start | center | end | baseline ]-[ whenNarrow | whenRegular | whenWide ]
├─ &.Stack--alignWrap-[ start | center | end | distribute | distributeEvenly ]-[ whenNarrow | whenRegular | whenWide ]
├─ &.Stack--spread-[ start | center | end | distribute | distributeEvenly ]-[ whenNarrow | whenRegular | whenWide ]
├─ &.Stack--wrap-[ whenNarrow | whenRegular | whenWide ]
├─ &.Stack--nowrap-[ whenNarrow | whenRegular | whenWide ]
├─ &.Stack--showDividers-[ whenNarrow | whenRegular | whenWide ]
│
├─ .Stack-divider
├─ .Stack-item
│  ├─ &.Stack-item--expand-[ whenNarrow | whenRegular | whenWide ]
│  ├─ &.Stack-item--keepSize-[ whenNarrow | whenRegular | whenWide ]
```

## Storybook

You can play with `Stack` in Storybook. By default it comes with `_debug` set to true, so you can see how the elements are positioned.

[✨ Link to Storybook ✨](https://primer-76f6bbc6c4-26588275.drafts.github.io/storybook/?path=/story/components-layout-stack--playground)


### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
