### PR TITLE
Prevent `SegmentedControl-text` from wrapping

### DIFF
--- a/.changeset/poor-dots-play.md
+++ b/.changeset/poor-dots-play.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Prevent `SegmentedControl-text` from wrapping

--- a/src/segmented-control/segmented-control.scss
+++ b/src/segmented-control/segmented-control.scss
@@ -90,6 +90,8 @@
 // Text -----------------------------------------
 
 .SegmentedControl-text {
+  white-space: nowrap;
+
   // renders a visibly hidden "copy" of the text in bold, reserving box space for when text becomes bold on selected
   &[data-content]::before {
     display: block;


### PR DESCRIPTION
### What are you trying to accomplish?

Follow-up to #2083. It prevents text from wrapping onto multiple lines.

Before | After
--- | ---
![Screen Shot 2022-07-27 at 12 08 54](https://user-images.githubusercontent.com/378023/181153169-2cfc6db8-8561-4ae9-9eb7-29247bfa19c4.png) | ![Screen Shot 2022-07-27 at 12 17 04](https://user-images.githubusercontent.com/378023/181153177-c09f2f7e-7060-4080-b005-85237c0221da.png)


### What approach did you choose and why?

`white-space: nowrap;`

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
