### PR TITLE
ActionList hide the first divider if there's hidden items in front of it.

### DIFF
--- a/.changeset/rich-boxes-crash.md
+++ b/.changeset/rich-boxes-crash.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+ActionList hide the first divider if there's hidden items in front of it.

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -113,6 +113,11 @@
     }
   }
 
+  // Make sure that the first visible item isn't a divider
+  &[hidden] + .ActionList-sectionDivider {
+    display: none;
+  }
+
   // Autocomplete [aria-selected] items
 
   &[aria-selected='true'] {


### PR DESCRIPTION
### What are you trying to accomplish?

| Before | After |
| :- | :- | 
| <img alt="image" src="https://user-images.githubusercontent.com/378023/187373984-f19012d3-5ba1-4679-80fb-72889d49f464.png" > | <img alt="image" src="https://user-images.githubusercontent.com/54012/187510604-f60ef125-81f5-4a72-9ec6-e7a1941941cc.png"> |

### What approach did you choose and why?

I'm using if there's a `[hidden]` ActionList-item, followed by a sectionDivider, then hide it.

### Can these changes ship as is?

I believe so, but I'm not sure if this change might effect other uses of ActionList?

- [ ] Yes, this PR does not depend on additional changes. 🚢 
