### PR TITLE
SegmentedControl Fixing the line between buttons

### DIFF
--- a/src/segmented-control/segmented-control.scss
+++ b/src/segmented-control/segmented-control.scss
@@ -9,30 +9,11 @@
   border-radius: var(--primer-borderRadius-medium, $border-radius);
   // stylelint-disable-next-line primer/box-shadow
   box-shadow: var(--primer-borderInset-thin, inset 0 0 0 $border-width) var(--color-border-default);
-
-  li {
-    position: relative;
-    display: inline-flex;
-
-    // stylelint-disable-next-line selector-max-compound-selectors
-    &:has([aria-current='true']) + li .SegmentedControl-button::before {
-      border-color: transparent;
-    }
-  }
 }
 
-// Button -----------------------------------------
-
-.SegmentedControl-button {
+.SegmentedControl-item {
   position: relative;
   display: inline-flex;
-  height: var(--primer-control-medium-size, 32px);
-  // stylelint-disable-next-line primer/spacing
-  padding: calc(var(--primer-control-xsmall-paddingInline-condensed, 4px) - var(--primer-borderWidth-thin, 1px));
-  // stylelint-disable-next-line primer/typography
-  font-size: var(--primer-text-body-size-medium, $body-font-size);
-  color: var(--color-fg-default);
-  background-color: transparent;
   // stylelint-disable-next-line primer/borders
   border: var(--primer-borderWidth-thin, $border-width) $border-style transparent;
   // stylelint-disable-next-line primer/borders
@@ -55,6 +36,10 @@
     font-weight: var(--base-text-weight-semibold, $font-weight-bold);
     background-color: var(--color-btn-bg);
     border-color: var(--color-segmented-control-button-selected-border);
+
+    + .SegmentedControl-item::before {
+      border-color: transparent;
+    }
   }
 
   // Divider
@@ -73,6 +58,28 @@
 
   &[aria-current='true']::before {
     border-color: transparent;
+  }
+}
+
+// Button -----------------------------------------
+
+.SegmentedControl-button {
+  position: relative;
+  display: inline-flex;
+  height: var(--primer-control-medium-size, 32px);
+  // stylelint-disable-next-line primer/spacing
+  padding: calc(var(--primer-control-xsmall-paddingInline-condensed, 4px) - var(--primer-borderWidth-thin, 1px));
+  // stylelint-disable-next-line primer/typography
+  font-size: var(--primer-text-body-size-medium, $body-font-size);
+  color: var(--color-fg-default);
+  background-color: transparent;
+  // stylelint-disable-next-line primer/borders
+  border: transparent;
+  // stylelint-disable-next-line primer/borders
+  border-radius: var(--primer-borderRadius-medium, $border-radius);
+
+  &:focus-visible {
+    outline-offset: -1px;
   }
 }
 

--- a/src/segmented-control/segmented-control.scss
+++ b/src/segmented-control/segmented-control.scss
@@ -14,6 +14,7 @@
     position: relative;
     display: inline-flex;
 
+    // stylelint-disable-next-line selector-max-compound-selectors
     &:has([aria-current='true']) + li .SegmentedControl-button::before {
       border-color: transparent;
     }

--- a/src/segmented-control/segmented-control.scss
+++ b/src/segmented-control/segmented-control.scss
@@ -13,6 +13,10 @@
   li {
     position: relative;
     display: inline-flex;
+
+    &:has([aria-current='true']) + li .SegmentedControl-button::before {
+      border-color: transparent;
+    }
   }
 }
 
@@ -54,8 +58,7 @@
 
   // Divider
 
-  // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
-  & + .SegmentedControl-button::before {
+  &[aria-current='false']::before {
     position: absolute;
     inset: var(--primer-borderWidth-thin, 1px) 0 0 calc(var(--primer-borderWidth-thin, 1px) * -1);
     height: var(--primer-text-body-size-large, 16px);
@@ -67,8 +70,7 @@
     transition: border-color var(--primer-duration-medium, 160ms) cubic-bezier(0.3, 0.1, 0.5, 1);
   }
 
-  &[aria-current='true']::before,
-  &[aria-current='true'] + .SegmentedControl-button::before {
+  &[aria-current='true']::before {
     border-color: transparent;
   }
 }
@@ -79,6 +81,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex: 1;
   gap: var(--primer-control-medium-gap, $spacer-2);
   height: 100%;
   // stylelint-disable-next-line primer/spacing


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/primer/css/issues/2204

This fixes the selectors to correctly show the line after the component markup changed.

Before

https://user-images.githubusercontent.com/54012/184714347-4d1f1608-93cf-4ab6-8d06-262d11ce3439.mov

After

https://user-images.githubusercontent.com/54012/184714359-3f5fc553-1162-46b5-8007-555c18590803.mov


### What approach did you choose and why?

For the direct sibling of the currently selected button, I used `:has` which doesn't have much support yet, but is growing quickly. 

In browsers that don't support `:has` yet, it's not too noticeable. 

<img width="381" alt="image" src="https://user-images.githubusercontent.com/54012/184715351-d858c1d8-c573-4846-a298-18ea6721bb9b.png">

### What should reviewers focus on?

I'm open to suggestions on other ways to fix the line issue.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
