### PR TITLE
Add additional :not selectors for flash classes

### DIFF
--- a/.changeset/tame-monkeys-march.md
+++ b/.changeset/tame-monkeys-march.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Add additional :not selectors for flash classes

--- a/src/alerts/flash.scss
+++ b/src/alerts/flash.scss
@@ -25,7 +25,7 @@
 }
 
 // Close button
-.flash-close {
+.flash-close:not(.Banner-close) {
   float: right;
   padding: $spacer-3;
   margin: -$spacer-3;
@@ -51,7 +51,7 @@
 }
 
 // Action button
-.flash-action {
+.flash-action:not(.Banner-actions) {
   float: right;
   // stylelint-disable-next-line primer/spacing
   margin-top: -3px;


### PR DESCRIPTION
### What are you trying to accomplish?

The specificity of the `.flash` class recently changed because I added `:not(.Banner)` to a bunch of them in [this PR](https://github.com/primer/css/pull/2289). That seems to be working well in dotcom, but @dylanatsmith noticed a small visual regression causing the dismiss button to have extra `margin-right`:

![image](https://user-images.githubusercontent.com/575280/199081638-ce06d896-0300-4fa9-ba04-3fd1e18d562f.png)

### What approach did you choose and why?

The problem appears to be related to the increased specificity of the `.flash` class and its friends. I believe we should also apply a few `:not` pseudo classes to `flash-close` and `flash-actions`, so that's what this PR does. Doing so should fix both the specificity issue and double-styling banners.

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 
