### PR TITLE
Restore contributor stats to docs footer

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -16,6 +16,8 @@ jobs:
     if: ${{ github.repository == 'primer/css' }}
     uses: primer/.github/.github/workflows/deploy_preview.yml@main
     name: Deploy preview
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:
       node_version: 14
       install: yarn && cd docs && yarn && cd ..

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -39,6 +39,8 @@ jobs:
     name: Production
     needs: [guard]
     uses: primer/.github/.github/workflows/deploy.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:
       node_version: 14
       install: yarn && cd docs && yarn && cd ..


### PR DESCRIPTION
### What are you trying to accomplish?

Restore the contribution info to the docs footer 👇 
![docs footer](https://user-images.githubusercontent.com/13340707/182624775-cffc6be2-37e9-4af2-9904-91e2bf2d5b1b.png)



### What approach did you choose and why?

Gatsby couldn't authenticate with the GitHub API.

### What should reviewers focus on?

Check docs in preview deploy and footer should be there now.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
