### PR TITLE
Add .tooltipped to deprecations json

### DIFF
--- a/.changeset/new-jars-complain.md
+++ b/.changeset/new-jars-complain.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Add .tooltipped to deprecations json

--- a/src/deprecations.json
+++ b/src/deprecations.json
@@ -340,6 +340,7 @@
     "btn-outline-mktg": "btn-muted-mktg",
     "btn-transparent": "btn-subtle-mktg",
     "text-pending": "text-yellow",
+    "tooltipped": null,
     "bg-pending": "bg-yellow-dark",
     "container": null,
     "columns": null,


### PR DESCRIPTION
### What are you trying to accomplish?

I was wondering why the `DeprecatedInPrimer` linter wasn't flagging `.tooltipped` which was deprecated months ago. 
It turns out I never updated the `deprecations.json` file which @jonrohan suggested here: https://github.com/primer/css/pull/1936. 😭

### What approach did you choose and why?

<!-- Here you can explain your approach and reasoning in more detail. -->

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [ ] Yes, this PR does not depend on additional changes. 🚢 
