### PR TITLE
Make sure to apply backdrops only to one Overlay

### DIFF
--- a/.changeset/stale-drinks-arrive.md
+++ b/.changeset/stale-drinks-arrive.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Make sure to apply backdrops only to the top level Overlay

--- a/.changeset/stale-drinks-arrive.md
+++ b/.changeset/stale-drinks-arrive.md
@@ -2,4 +2,5 @@
 "@primer/css": patch
 ---
 
-Make sure to apply backdrops only to the top level Overlay
+Increase specificy for Overlay styles as they relate to the backdrop and positioning options
+- If a Dialog opens a second Dialog, each Dialog properties should be contained to its own scope

--- a/src/overlay/overlay.scss
+++ b/src/overlay/overlay.scss
@@ -345,7 +345,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: center;
     justify-content: left;
 
-    .Overlay#{$responsiveVariant} {
+    & > .Overlay#{$responsiveVariant} {
       height: 100vh;
       max-height: unset;
       border-radius: $primer-borderRadius-large;
@@ -362,7 +362,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: center;
     justify-content: right;
 
-    .Overlay#{$responsiveVariant} {
+    & > .Overlay#{$responsiveVariant} {
       height: 100vh;
       max-height: unset;
       border-radius: $primer-borderRadius-large;
@@ -379,7 +379,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: end;
     justify-content: center;
 
-    .Overlay#{$responsiveVariant} {
+    & > .Overlay#{$responsiveVariant} {
       width: 100vw;
       height: auto;
       max-height: calc(100vh - 2rem);
@@ -397,7 +397,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: start;
     justify-content: center;
 
-    .Overlay#{$responsiveVariant} {
+    & > .Overlay#{$responsiveVariant} {
       border-radius: $primer-borderRadius-large;
       border-top-left-radius: 0;
       border-top-right-radius: 0;

--- a/src/overlay/overlay.scss
+++ b/src/overlay/overlay.scss
@@ -345,7 +345,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: center;
     justify-content: left;
 
-    & > .Overlay#{$responsiveVariant} {
+    > .Overlay#{$responsiveVariant} {
       height: 100vh;
       max-height: unset;
       border-radius: $primer-borderRadius-large;
@@ -362,7 +362,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: center;
     justify-content: right;
 
-    & > .Overlay#{$responsiveVariant} {
+    > .Overlay#{$responsiveVariant} {
       height: 100vh;
       max-height: unset;
       border-radius: $primer-borderRadius-large;
@@ -379,7 +379,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: end;
     justify-content: center;
 
-    & > .Overlay#{$responsiveVariant} {
+    > .Overlay#{$responsiveVariant} {
       width: 100vw;
       height: auto;
       max-height: calc(100vh - 2rem);
@@ -397,7 +397,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: start;
     justify-content: center;
 
-    & > .Overlay#{$responsiveVariant} {
+    > .Overlay#{$responsiveVariant} {
       border-radius: $primer-borderRadius-large;
       border-top-left-radius: 0;
       border-top-right-radius: 0;


### PR DESCRIPTION
### What are you trying to accomplish?

I want to make sure backdrop styles are only applied to the correct Overlay. Right now, nested Overlays will inherit their parent overlay styles which makes it impossible to style them correctly.

### What approach did you choose and why?

I made sure to use the direct child selector to select the Overlay that a given backdrop should apply to.

### What should reviewers focus on?

Is this correct? I just did this quickly and without testing in the GitHub editor.

### Can these changes ship as is?

- [x] This PR does not depend on additional changes. 🚢 
