### PR TITLE
Autocomplete item selected state

### DIFF
--- a/.changeset/mighty-toes-nail.md
+++ b/.changeset/mighty-toes-nail.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Autocomplete item selected state

--- a/.changeset/mighty-toes-nail.md
+++ b/.changeset/mighty-toes-nail.md
@@ -2,4 +2,4 @@
 "@primer/css": patch
 ---
 
-Autocomplete item selected state
+Autocomplete item selected state 

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -207,7 +207,8 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition:
+        visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -1,9 +1,9 @@
 // stylelint-disable max-nesting-depth, selector-max-specificity, selector-max-compound-selectors
 
-@mixin activeIndicatorLine {
+@mixin activeIndicatorLine($padding-left: -$actionList-item-padding-horizontal) {
   position: absolute;
   top: calc(50% - 12px);
-  left: -$actionList-item-padding-horizontal;
+  left: $padding-left;
   width: $spacer-1;
   height: $spacer-4;
   content: '';
@@ -113,10 +113,32 @@
     }
   }
 
+  // Autocomplete [aria-selected] items
+
+  &[aria-selected='true'] {
+    font-weight: $font-weight-normal;
+    background: var(--color-action-list-item-default-selected-bg);
+
+    @media (hover: hover) {
+      &:hover {
+        background-color: var(--color-action-list-item-default-hover-bg);
+      }
+    }
+
+    &::before,
+    + .ActionList-item::before {
+      visibility: hidden;
+    }
+
+    // blue accent line
+    &::after {
+      @include activeIndicatorLine(-$spacer-1);
+    }
+  }
+
   // active state [aria-current]
 
-  &.ActionList-item--navActive,
-  &[aria-selected='true'] {
+  &.ActionList-item--navActive {
     &:not(.ActionList-item--subItem) {
       .ActionList-item-label {
         font-weight: $font-weight-bold;
@@ -185,8 +207,7 @@
     .ActionList-item-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition:
-        visibility 0 linear $actionList-item-checkmark-transition-timing,
+      transition: visibility 0 linear $actionList-item-checkmark-transition-timing,
         opacity $actionList-item-checkmark-transition-timing;
     }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Quick patch to use the `navActive` state for `aria-selected` in the case of Autocomplete items.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
