### PR TITLE
Remove `z-index: 1` from Overlay header and footer

### DIFF
--- a/src/overlay/overlay.scss
+++ b/src/overlay/overlay.scss
@@ -153,7 +153,6 @@ $primer-borderRadius-large: 0.75rem;
 }
 
 .Overlay-header {
-  z-index: 1;
   display: flex;
   flex-direction: column;
 
@@ -239,7 +238,6 @@ $primer-borderRadius-large: 0.75rem;
 
 // generic footer slot
 .Overlay-footer {
-  z-index: 1;
   display: flex;
   padding: 0 $spacer-3 $spacer-3 $spacer-3;
   flex-direction: row;


### PR DESCRIPTION
### What are you trying to accomplish?

I'm trying to fix https://github.com/github/platform-ux/issues/1085.

### What approach did you choose and why?

 I'm not sure why but removing the `z-index` fixes the issue and has no other observible effect on the component.

### What should reviewers focus on?

Does this break anything? How can I test it?

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 
