### PR TITLE
Set FormControl color

### DIFF
--- a/.changeset/quick-seas-tickle.md
+++ b/.changeset/quick-seas-tickle.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Set FormControl color

--- a/src/forms/FormControl.scss
+++ b/src/forms/FormControl.scss
@@ -48,6 +48,7 @@
 
 // shared among all form control components (input, select, textarea, checkbox, radio)
 @mixin Field {
+  color: var(--color-fg-default);
   background-color: var(--color-canvas-default);
   border: solid var(--primer-borderWidth-thin, 1px) var(--color-border-default);
 


### PR DESCRIPTION
### What are you trying to accomplish?

This came up in https://github.com/github/primer/discussions/1313#discussioncomment-3748057. It seems that form controls don't inherit the `color` and use the browser default which is `#000000`. This PR overrides the browser default with `--color-fg-default`.

### What approach did you choose and why?

```scss
@mixin Field {
  color: var(--color-fg-default);
```

### What should reviewers focus on?

Instead of adding the color to the `Field` mixin, we could also add it to: https://github.com/primer/css/blob/b087282e5040a53a48b707bd94151a3b896659db/src/forms/FormControl.scss#L116-L118

But I thought might be good to keep fg and bg color in the same place.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
