### PR TITLE
Remove `--syntax` option, which is no longer available

### DIFF
--- a/docs/content/tools/linting.md
+++ b/docs/content/tools/linting.md
@@ -20,7 +20,7 @@ npm install -g stylelint
 Whether you work on `github/github` or not, it's useful to see lint errors locally. The easiest way to lint your code is to install a [plugin](#plugins) in your workflow. If you prefer to run stylelint manually, pass it a glob pattern of the files you want to lint. If you work on `github/github`, you can run stylelint from the command line:
 
 ```
-bin/stylelint "app/assets/stylesheets/**/*.scss" --syntax scss
+bin/stylelint "app/assets/stylesheets/**/*.scss"
 ```
 
 For more advanced usage, we recommend reading the [stylelint user guide](http://stylelint.io/user-guide/) and checking out our [primer stylelint configuration](https://github.com/primer/stylelint-config).


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->

Original:
```
@imjohnbo ➜ /workspaces/my-workspace $ bin/stylelint "app/assets/stylesheets/**/*.scss" --syntax scss
Error: The "syntax" option is no longer available. You should install an appropriate syntax, e.g. postcss-scss, and use the "customSyntax" option
```

Proposed:
```
bin/stylelint "app/assets/stylesheets/**/*.scss"
```

- [x] Yes, this PR does not depend on additional changes. 🚢 
