### PR TITLE
Rename SegmentedControl--iconOnly-whenNarrow to SegmentedControl-button--iconOnly-whenNarrow and place on button

### DIFF
--- a/.changeset/silent-crews-pay.md
+++ b/.changeset/silent-crews-pay.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Rename SegmentedControl--iconOnly-whenNarrow to SegmentedControl-button--iconOnly-whenNarrow and place on button

--- a/src/segmented-control/segmented-control.scss
+++ b/src/segmented-control/segmented-control.scss
@@ -135,10 +135,8 @@
 
 // Icon only when narrow
 @media (max-width: $width-md) {
-  .SegmentedControl--iconOnly-whenNarrow {
-    .SegmentedControl-button {
-      width: var(--primer-control-medium-size, 32px);
-    }
+  .SegmentedControl-button--iconOnly-whenNarrow {
+    width: var(--primer-control-medium-size, 32px);
 
     .SegmentedControl-content {
       padding: 0;
@@ -163,7 +161,7 @@
 
   // reset for icon-only buttons
   .SegmentedControl-button--iconOnly,
-  .SegmentedControl--iconOnly-whenNarrow .SegmentedControl-button {
+  .SegmentedControl-button--iconOnly-whenNarrow {
     min-width: unset;
   }
 }


### PR DESCRIPTION
### What are you trying to accomplish?

Based on review feedback, [I moved the `icon_only` argument of the PVC component](https://github.com/primer/view_components/pull/1225/commits/267db5f038deba4bc79bb7fd7095ff0573cd3791#diff-18094351a906e1b86ec46d0749793e19db6c3ed4cfa31b9272872813c94e8cceL11-L12) from the SegmentedControl to the SegmentedControl::Button. This PR updates the classes to account for the iconOnly--WhenNarrow class being on the button, and changes the classname to reflect the new placement.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
