### PR TITLE
Vertically center close button when header height is increased

### DIFF
--- a/.changeset/funny-ads-cheer.md
+++ b/.changeset/funny-ads-cheer.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Vertically center close button when header height is increased

--- a/src/overlay/overlay.scss
+++ b/src/overlay/overlay.scss
@@ -193,6 +193,7 @@ $primer-borderRadius-large: 0.75rem;
       display: flex;
       flex-direction: row;
       gap: $spacer-2;
+      align-self: center;
     }
 
     .Overlay-titleWrap {


### PR DESCRIPTION
### What are you trying to accomplish?

I want the close button to be veritcally centered when the header height is increased.

### What approach did you choose and why?

I put a `align-self: center` since the parent is a flex container to verically center the close button.
### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
