### PR TITLE
Update tooltips.md to point to PVC Tooltip docs

### DIFF
--- a/docs/content/components/tooltips.md
+++ b/docs/content/components/tooltips.md
@@ -7,7 +7,7 @@ bundle: tooltips
 ---
 
 <Note>
-  Please note that the `.tooltipped` component is **deprecated**.
+  Please note that the `.tooltipped` component is **deprecated**. We recommend using the [Tooltip component](https://primer.style/view-components/components/alpha/tooltip) instead.
 </Note>
 
 Add tooltips built entirely in CSS to appropriate elements.


### PR DESCRIPTION
### What are you trying to accomplish?

From [this thread](https://github.slack.com/archives/CSGAVNZ19/p1665585252456199), the discoverability of the Tooltip component in PVC was harder than it could be.

### What approach did you choose and why?

Just adding a link to the replacement for the deprecated tooltips.

### What should reviewers focus on?

How's my verbiage?

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
