### PR TITLE
Fix CSS block formatting

### DIFF
--- a/docs/content/utilities/flexbox.md
+++ b/docs/content/utilities/flexbox.md
@@ -199,7 +199,7 @@ Use these classes to distribute space between and around flex items along the **
 
 ### CSS
 
-```CSS
+```css
 .flex-justify-start    { justify-content: flex-start; }
 .flex-justify-end      { justify-content: flex-end; }
 .flex-justify-center   { justify-content: center; }


### PR DESCRIPTION
### What are you trying to accomplish?

Before:
<img width="531" alt="CleanShot 2022-10-12 at 00 06 41@2x" src="https://user-images.githubusercontent.com/809707/195208405-43be423b-3cb3-4339-ab67-b84f481f9b77.png">

After:
<img width="531" alt="CleanShot 2022-10-12 at 00 07 06@2x" src="https://user-images.githubusercontent.com/809707/195208419-32bd95a3-68d9-475f-9c9d-ffb929cfa4d1.png">

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
