### PR TITLE
Remove scrollbar CSS property from Overlay

### DIFF
--- a/.changeset/cool-ligers-yell.md
+++ b/.changeset/cool-ligers-yell.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Remove scrollbar CSS property from Overlay

--- a/src/overlay/overlay.scss
+++ b/src/overlay/overlay.scss
@@ -162,7 +162,7 @@ $primer-borderRadius-large: 0.75rem;
     // stylelint-disable-next-line primer/box-shadow
     box-shadow: inset 0 #{-$border-width} var(--color-border-default);
 
-    + .Overlay-body {
+    +.Overlay-body {
       padding-top: $spacer-3;
     }
   }
@@ -224,7 +224,6 @@ $primer-borderRadius-large: 0.75rem;
   padding-top: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  scrollbar-gutter: stable;
   font-size: $body-font-size;
   flex-grow: 1;
 
@@ -345,7 +344,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: center;
     justify-content: left;
 
-    > .Overlay#{$responsiveVariant} {
+    >.Overlay#{$responsiveVariant} {
       height: 100vh;
       max-height: unset;
       border-radius: $primer-borderRadius-large;
@@ -362,7 +361,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: center;
     justify-content: right;
 
-    > .Overlay#{$responsiveVariant} {
+    >.Overlay#{$responsiveVariant} {
       height: 100vh;
       max-height: unset;
       border-radius: $primer-borderRadius-large;
@@ -379,7 +378,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: end;
     justify-content: center;
 
-    > .Overlay#{$responsiveVariant} {
+    >.Overlay#{$responsiveVariant} {
       width: 100vw;
       height: auto;
       max-height: calc(100vh - 2rem);
@@ -397,7 +396,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: start;
     justify-content: center;
 
-    > .Overlay#{$responsiveVariant} {
+    >.Overlay#{$responsiveVariant} {
       border-radius: $primer-borderRadius-large;
       border-top-left-radius: 0;
       border-top-right-radius: 0;

--- a/src/overlay/overlay.scss
+++ b/src/overlay/overlay.scss
@@ -162,7 +162,7 @@ $primer-borderRadius-large: 0.75rem;
     // stylelint-disable-next-line primer/box-shadow
     box-shadow: inset 0 #{-$border-width} var(--color-border-default);
 
-    +.Overlay-body {
+    + .Overlay-body {
       padding-top: $spacer-3;
     }
   }
@@ -344,7 +344,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: center;
     justify-content: left;
 
-    >.Overlay#{$responsiveVariant} {
+    > .Overlay#{$responsiveVariant} {
       height: 100vh;
       max-height: unset;
       border-radius: $primer-borderRadius-large;
@@ -361,7 +361,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: center;
     justify-content: right;
 
-    >.Overlay#{$responsiveVariant} {
+    > .Overlay#{$responsiveVariant} {
       height: 100vh;
       max-height: unset;
       border-radius: $primer-borderRadius-large;
@@ -378,7 +378,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: end;
     justify-content: center;
 
-    >.Overlay#{$responsiveVariant} {
+    > .Overlay#{$responsiveVariant} {
       width: 100vw;
       height: auto;
       max-height: calc(100vh - 2rem);
@@ -396,7 +396,7 @@ $primer-borderRadius-large: 0.75rem;
     align-items: start;
     justify-content: center;
 
-    >.Overlay#{$responsiveVariant} {
+    > .Overlay#{$responsiveVariant} {
       border-radius: $primer-borderRadius-large;
       border-top-left-radius: 0;
       border-top-right-radius: 0;


### PR DESCRIPTION
### What are you trying to accomplish?

Closes https://github.com/github/primer/issues/1311

### What approach did you choose and why?

This CSS property is a nice feature for Dialogs, but in the context of an ActionMenu presents extra white-space where scrolling is a rare occurrence. We should consider adding this back for Dialog specific CSS.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
