### PR TITLE
Fix Overlay easing animation

### DIFF
--- a/.changeset/empty-hornets-kick.md
+++ b/.changeset/empty-hornets-kick.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fix Overlay easing animation

--- a/src/overlay/overlay.scss
+++ b/src/overlay/overlay.scss
@@ -352,7 +352,7 @@ $primer-borderRadius-large: 0.75rem;
       border-bottom-left-radius: 0;
 
       @media screen and (prefers-reduced-motion: no-preference) {
-        animation: 160ms cubic-bezier(0.32, 0, 0.67, 0) 0s 1 normal none running Overlay--motion-slideInRight;
+        animation: 250ms cubic-bezier(0.33, 1, 0.68, 1) 0s 1 normal none running Overlay--motion-slideInRight;
       }
     }
   }
@@ -369,7 +369,7 @@ $primer-borderRadius-large: 0.75rem;
       border-bottom-right-radius: 0;
 
       @media screen and (prefers-reduced-motion: no-preference) {
-        animation: 160ms cubic-bezier(0.32, 0, 0.67, 0) 0s 1 normal none running Overlay--motion-slideInLeft;
+        animation: 250ms cubic-bezier(0.33, 1, 0.68, 1) 0s 1 normal none running Overlay--motion-slideInLeft;
       }
     }
   }
@@ -387,7 +387,7 @@ $primer-borderRadius-large: 0.75rem;
       border-bottom-left-radius: 0;
 
       @media screen and (prefers-reduced-motion: no-preference) {
-        animation: 160ms cubic-bezier(0.32, 0, 0.67, 0) 0s 1 normal none running Overlay--motion-slideUp;
+        animation: 250ms cubic-bezier(0.33, 1, 0.68, 1) 0s 1 normal none running Overlay--motion-slideUp;
       }
     }
   }
@@ -400,6 +400,10 @@ $primer-borderRadius-large: 0.75rem;
       border-radius: $primer-borderRadius-large;
       border-top-left-radius: 0;
       border-top-right-radius: 0;
+
+      @media screen and (prefers-reduced-motion: no-preference) {
+        animation: 250ms cubic-bezier(0.33, 1, 0.68, 1) 0s 1 normal none running Overlay--motion-slideDown;
+      }
     }
   }
 }
@@ -452,6 +456,12 @@ $primer-borderRadius-large: 0.75rem;
 
   .Overlay-backdrop--full-whenNarrow {
     @include Overlay-backdrop--full;
+  }
+}
+
+@keyframes Overlay--motion-slideDown {
+  from {
+    transform: translateY(-100%);
   }
 }
 


### PR DESCRIPTION
Slide-in overlays should have an `ease-out` animation. This PR fixes this, using values from an animation design token proposal: https://github.com/github/primer/issues/1026 (link only available for hubbers)

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [ ] Yes, this PR does not depend on additional changes. 🚢 
