### PR TITLE
Don't apply flash* classes to banners

### DIFF
--- a/.changeset/dirty-lemons-flash.md
+++ b/.changeset/dirty-lemons-flash.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Don't apply flash\* classes to banners

--- a/src/alerts/flash.scss
+++ b/src/alerts/flash.scss
@@ -86,7 +86,7 @@
   }
 }
 
-.flash-warn:not(.Banner--warning) {
+.flash-warn:not(.Banner) {
   color: var(--color-fg-default);
   background-image: linear-gradient(var(--color-attention-subtle), var(--color-attention-subtle));
   border-color: var(--color-attention-muted);
@@ -96,7 +96,7 @@
   }
 }
 
-.flash-error:not(.Banner--error) {
+.flash-error:not(.Banner) {
   color: var(--color-fg-default);
   background-image: linear-gradient(var(--color-danger-subtle), var(--color-danger-subtle));
   border-color: var(--color-danger-muted);
@@ -106,7 +106,7 @@
   }
 }
 
-.flash-success:not(.Banner--success) {
+.flash-success:not(.Banner) {
   color: var(--color-fg-default);
   background-image: linear-gradient(var(--color-success-subtle), var(--color-success-subtle));
   border-color: var(--color-success-muted);
@@ -120,7 +120,7 @@
 // Layout variations
 //
 
-.flash-full:not(.Banner--full) {
+.flash-full:not(.Banner) {
   // stylelint-disable-next-line primer/spacing
   margin-top: -1px;
   border-width: $border-width 0;

--- a/src/alerts/flash.scss
+++ b/src/alerts/flash.scss
@@ -1,7 +1,7 @@
 // stylelint-disable selector-max-type, no-duplicate-selectors
 
 // Default flash
-.flash {
+.flash:not(.Banner) {
   position: relative;
   // stylelint-disable-next-line primer/spacing
   padding: 20px $spacer-3;
@@ -76,7 +76,7 @@
 // Color variations
 //
 
-.flash {
+.flash:not(.Banner) {
   color: var(--color-fg-default);
   background-image: linear-gradient(var(--color-accent-subtle), var(--color-accent-subtle));
   border-color: var(--color-accent-muted);
@@ -86,7 +86,7 @@
   }
 }
 
-.flash-warn {
+.flash-warn:not(.Banner--warning) {
   color: var(--color-fg-default);
   background-image: linear-gradient(var(--color-attention-subtle), var(--color-attention-subtle));
   border-color: var(--color-attention-muted);
@@ -96,7 +96,7 @@
   }
 }
 
-.flash-error {
+.flash-error:not(.Banner--error) {
   color: var(--color-fg-default);
   background-image: linear-gradient(var(--color-danger-subtle), var(--color-danger-subtle));
   border-color: var(--color-danger-muted);
@@ -106,7 +106,7 @@
   }
 }
 
-.flash-success {
+.flash-success:not(.Banner--success) {
   color: var(--color-fg-default);
   background-image: linear-gradient(var(--color-success-subtle), var(--color-success-subtle));
   border-color: var(--color-success-muted);
@@ -120,7 +120,7 @@
 // Layout variations
 //
 
-.flash-full {
+.flash-full:not(.Banner--full) {
   // stylelint-disable-next-line primer/spacing
   margin-top: -1px;
   border-width: $border-width 0;


### PR DESCRIPTION
### What are you trying to accomplish?

We've run into some issues attempting to migrate usages of `Primer::Beta::Flash` to `Primer::Beta::Banner`, namely that existing CSS and JS in dotcom select on the `flash` class and its friends. This has made it really difficult to migrate to the `Banner` component because the `flash` class is no longer used.

### What approach did you choose and why?

To ease the transition, we propose adding these legacy class names to banner elements while updating primer/css to only apply flash styles to elements that are not also banner elements.

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 