### PR TITLE
Fix: autoprefix giving a warning about align-content

### DIFF
--- a/.changeset/good-colts-jam.md
+++ b/.changeset/good-colts-jam.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fix: autoprefix giving a warning about align-content

--- a/src/layout/stack.scss
+++ b/src/layout/stack.scss
@@ -35,7 +35,7 @@
   display: flex;
   flex-flow: column;
   align-items: stretch;
-  align-content: start;
+  align-content: flex-start;
   gap: var(--Stack-gap-whenRegular);
 
   @media ($viewport-narrow) {


### PR DESCRIPTION
### What are you trying to accomplish?

Fixing a warning about `align-items: start;`

![image](https://user-images.githubusercontent.com/54012/181814524-71dda499-411d-424e-b353-582967f997db.png)

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
