### PR TITLE
Fail dist build when for postcss warnings

### DIFF
--- a/.changeset/rotten-phones-ring.md
+++ b/.changeset/rotten-phones-ring.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fail dist build when for postcss warnings

--- a/script/dist.js
+++ b/script/dist.js
@@ -51,6 +51,15 @@ async function dist() {
       const scss = await readFile(from, encoding)
       meta.imports = getExternalImports(scss, path).map(getPathName)
       const result = await compiler(scss, {from, to})
+      const warnings = result.warnings()
+
+      // We don't want to release changes that cause warnings with postcss. Fail the dist build if any warnings are detected.
+      if (warnings.length) {
+        for (const warning of warnings) {
+          console.warn(warning.toString())
+        }
+        throw new Error(`Warnings while compiling ${from}.  See output above.`)
+      }
 
       await Promise.all([
         writeFile(to, result.css, encoding),


### PR DESCRIPTION
### What are you trying to accomplish?

We would like to detect postcss warnings at build time, and prevent them from being merged/published

### What approach did you choose and why?

Throw an error when a warning is detected during postcss build.  Sample output from a few commits back:

```bash
@dgreif ➜ /workspaces/css (37deef3a ✗) $ script/dist.js
autoprefixer: /workspaces/css/src/layout/index.scss#sass:586:2: start value has mixed support, consider using flex-start instead
Error: Warnings while compiling src/layout/index.scss.  See output above.
    at file:///workspaces/css/script/dist.js:60:15
    at async Promise.all (index 17)
    at async dist (file:///workspaces/css/script/dist.js:72:5)
autoprefixer: /workspaces/css/src/core/index.scss#sass:1:0: start value has mixed support, consider using flex-start instead
autoprefixer: /workspaces/css/src/index.scss#sass:10455:2: start value has mixed support, consider using flex-start instead
```

This will cause `script/dist.js` to exit with code `1`

### What should reviewers focus on?

Is failing the build for warnings the right approach?

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
