### PR TITLE
Increase z-index for .show-on-focus

### DIFF
--- a/.changeset/short-kings-compete.md
+++ b/.changeset/short-kings-compete.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Increases z-index for .show-on-focus

--- a/src/utilities/visibility-display.scss
+++ b/src/utilities/visibility-display.scss
@@ -115,7 +115,7 @@
   clip: rect(1px, 1px, 1px, 1px);
 
   &:focus {
-    z-index: 20;
+    z-index: 999;
     width: auto;
     height: auto;
     clip: auto;


### PR DESCRIPTION
### What are you trying to accomplish?

When focused on the "Skip to content" button and not logged in, the button remains hidden.

Before:
![The GitHub header with no skip link visible](https://user-images.githubusercontent.com/4696224/180433721-e4937e13-5304-4728-ad8c-1e556e3cc90a.png)

After
![The GitHub header with skip link visible](https://user-images.githubusercontent.com/4696224/180433849-dbbab056-754e-46ba-8137-0764d88406c0.png)

### What approach did you choose and why?

I increased the z-index to make it visible.

### What should reviewers focus on?

All good 👍 

### Can these changes ship as is?

- [ ] Yes, this PR does not depend on additional changes. 🚢 
