### PR TITLE
Deprecate form validation docs

### DIFF
--- a/docs/content/components/forms.md
+++ b/docs/content/components/forms.md
@@ -232,7 +232,11 @@ Use the `.select-sm` class to resize both default and custom `<select>`s to matc
 </form>
 ```
 
-## Form group validation
+## Form group validation (deprecated)
+
+<Note>
+  These form validation styles are deprecated. Please use the <a href="https://primer.style/view-components/components/alpha/textfield#with-a-validation-message">TextField</a> ViewComponent instead or refer to the <a href="https://primer.style/design/ui-patterns/forms#validation">design guidelines</a>.
+</Note>
 
 Convey success, errors and warnings for form groups. For github.com consider using the [`<auto-check>`](https://github.github.io/web-systems-documentation/#custom-elements-auto-check-md) element to perform server-side validation on an input.
 


### PR DESCRIPTION
### What are you trying to accomplish?

This came up in [Slack](https://github.slack.com/archives/CPA865D9S/p1667319836889429). The [form validation docs](https://primer.style/css/components/forms#form-group-validation) are outdated and shouldn't be used anymore.

### What approach did you choose and why?

I used a `<Note>` to point to PVC and the design guidelines.

![Screen Shot 2022-11-02 at 14 25 17](https://user-images.githubusercontent.com/378023/199406345-aa06551d-3850-42a7-9775-471e8c089967.png)

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
