### PR TITLE
Add styling for `readonly`, fix AutoComplete inset focus background color

### DIFF
--- a/.changeset/brown-grapes-swim.md
+++ b/.changeset/brown-grapes-swim.md
@@ -3,4 +3,4 @@
 ---
 
 - Adding readonly styles
-- Fixing focus background color for inset field
+- Fixing focus background color for inset field 

--- a/docs/src/stories/rails-form-framework/TextInput.stories.jsx
+++ b/docs/src/stories/rails-form-framework/TextInput.stories.jsx
@@ -146,6 +146,13 @@ export default {
       table: {
         category: 'Input'
       }
+    },
+    readOnly: {
+      description: 'readonly styles',
+      control: {type: 'boolean'},
+      table: {
+        category: 'Input'
+      }
     }
   }
 }
@@ -173,7 +180,8 @@ export const InputTemplate = ({
   caption,
   validation,
   trailingActionDivider,
-  validationStatus
+  validationStatus,
+  readOnly
 }) => (
   <>
     <div className={clsx('FormControl', fullWidth && 'FormControl--fullWidth')}>
@@ -212,6 +220,7 @@ export const InputTemplate = ({
             placeholder={placeholder}
             id="input-id"
             type="text"
+            readonly={readOnly ? 'true' : 'false'}
             className={clsx(
               'FormControl-input',
               size && `${size}`,
@@ -253,6 +262,7 @@ export const InputTemplate = ({
           id="input-id"
           type="text"
           disabled={disabled ? 'true' : undefined}
+          readonly={readOnly ? 'true' : 'false'}
           className={clsx(
             'FormControl-input',
             size && `${size}`,
@@ -307,5 +317,6 @@ Playground.args = {
   visuallyHidden: false,
   validation: '',
   trailingActionDivider: false,
-  validationStatus: 0
+  validationStatus: 0,
+  readOnly: false
 }

--- a/docs/src/stories/rails-form-framework/TextInput.stories.jsx
+++ b/docs/src/stories/rails-form-framework/TextInput.stories.jsx
@@ -220,7 +220,7 @@ export const InputTemplate = ({
             placeholder={placeholder}
             id="input-id"
             type="text"
-            readonly={readOnly ? 'true' : 'false'}
+            readonly={readOnly ? 'true' : undefined}
             className={clsx(
               'FormControl-input',
               size && `${size}`,
@@ -262,7 +262,7 @@ export const InputTemplate = ({
           id="input-id"
           type="text"
           disabled={disabled ? 'true' : undefined}
-          readonly={readOnly ? 'true' : 'false'}
+          readonly={readOnly ? 'true' : undefined}
           className={clsx(
             'FormControl-input',
             size && `${size}`,

--- a/src/forms/FormControl.scss
+++ b/src/forms/FormControl.scss
@@ -173,10 +173,11 @@
   }
 
   &.FormControl-monospace {
-    font-family: var(
-      --primer-fontStack-monospace,
-      'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace'
-    );
+    font-family:
+      var(
+        --primer-fontStack-monospace,
+        'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace'
+      );
   }
 
   // validation states
@@ -288,10 +289,11 @@
 	*/
   &.FormControl-input-wrap--leadingVisual {
     .FormControl-input {
-      padding-inline-start: calc(
-        var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+      padding-inline-start:
+        calc(
+          var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
           var(--primer-control-medium-gap, 8px)
-      ); /* 32px */
+        ); /* 32px */
     }
   }
 
@@ -305,10 +307,11 @@
   // if trailingAction is present
   &.FormControl-input-wrap--trailingAction {
     .FormControl-input {
-      padding-inline-end: calc(
-        var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+      padding-inline-end:
+        calc(
+          var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
           var(--primer-control-medium-gap, 8px)
-      ); /* 32px */
+        ); /* 32px */
     }
 
     /*
@@ -323,10 +326,11 @@
     // can be refactored to has(.FormControl-input-trailingAction--divider)
     &.FormControl-input-wrap-trailingAction--divider {
       .FormControl-input {
-        padding-inline-end: calc(
-          var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+        padding-inline-end:
+          calc(
+            var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
             var(--primer-control-medium-gap, 8px) + var(--primer-borderWidth-thin, 1px)
-        ); /* 33px */
+          ); /* 33px */
       }
     }
   }
@@ -348,10 +352,11 @@
     */
     &.FormControl-input-wrap--trailingAction {
       .FormControl-input.FormControl-small {
-        padding-inline-end: calc(
-          var(--primer-control-small-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+        padding-inline-end:
+          calc(
+            var(--primer-control-small-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
             var(--primer-control-small-gap, 8px)
-        ); /* 28px */
+          ); /* 28px */
       }
 
       /*
@@ -364,10 +369,11 @@
 			*/
       &.FormControl-input-wrap-trailingAction--divider {
         .FormControl-input.FormControl-small {
-          padding-inline-end: calc(
-            var(--primer-control-small-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+          padding-inline-end:
+            calc(
+              var(--primer-control-small-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
               var(--primer-control-small-gap, 8px) + var(--primer-borderWidth-thin, 1px)
-          ); /* 29px */
+            ); /* 29px */
         }
       }
     }
@@ -397,10 +403,11 @@
     */
     &.FormControl-input-wrap--leadingVisual {
       .FormControl-input.FormControl-large {
-        padding-inline-start: calc(
-          var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
+        padding-inline-start:
+          calc(
+            var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
             var(--primer-control-large-gap, 8px)
-        ); /* 36px */
+          ); /* 36px */
       }
     }
 
@@ -413,10 +420,11 @@
     */
     &.FormControl-input-wrap--trailingAction {
       .FormControl-input.FormControl-large {
-        padding-inline-end: calc(
-          var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
+        padding-inline-end:
+          calc(
+            var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
             var(--primer-control-large-gap, 8px)
-        ); /* 36px */
+          ); /* 36px */
       }
 
       /*
@@ -428,10 +436,11 @@
 			*/
       &.FormControl-input-wrap-trailingAction--divider {
         .FormControl-input.FormControl-large {
-          padding-inline-end: calc(
-            var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
+          padding-inline-end:
+            calc(
+              var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
               var(--primer-control-large-gap, 8px) + var(--primer-borderWidth-thin, 1px)
-          ); /* 37px */
+            ); /* 37px */
         }
       }
     }

--- a/src/forms/FormControl.scss
+++ b/src/forms/FormControl.scss
@@ -134,8 +134,7 @@
   }
 
   &[readonly] {
-    background-color: var(--color-primer-fg-disabled);
-    border-color: var(--color-primer-fg-disabled);
+    background-color: var(--color-input-disabled-bg);
   }
 
   ::placeholder {

--- a/src/forms/FormControl.scss
+++ b/src/forms/FormControl.scss
@@ -133,6 +133,11 @@
     }
   }
 
+  &[readonly] {
+    background-color: var(--color-primer-fg-disabled);
+    border-color: var(--color-primer-fg-disabled);
+  }
+
   ::placeholder {
     color: var(--color-fg-subtle);
     opacity: 1;
@@ -164,11 +169,10 @@
   }
 
   &.FormControl-monospace {
-    font-family:
-      var(
-        --primer-fontStack-monospace,
-        'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace'
-      );
+    font-family: var(
+      --primer-fontStack-monospace,
+      'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace'
+    );
   }
 
   // validation states
@@ -280,11 +284,10 @@
 	*/
   &.FormControl-input-wrap--leadingVisual {
     .FormControl-input {
-      padding-inline-start:
-        calc(
-          var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+      padding-inline-start: calc(
+        var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
           var(--primer-control-medium-gap, 8px)
-        ); /* 32px */
+      ); /* 32px */
     }
   }
 
@@ -298,11 +301,10 @@
   // if trailingAction is present
   &.FormControl-input-wrap--trailingAction {
     .FormControl-input {
-      padding-inline-end:
-        calc(
-          var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+      padding-inline-end: calc(
+        var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
           var(--primer-control-medium-gap, 8px)
-        ); /* 32px */
+      ); /* 32px */
     }
 
     /*
@@ -317,11 +319,10 @@
     // can be refactored to has(.FormControl-input-trailingAction--divider)
     &.FormControl-input-wrap-trailingAction--divider {
       .FormControl-input {
-        padding-inline-end:
-          calc(
-            var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+        padding-inline-end: calc(
+          var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
             var(--primer-control-medium-gap, 8px) + var(--primer-borderWidth-thin, 1px)
-          ); /* 33px */
+        ); /* 33px */
       }
     }
   }
@@ -343,11 +344,10 @@
     */
     &.FormControl-input-wrap--trailingAction {
       .FormControl-input.FormControl-small {
-        padding-inline-end:
-          calc(
-            var(--primer-control-small-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+        padding-inline-end: calc(
+          var(--primer-control-small-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
             var(--primer-control-small-gap, 8px)
-          ); /* 28px */
+        ); /* 28px */
       }
 
       /*
@@ -360,11 +360,10 @@
 			*/
       &.FormControl-input-wrap-trailingAction--divider {
         .FormControl-input.FormControl-small {
-          padding-inline-end:
-            calc(
-              var(--primer-control-small-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+          padding-inline-end: calc(
+            var(--primer-control-small-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
               var(--primer-control-small-gap, 8px) + var(--primer-borderWidth-thin, 1px)
-            ); /* 29px */
+          ); /* 29px */
         }
       }
     }
@@ -394,11 +393,10 @@
     */
     &.FormControl-input-wrap--leadingVisual {
       .FormControl-input.FormControl-large {
-        padding-inline-start:
-          calc(
-            var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
+        padding-inline-start: calc(
+          var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
             var(--primer-control-large-gap, 8px)
-          ); /* 36px */
+        ); /* 36px */
       }
     }
 
@@ -411,11 +409,10 @@
     */
     &.FormControl-input-wrap--trailingAction {
       .FormControl-input.FormControl-large {
-        padding-inline-end:
-          calc(
-            var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
+        padding-inline-end: calc(
+          var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
             var(--primer-control-large-gap, 8px)
-          ); /* 36px */
+        ); /* 36px */
       }
 
       /*
@@ -427,11 +424,10 @@
 			*/
       &.FormControl-input-wrap-trailingAction--divider {
         .FormControl-input.FormControl-large {
-          padding-inline-end:
-            calc(
-              var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
+          padding-inline-end: calc(
+            var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
               var(--primer-control-large-gap, 8px) + var(--primer-borderWidth-thin, 1px)
-            ); /* 37px */
+          ); /* 37px */
         }
       }
     }

--- a/src/forms/FormControl.scss
+++ b/src/forms/FormControl.scss
@@ -165,14 +165,18 @@
 
   &.FormControl-inset {
     background-color: var(--color-canvas-inset);
+
+    &:focus-visible,
+    &:focus {
+      background-color: var(--color-canvas-default);
+    }
   }
 
   &.FormControl-monospace {
-    font-family:
-      var(
-        --primer-fontStack-monospace,
-        'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace'
-      );
+    font-family: var(
+      --primer-fontStack-monospace,
+      'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace'
+    );
   }
 
   // validation states
@@ -284,11 +288,10 @@
 	*/
   &.FormControl-input-wrap--leadingVisual {
     .FormControl-input {
-      padding-inline-start:
-        calc(
-          var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+      padding-inline-start: calc(
+        var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
           var(--primer-control-medium-gap, 8px)
-        ); /* 32px */
+      ); /* 32px */
     }
   }
 
@@ -302,11 +305,10 @@
   // if trailingAction is present
   &.FormControl-input-wrap--trailingAction {
     .FormControl-input {
-      padding-inline-end:
-        calc(
-          var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+      padding-inline-end: calc(
+        var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
           var(--primer-control-medium-gap, 8px)
-        ); /* 32px */
+      ); /* 32px */
     }
 
     /*
@@ -321,11 +323,10 @@
     // can be refactored to has(.FormControl-input-trailingAction--divider)
     &.FormControl-input-wrap-trailingAction--divider {
       .FormControl-input {
-        padding-inline-end:
-          calc(
-            var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+        padding-inline-end: calc(
+          var(--primer-control-medium-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
             var(--primer-control-medium-gap, 8px) + var(--primer-borderWidth-thin, 1px)
-          ); /* 33px */
+        ); /* 33px */
       }
     }
   }
@@ -347,11 +348,10 @@
     */
     &.FormControl-input-wrap--trailingAction {
       .FormControl-input.FormControl-small {
-        padding-inline-end:
-          calc(
-            var(--primer-control-small-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+        padding-inline-end: calc(
+          var(--primer-control-small-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
             var(--primer-control-small-gap, 8px)
-          ); /* 28px */
+        ); /* 28px */
       }
 
       /*
@@ -364,11 +364,10 @@
 			*/
       &.FormControl-input-wrap-trailingAction--divider {
         .FormControl-input.FormControl-small {
-          padding-inline-end:
-            calc(
-              var(--primer-control-small-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
+          padding-inline-end: calc(
+            var(--primer-control-small-paddingInline-condensed, 8px) + var(--base-size-16, 16px) +
               var(--primer-control-small-gap, 8px) + var(--primer-borderWidth-thin, 1px)
-            ); /* 29px */
+          ); /* 29px */
         }
       }
     }
@@ -398,11 +397,10 @@
     */
     &.FormControl-input-wrap--leadingVisual {
       .FormControl-input.FormControl-large {
-        padding-inline-start:
-          calc(
-            var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
+        padding-inline-start: calc(
+          var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
             var(--primer-control-large-gap, 8px)
-          ); /* 36px */
+        ); /* 36px */
       }
     }
 
@@ -415,11 +413,10 @@
     */
     &.FormControl-input-wrap--trailingAction {
       .FormControl-input.FormControl-large {
-        padding-inline-end:
-          calc(
-            var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
+        padding-inline-end: calc(
+          var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
             var(--primer-control-large-gap, 8px)
-          ); /* 36px */
+        ); /* 36px */
       }
 
       /*
@@ -431,11 +428,10 @@
 			*/
       &.FormControl-input-wrap-trailingAction--divider {
         .FormControl-input.FormControl-large {
-          padding-inline-end:
-            calc(
-              var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
+          padding-inline-end: calc(
+            var(--primer-control-large-paddingInline-normal, 12px) + var(--base-size-16, 16px) +
               var(--primer-control-large-gap, 8px) + var(--primer-borderWidth-thin, 1px)
-            ); /* 37px */
+          ); /* 37px */
         }
       }
     }


### PR DESCRIPTION
Co-authored-by: Eric Bailey <ericwbailey@users.noreply.github.com>

### What are you trying to accomplish?

This pull request addresses issues https://github.com/github/primer/issues/1230 and https://github.com/github/primer/issues/1208. It:

1. Adds styling for `input`, `select`, and `textarea` elements if a `readonly` attribute is applied to it.
2. Adds `readonly` support to Storybook.
3. Updates the background color of an AutoComplete inset input field to match the focus background color treatment of other input fields. 

### What approach did you choose and why?

#### `readonly`

We added a `readonly` attribute selector scoped to the`.FormControl-input,` `.FormControl-select`, and `.FormControl-textarea` selector grouping. This scopes it to only Primer-related inputs, matching the treatment approach we use for the `disabled` attribute.

We also added logic for Storybook to let it display the `readonly` attribute, if toggled.

#### AutoComplete focus background color

We added a `:focus-visible` and `:focus` selector grouping to `.FormControl-inset` to adjust the background color to use `--color-canvas-default` on the input's background, matching the treatment used on other Primer inputs.

### What should reviewers focus on?

Are the declarations applied to the most relevant selector set?

### Can these changes ship as is?

Yes.

- [x] Yes, this PR does not depend on additional changes. 🚢 
