### PR TITLE
Add `Noto Sans` to the body font stack

### DIFF
--- a/.changeset/lucky-emus-teach.md
+++ b/.changeset/lucky-emus-teach.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Add `Noto Sans` to the body font stack

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -32,7 +32,7 @@ $lh-condensed: 1.25 !default;
 $lh-default: 1.5 !default;
 
 // Font stacks
-$body-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji' !default;
+$body-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji' !default;
 
 // Monospace font stack
 // Note: SFMono-Regular needs to come before SF Mono to fix an older version of the font in Chrome


### PR DESCRIPTION
### What are you trying to accomplish?

This adds `Noto Sans` to the `$body-font` stack. I think the break down will be something like:

- `-apple-system` for Safari + Firefox on macOS
- `BlinkMacSystemFont` for Chrome on macOS
- `Segoe UI` for Windows
- `Noto Sans` for Linux ✨ new ✨
- `Helvetica` as legacy fallback
- `Arial` as legacy fallback
- `sans-serif` as a system fallback
- `Apple Color Emoji` + `Segoe UI Emoji` for emojis

### What approach did you choose and why?

Adding `Noto Sans` should improve alignment issues on Linux. See https://github.com/primer/css/issues/1209.

### What should reviewers focus on?

If anyone is on Linux and wants to test the new font stack, you could use the following in DevTools:

```css
font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
```

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢
- [ ] If we move forward with this PR, we should also update [Primitives](https://github.com/primer/primitives/blob/56108a94c612f30d2d46208bf03c613cce0924bc/tokens/functional/typography/typography.json#L5)
