### PR TITLE
479-user-pics-misaligned-in-issues-assignment-view

### DIFF
--- a/.changeset/smooth-crabs-protect.md
+++ b/.changeset/smooth-crabs-protect.md
@@ -2,5 +2,4 @@
 "@primer/css": patch
 ---
 
-479-user-pics-misaligned-in-issues-assignment-view
 This border change was made to ensure that assignee avatars would stack next to one another correctly.

--- a/.changeset/smooth-crabs-protect.md
+++ b/.changeset/smooth-crabs-protect.md
@@ -1,0 +1,6 @@
+---
+"@primer/css": patch
+---
+
+479-user-pics-misaligned-in-issues-assignment-view
+This border change was made to ensure that assignee avatars would stack next to one another correctly.

--- a/src/avatars/avatar-stack.scss
+++ b/src/avatars/avatar-stack.scss
@@ -119,7 +119,7 @@
       margin-left: 3px;
     }
 
-    &:last-child {
+    &:not(:last-child) {
       border-left: 0;
     }
   }

--- a/src/avatars/avatar-stack.scss
+++ b/src/avatars/avatar-stack.scss
@@ -119,7 +119,7 @@
       margin-left: 3px;
     }
 
-    &:not(:last-child) {
+    .avatar:not(:last-child) {
       border-left: 0;
     }
   }

--- a/src/avatars/avatar-stack.scss
+++ b/src/avatars/avatar-stack.scss
@@ -56,7 +56,7 @@
     // stylelint-enable selector-max-type
 
     // Account for 4+ avatars
-    &:nth-child(n+4) {
+    &:nth-child(n + 4) {
       display: none;
       opacity: 0;
     }
@@ -68,7 +68,7 @@
       margin-right: 3px;
     }
 
-    .avatar:nth-child(n+4) {
+    .avatar:nth-child(n + 4) {
       display: flex;
       opacity: 1;
     }
@@ -117,6 +117,10 @@
       margin-right: 0;
       // stylelint-disable-next-line primer/spacing
       margin-left: 3px;
+    }
+
+    &:last-child {
+      border-left: 0;
     }
   }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Looking to fix the user pics misalignment issue found in the assignments view.
[Issue found here](https://github.com/github/primer/issues/479).

![image](https://user-images.githubusercontent.com/31220082/188942374-7502a1ee-37a3-4d32-bdd9-9c6e0307b71d.png)

Now it should look like this

![image](https://user-images.githubusercontent.com/31220082/188942213-1823ef56-9d7c-4b71-bfa2-25d27498c292.png)

### What approach did you choose and why?

I am following the approach provided in the issue before testing the new canary in dotcom

### What should reviewers focus on?

The reviewer should focus on the spacing of the user profile images in the assignment view.

### Can these changes ship as is?

- [X] Yes, this PR does not depend on additional changes. 🚢 
