### PR TITLE
Add `aria-selected` to ActionList-item for Autocomplete

### DIFF
--- a/.changeset/tricky-mangos-nail.md
+++ b/.changeset/tricky-mangos-nail.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Add `aria-selected` to ActionList-item for Autocomplete

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -115,7 +115,8 @@
 
   // active state [aria-current]
 
-  &.ActionList-item--navActive {
+  &.ActionList-item--navActive,
+  &[aria-selected='true'] {
     &:not(.ActionList-item--subItem) {
       .ActionList-item-label {
         font-weight: $font-weight-bold;
@@ -184,8 +185,7 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition:
-        visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -185,7 +185,8 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition:
+        visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Quick patch to use the `navActive` state for `aria-selected` in the case of Autocomplete items.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
