### PR TITLE
Remove outline reset of `.SelectMenu-closeButton`

### DIFF
--- a/.changeset/clean-wombats-run.md
+++ b/.changeset/clean-wombats-run.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Remove outline reset of `.SelectMenu-closeButton`

--- a/src/select-menu/select-menu.scss
+++ b/src/select-menu/select-menu.scss
@@ -371,7 +371,6 @@ $SelectMenu-max-height: 480px !default;
 // Different states
 
 // Reset outlines
-.SelectMenu-closeButton:focus,
 .SelectMenu-tab:focus,
 .SelectMenu-item:focus {
   outline: 0;


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->

The current `.SelectMenu-closeButton` `focus` state is nearly hidden, even to the keenest of users. An outline state was recommended by @edokoa. This PR removes the `outline` reset to let keyboard users see an outline around `.SelectMenu-closeButton` when focused.

#### Before

https://user-images.githubusercontent.com/2993937/186238357-70e8478b-dbbe-45bc-8b86-1bb670e9c45a.mp4

#### After

https://user-images.githubusercontent.com/2993937/186239879-3d2b3d37-3503-4153-bb38-e2ac78f6003c.mp4

### What approach did you choose and why?

<!-- Here you can explain your approach and reasoning in more detail. -->

Removing the outline as suggested by @langermank 🙏 

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

Nothing especially tricky! 😄 

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 