### PR TITLE
Fixing ActionList Item hover focus style

### DIFF
--- a/.changeset/plenty-papayas-reflect.md
+++ b/.changeset/plenty-papayas-reflect.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fixing ActionList Item hover focus style

--- a/src/actionlist/action-list-item.scss
+++ b/src/actionlist/action-list-item.scss
@@ -32,7 +32,7 @@
         cursor: pointer;
         background-color: var(--color-action-list-item-default-hover-bg);
 
-        &:not(.ActionList-item--navActive) {
+        &:not(.ActionList-item--navActive):not(:focus-visible) {
           // Support for "Windows high contrast mode"
           outline: $border-style $border-width transparent;
           outline-offset: -$border-width;


### PR DESCRIPTION
### What are you trying to accomplish?

Show the focus ring around focused items with subitems while they are hovered. Fixes https://github.com/primer/css/issues/2254

<img width="346" alt="Screen Shot 2022-09-14 at 10 50 39 PM" src="https://user-images.githubusercontent.com/955442/190302511-f6e06867-e1ca-41e3-9597-b97a241704c7.png">

### What approach did you choose and why?

Adding a not:(:focus-visible) to the rule that overrides the outline


### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
