### PR TITLE
fix: corrects instances of nested unordered lists in ActionList

### DIFF
--- a/docs/content/components/action-list.md
+++ b/docs/content/components/action-list.md
@@ -149,13 +149,15 @@ When using a section label for a group, give the `h3` an id to be referenced by 
         List group title
         </h3>
     </li>
-    <ul class="ActionList" aria-labelledby="group-id">
-        <li class="ActionList-item">
-            <a href="/" class="ActionList-content">
-                <span class="ActionList-item-label">Group Item</span>
-            </a>
-        </li>
-    </ul>
+    <li>
+      <ul class="ActionList" aria-labelledby="group-id">
+          <li class="ActionList-item">
+              <a href="/" class="ActionList-content">
+                  <span class="ActionList-item-label">Group Item</span>
+              </a>
+         </li>
+      </ul>
+    </li>
 </ul>
 ```
 
@@ -168,13 +170,15 @@ When using a section label for a group, give the `h3` an id to be referenced by 
         List group title
         </h3>
     </li>
-    <ul class="ActionList" aria-labelledby="group-id">
-        <li class="ActionList-item">
-            <a href="/" class="ActionList-content">
-                <span class="ActionList-item-label">Group Item</span>
-            </a>
-        </li>
-    </ul>
+    <li>
+      <ul class="ActionList" aria-labelledby="group-id">
+          <li class="ActionList-item">
+              <a href="/" class="ActionList-content">
+                  <span class="ActionList-item-label">Group Item</span>
+              </a>
+          </li>
+      </ul>
+    </li>
 </ul>
 ```
 


### PR DESCRIPTION
Hi team --

I'm opening this as a conversation starter. After a discussion regarding a [Deque linting error around the markup `ul.ul`](https://github.slack.com/archives/C0FSWLQ0Y/p1661502437269329) being a violation of permissible children for an `ul`, we've determined that the proper syntax is instead `ul.li.ul`.

I can think of a multi-pronged approach here:
- Change the docs to guide people
- Add linting to prevent providing `ul.ul` to the component (if that's the API? I'm unfamiliar)
- And, anything else we need to do as actionable after the conversation. 

cc @khiga8 @inkblotty I'm not sure who should own this, hence the suggestion arriving at the code instead of as an issue somewhere. 

### What are you trying to accomplish?

An accessible-by-default ActionList component that's easy to use!

### What approach did you choose and why?

<!-- Here you can explain your approach and reasoning in more detail. -->

TBD with the Primer team. 

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [ ] Yes, this PR does not depend on additional changes. 🚢 
