### PR TITLE
Convert typography to use `rem` units with `px` fallbacks

### DIFF
--- a/.changeset/nervous-experts-camp.md
+++ b/.changeset/nervous-experts-camp.md
@@ -2,4 +2,4 @@
 "@primer/css": minor
 ---
 
-Convert typography to use `rem` units with `px` fallbacks
+Convert typography to use `rem` units with `px` fallbacks 

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -1,4 +1,4 @@
-// stylelint-disable selector-max-type, selector-no-qualifying-type
+// stylelint-disable selector-max-type, selector-no-qualifying-type, primer/typography
 * {
   box-sizing: border-box;
 }

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -82,9 +82,8 @@ details {
   }
 
   &:not([open]) {
-
     // Set details content hidden by default for browsers that don't do this
-    >*:not(summary) {
+    > *:not(summary) {
       display: none !important;
     }
   }
@@ -97,7 +96,6 @@ button,
 [role='button'],
 input[type='radio'],
 input[type='checkbox'] {
-
   // fallback :focus state
   &:focus {
     @include focusOutline;
@@ -117,7 +115,6 @@ input[type='checkbox'] {
 a:not([class]),
 input[type='radio'],
 input[type='checkbox'] {
-
   &:focus,
   &:focus-visible {
     outline-offset: 0;
@@ -131,7 +128,6 @@ input[type='checkbox'] {
 
 // Windows High Contrast mode
 @media (forced-colors: active) {
-
   *:focus,
   *:focus-visible {
     outline: solid 1px transparent;
@@ -140,7 +136,6 @@ input[type='checkbox'] {
   input:not([type='radio'], [type='checkbox']),
   textarea,
   select {
-
     &:focus,
     &:focus-visible {
       outline-offset: 2px;

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -14,7 +14,7 @@ button {
 
 body {
   font-family: $body-font;
-  font-size: $body-font-size;
+  font-size: var(--body-font-size, $body-font-size);
   line-height: $body-line-height;
   color: var(--color-fg-default);
   background-color: var(--color-canvas-default);
@@ -82,8 +82,9 @@ details {
   }
 
   &:not([open]) {
+
     // Set details content hidden by default for browsers that don't do this
-    > *:not(summary) {
+    >*:not(summary) {
       display: none !important;
     }
   }
@@ -96,6 +97,7 @@ button,
 [role='button'],
 input[type='radio'],
 input[type='checkbox'] {
+
   // fallback :focus state
   &:focus {
     @include focusOutline;
@@ -115,6 +117,7 @@ input[type='checkbox'] {
 a:not([class]),
 input[type='radio'],
 input[type='checkbox'] {
+
   &:focus,
   &:focus-visible {
     outline-offset: 0;
@@ -128,6 +131,7 @@ input[type='checkbox'] {
 
 // Windows High Contrast mode
 @media (forced-colors: active) {
+
   *:focus,
   *:focus-visible {
     outline: solid 1px transparent;
@@ -136,6 +140,7 @@ input[type='checkbox'] {
   input:not([type='radio'], [type='checkbox']),
   textarea,
   select {
+
     &:focus,
     &:focus-visible {
       outline-offset: 2px;

--- a/src/primitives/index.scss
+++ b/src/primitives/index.scss
@@ -7,3 +7,27 @@
 @import '@primer/primitives/tokens-v2-private/css/tokens/functional/size/size.css';
 @import '@primer/primitives/tokens-v2-private/css/tokens/functional/size/viewport.css';
 @import '@primer/primitives/tokens-v2-private/css/tokens/functional/typography/typography.css';
+
+// Temporary typography vars in rem units variables
+:root {
+  // Heading sizes - mobile
+  // h4-h6 remain the same size on both mobile & desktop
+  --h00-size-mobile: 2.5rem;
+  --h0-size-mobile: 2rem;
+  --h1-size-mobile: 1.625rem;
+  --h2-size-mobile: 1.375rem;
+  --h3-size-mobile: 1.125rem;
+
+  // Heading sizes - desktop
+  --h00-size: 3rem;
+  --h0-size: 2.5rem;
+  --h1-size: 2rem;
+  --h2-size: 1.5rem;
+  --h3-size: 1.25rem;
+  --h4-size: 1rem;
+  --h5-size: 0.875rem;
+  --h6-size: 0.75rem;
+
+  --body-font-size: 0.875rem;
+  --font-size-small: 0.75rem;
+}

--- a/src/primitives/index.scss
+++ b/src/primitives/index.scss
@@ -7,27 +7,4 @@
 @import '@primer/primitives/tokens-v2-private/css/tokens/functional/size/size.css';
 @import '@primer/primitives/tokens-v2-private/css/tokens/functional/size/viewport.css';
 @import '@primer/primitives/tokens-v2-private/css/tokens/functional/typography/typography.css';
-
-// Temporary typography vars in rem units variables
-:root {
-  // Heading sizes - mobile
-  // h4-h6 remain the same size on both mobile & desktop
-  --h00-size-mobile: 2.5rem;
-  --h0-size-mobile: 2rem;
-  --h1-size-mobile: 1.625rem;
-  --h2-size-mobile: 1.375rem;
-  --h3-size-mobile: 1.125rem;
-
-  // Heading sizes - desktop
-  --h00-size: 3rem;
-  --h0-size: 2.5rem;
-  --h1-size: 2rem;
-  --h2-size: 1.5rem;
-  --h3-size: 1.25rem;
-  --h4-size: 1rem;
-  --h5-size: 0.875rem;
-  --h6-size: 0.75rem;
-
-  --body-font-size: 0.875rem;
-  --font-size-small: 0.75rem;
-}
+@import './temp-typography-tokens.scss';

--- a/src/primitives/temp-typography-tokens.scss
+++ b/src/primitives/temp-typography-tokens.scss
@@ -17,7 +17,6 @@
   --h4-size: 1rem;
   --h5-size: 0.875rem;
   --h6-size: 0.75rem;
-
   --body-font-size: 0.875rem;
   --font-size-small: 0.75rem;
 }

--- a/src/primitives/temp-typography-tokens.scss
+++ b/src/primitives/temp-typography-tokens.scss
@@ -1,0 +1,23 @@
+// Temporary typography vars in rem units variables
+:root {
+  // Heading sizes - mobile
+  // h4-h6 remain the same size on both mobile & desktop
+  --h00-size-mobile: 2.5rem;
+  --h0-size-mobile: 2rem;
+  --h1-size-mobile: 1.625rem;
+  --h2-size-mobile: 1.375rem;
+  --h3-size-mobile: 1.125rem;
+
+  // Heading sizes - desktop
+  --h00-size: 3rem;
+  --h0-size: 2.5rem;
+  --h1-size: 2rem;
+  --h2-size: 1.5rem;
+  --h3-size: 1.25rem;
+  --h4-size: 1rem;
+  --h5-size: 0.875rem;
+  --h6-size: 0.75rem;
+
+  --body-font-size: 0.875rem;
+  --font-size-small: 0.75rem;
+}

--- a/src/support/mixins/typography.scss
+++ b/src/support/mixins/typography.scss
@@ -10,32 +10,32 @@
 // Heading mixins for use within components
 // These match heading utilities in utilities/typography
 @mixin h1 {
-  font-size: $h1-size;
+  font-size: var(--h1-size, $h1-size);
   font-weight: $font-weight-bold;
 }
 
 @mixin h2 {
-  font-size: $h2-size;
+  font-size: var(--h2-size, $h2-size);
   font-weight: $font-weight-bold;
 }
 
 @mixin h3 {
-  font-size: $h3-size;
+  font-size: var(--h3-size, $h3-size);
   font-weight: $font-weight-bold;
 }
 
 @mixin h4 {
-  font-size: $h4-size;
+  font-size: var(--h4-size, $h4-size);
   font-weight: $font-weight-bold;
 }
 
 @mixin h5 {
-  font-size: $h5-size;
+  font-size: var(--h5-size, $h5-size);
   font-weight: $font-weight-bold;
 }
 
 @mixin h6 {
-  font-size: $h6-size;
+  font-size: var(--h6-size, $h6-size);
   font-weight: $font-weight-bold;
 }
 
@@ -43,24 +43,30 @@
 // There are no responsive mixins for h4-h6 because they are small
 // and don't need to be smaller on mobile.
 @mixin f1-responsive {
-  font-size: $h1-size-mobile;
+  font-size: var(--h1-size-mobile, $h1-size-mobile);
 
   // 32px on desktop
-  @include breakpoint(md) { font-size: $h1-size; }
+  @include breakpoint(md) {
+    font-size: var(--h1-size, $h1-size);
+  }
 }
 
 @mixin f2-responsive {
-  font-size: $h2-size-mobile;
+  font-size: var(--h2-size-mobile, $h2-size-mobile);
 
   // 24px on desktop
-  @include breakpoint(md) { font-size: $h2-size; }
+  @include breakpoint(md) {
+    font-size: var(--h2-size, $h2-size);
+  }
 }
 
 @mixin f3-responsive {
-  font-size: $h3-size-mobile;
+  font-size: var(--h3-size-mobile, $h3-size-mobile);
 
   // 20px on desktop
-  @include breakpoint(md) { font-size: $h3-size; }
+  @include breakpoint(md) {
+    font-size: var(--h3-size, $h3-size);
+  }
 }
 
 // These use the mixins from above for responsive heading sizes.

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -21,10 +21,10 @@ $h6-size: 12px !default;
 $font-size-small: 12px !default;
 
 // Font weights
-$font-weight-bold: 600 !default;
-$font-weight-semibold: 500 !default;
-$font-weight-normal: 400 !default;
-$font-weight-light: 300 !default;
+$font-weight-bold: var(--base-text-weight-medium, 600) !default;
+$font-weight-semibold: var(--base-text-weight-semibold, 500) !default;
+$font-weight-normal: var(--base-text-weight-normal, 400) !default;
+$font-weight-light: var(--base-text-weight-light, 300) !default;
 
 // Line heights
 $lh-condensed-ultra: 1 !default;

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -17,7 +17,6 @@
 
 /* Set the font size to 26px */
 .h1 {
-  // stylelint-disable-next-line primer/typography
   font-size: var(--h1-size-mobile, $h1-size-mobile) !important;
 
   @include breakpoint(md) {
@@ -27,7 +26,6 @@
 
 /* Set the font size to 22px */
 .h2 {
-  // stylelint-disable-next-line primer/typography
   font-size: var(--h2-size-mobile, $h2-size-mobile) !important;
 
   @include breakpoint(md) {
@@ -37,7 +35,6 @@
 
 /* Set the font size to 18px */
 .h3 {
-  // stylelint-disable-next-line primer/typography
   font-size: var(--h3-size-mobile, $h3-size-mobile) !important;
 
   @include breakpoint(md) {
@@ -75,7 +72,7 @@
 // Type utilities that match type sale
 /* Set the font size to 26px */
 .f1 {
-  // stylelint-disable-next-line primer/typography
+
   font-size: var(--h1-size-mobile, $h1-size-mobile) !important;
 
   @include breakpoint(md) {
@@ -85,7 +82,7 @@
 
 /* Set the font size to 22px */
 .f2 {
-  // stylelint-disable-next-line primer/typography
+
   font-size: var(--h2-size-mobile, $h2-size-mobile) !important;
 
   @include breakpoint(md) {
@@ -95,7 +92,7 @@
 
 /* Set the font size to 18px */
 .f3 {
-  // stylelint-disable-next-line primer/typography
+
   font-size: var(--h3-size-mobile, $h3-size-mobile) !important;
 
   @include breakpoint(md) {
@@ -125,7 +122,6 @@
 // Type utils with light weight that match type scale
 /* Set the font size to 40px and weight to light */
 .f00-light {
-  // stylelint-disable-next-line primer/typography
   font-size: var(--h00-size-mobile, $h00-size-mobile) !important;
   font-weight: var(--base-text-weight-light, $font-weight-light) !important;
 
@@ -136,7 +132,7 @@
 
 /* Set the font size to 32px and weight to light */
 .f0-light {
-  // stylelint-disable-next-line primer/typography
+
   font-size: var(--h0-size-mobile, $h0-size-mobile) !important;
   font-weight: var(--base-text-weight-light, $font-weight-light) !important;
 
@@ -147,7 +143,7 @@
 
 /* Set the font size to 26px and weight to light */
 .f1-light {
-  // stylelint-disable-next-line primer/typography
+
   font-size: var(--h1-size-mobile, $h1-size-mobile) !important;
   font-weight: var(--base-text-weight-light, $font-weight-light) !important;
 
@@ -158,7 +154,7 @@
 
 /* Set the font size to 22px and weight to light */
 .f2-light {
-  // stylelint-disable-next-line primer/typography
+
   font-size: var(--h2-size-mobile, $h2-size-mobile) !important;
   font-weight: var(--base-text-weight-light, $font-weight-light) !important;
 
@@ -170,7 +166,6 @@
 // Same size and weight as .lead but without color property
 /* Set the font size to 18px and weight to light */
 .f3-light {
-  // stylelint-disable-next-line primer/typography
   font-size: var(--h3-size-mobile, $h3-size-mobile) !important;
   font-weight: var(--base-text-weight-light, $font-weight-light) !important;
 

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -252,20 +252,20 @@ $variant in $responsive-variants {
 // Text styles
 /* Set the font weight to normal */
 .text-normal {
-  font-weight: var(--base-text-weight-normal, $font-weight-normal) !important;
+  font-weight: $font-weight-normal !important;
 }
 
 /* Set the font weight to bold */
 .text-bold {
-  font-weight: var(--base-text-weight-semibold, $font-weight-bold) !important;
+  font-weight: $font-weight-bold !important;
 }
 
 .text-semibold {
-  font-weight: var(--base-text-weight-medium, $font-weight-semibold) !important;
+  font-weight: $font-weight-semibold !important;
 }
 
 .text-light {
-  font-weight: var(--base-text-weight-light, $font-weight-light) !important;
+  font-weight: $font-weight-light !important;
 }
 
 /* Set the font to italic */

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -1,4 +1,4 @@
-// stylelint-disable comment-empty-line-before
+// stylelint-disable comment-empty-line-before, primer/typography
 
 // Type scale variables found in ../support/lib/variables.scss
 // $h00-size-mobile: 40px;
@@ -200,8 +200,7 @@
 // combined with type size equate to whole pixels.
 // Will be improved with future typography scale updates.
 // Responsive line-height
-@each $breakpoint,
-$variant in $responsive-variants {
+@each $breakpoint, $variant in $responsive-variants {
   @include breakpoint($breakpoint) {
 
     /* Set the line height to ultra condensed */
@@ -228,8 +227,7 @@ $variant in $responsive-variants {
 
 // Text alignments
 // Responsive text alignment
-@each $breakpoint,
-$variant in $responsive-variants {
+@each $breakpoint, $variant in $responsive-variants {
   @include breakpoint($breakpoint) {
 
     /* Text align to the right */

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -18,39 +18,49 @@
 /* Set the font size to 26px */
 .h1 {
   // stylelint-disable-next-line primer/typography
-  font-size: $h1-size-mobile !important;
+  font-size: var(--h1-size-mobile, $h1-size-mobile) !important;
 
-  @include breakpoint(md) { font-size: $h1-size !important; }
+  @include breakpoint(md) {
+    font-size: var(--h1-size, $h1-size) !important;
+  }
 }
 
 /* Set the font size to 22px */
 .h2 {
   // stylelint-disable-next-line primer/typography
-  font-size: $h2-size-mobile !important;
+  font-size: var(--h2-size-mobile, $h2-size-mobile) !important;
 
-  @include breakpoint(md) { font-size: $h2-size !important; }
+  @include breakpoint(md) {
+    font-size: var(--h2-size, $h2-size) !important;
+  }
 }
 
 /* Set the font size to 18px */
 .h3 {
   // stylelint-disable-next-line primer/typography
-  font-size: $h3-size-mobile !important;
+  font-size: var(--h3-size-mobile, $h3-size-mobile) !important;
 
-  @include breakpoint(md) { font-size: $h3-size !important; }
+  @include breakpoint(md) {
+    font-size: var(--h3-size, $h3-size) !important;
+  }
 }
 
 /* Set the font size to #{$h4-size} */
 .h4 {
-  font-size: $h4-size !important;
+  font-size: var(--h4-size, $h4-size) !important;
 }
 
 /* Set the font size to #{$h5-size} */
-.h5 { font-size: $h5-size !important; }
+.h5 {
+  font-size: var(--h5-size, $h5-size) !important;
+}
 
 // Does not include color property like typography base
 // styles, color should be applied with color utilities.
 /* Set the font size to #{$h6-size} */
-.h6 { font-size: $h6-size !important; }
+.h6 {
+  font-size: var(--h6-size, $h6-size) !important;
+}
 
 // Heading utilities
 .h1,
@@ -58,102 +68,131 @@
 .h3,
 .h4,
 .h5,
-.h6 { font-weight: $font-weight-bold !important; }
+.h6 {
+  font-weight: var(--base-text-weight-semibold, $font-weight-bold) !important;
+}
 
 // Type utilities that match type sale
 /* Set the font size to 26px */
 .f1 {
   // stylelint-disable-next-line primer/typography
-  font-size: $h1-size-mobile !important;
+  font-size: var(--h1-size-mobile, $h1-size-mobile) !important;
 
-  @include breakpoint(md) { font-size: $h1-size !important; }
+  @include breakpoint(md) {
+    font-size: var(--h1-size, $h1-size) !important;
+  }
 }
 
 /* Set the font size to 22px */
 .f2 {
   // stylelint-disable-next-line primer/typography
-  font-size: $h2-size-mobile !important;
+  font-size: var(--h2-size-mobile, $h2-size-mobile) !important;
 
-  @include breakpoint(md) { font-size: $h2-size !important; }
+  @include breakpoint(md) {
+    font-size: var(--h2-size, $h2-size) !important;
+  }
 }
 
 /* Set the font size to 18px */
 .f3 {
   // stylelint-disable-next-line primer/typography
-  font-size: $h3-size-mobile !important;
+  font-size: var(--h3-size-mobile, $h3-size-mobile) !important;
 
-  @include breakpoint(md) { font-size: $h3-size !important; }
+  @include breakpoint(md) {
+    font-size: var(--h3-size, $h3-size) !important;
+  }
 }
 
 /* Set the font size to #{$h4-size} */
 .f4 {
-  font-size: $h4-size !important;
+  font-size: var(--h4-size, $h4-size) !important;
 
-  @include breakpoint(md) { font-size: $h4-size !important; }
+  @include breakpoint(md) {
+    font-size: var(--h4-size, $h4-size) !important;
+  }
 }
 
 /* Set the font size to #{$h5-size} */
-.f5 { font-size: $h5-size !important; }
+.f5 {
+  font-size: var(--h5-size, $h5-size) !important;
+}
+
 /* Set the font size to #{$h6-size} */
-.f6 { font-size: $h6-size !important; }
+.f6 {
+  font-size: var(--h6-size, $h6-size) !important;
+}
 
 // Type utils with light weight that match type scale
 /* Set the font size to 40px and weight to light */
 .f00-light {
   // stylelint-disable-next-line primer/typography
-  font-size: $h00-size-mobile !important;
-  font-weight: $font-weight-light !important;
+  font-size: var(--h00-size-mobile, $h00-size-mobile) !important;
+  font-weight: var(--base-text-weight-light, $font-weight-light) !important;
 
-  @include breakpoint(md) { font-size: $h00-size !important; }
+  @include breakpoint(md) {
+    font-size: var(--h00-size, $h00-size) !important;
+  }
 }
 
 /* Set the font size to 32px and weight to light */
 .f0-light {
   // stylelint-disable-next-line primer/typography
-  font-size: $h0-size-mobile !important;
-  font-weight: $font-weight-light !important;
+  font-size: var(--h0-size-mobile, $h0-size-mobile) !important;
+  font-weight: var(--base-text-weight-light, $font-weight-light) !important;
 
-  @include breakpoint(md) { font-size: $h0-size !important; }
+  @include breakpoint(md) {
+    font-size: var(--h0-size, $h0-size) !important;
+  }
 }
 
 /* Set the font size to 26px and weight to light */
 .f1-light {
   // stylelint-disable-next-line primer/typography
-  font-size: $h1-size-mobile !important;
-  font-weight: $font-weight-light !important;
+  font-size: var(--h1-size-mobile, $h1-size-mobile) !important;
+  font-weight: var(--base-text-weight-light, $font-weight-light) !important;
 
-  @include breakpoint(md) { font-size: $h1-size !important; }
+  @include breakpoint(md) {
+    font-size: var(--h1-size, $h1-size) !important;
+  }
 }
 
 /* Set the font size to 22px and weight to light */
 .f2-light {
   // stylelint-disable-next-line primer/typography
-  font-size: $h2-size-mobile !important;
-  font-weight: $font-weight-light !important;
+  font-size: var(--h2-size-mobile, $h2-size-mobile) !important;
+  font-weight: var(--base-text-weight-light, $font-weight-light) !important;
 
-  @include breakpoint(md) { font-size: $h2-size !important; }
+  @include breakpoint(md) {
+    font-size: var(--h2-size, $h2-size) !important;
+  }
 }
 
 // Same size and weight as .lead but without color property
 /* Set the font size to 18px and weight to light */
 .f3-light {
   // stylelint-disable-next-line primer/typography
-  font-size: $h3-size-mobile !important;
-  font-weight: $font-weight-light !important;
+  font-size: var(--h3-size-mobile, $h3-size-mobile) !important;
+  font-weight: var(--base-text-weight-light, $font-weight-light) !important;
 
-  @include breakpoint(md) { font-size: $h3-size !important; }
+  @include breakpoint(md) {
+    font-size: var(--h3-size, $h3-size) !important;
+  }
 }
 
 // Smallest text size
 /* Set the font size to ${#h6-size} */
-.text-small { font-size: $h6-size !important; } // 12px
+.text-small {
+  font-size: var(--h6-size, $h6-size) !important;
+}
+
+// 12px
 
 /* Large leading paragraphs */
 .lead {
   // stylelint-disable-next-line primer/spacing
   margin-bottom: 30px;
-  font-size: $h3-size;
-  font-weight: $font-weight-light;
+  font-size: var(--h3-size, $h3-size);
+  font-weight: var(--base-text-weight-light, $font-weight-light);
 }
 
 // Line-height variations
@@ -161,51 +200,103 @@
 // combined with type size equate to whole pixels.
 // Will be improved with future typography scale updates.
 // Responsive line-height
-@each $breakpoint, $variant in $responsive-variants {
+@each $breakpoint,
+$variant in $responsive-variants {
   @include breakpoint($breakpoint) {
+
     /* Set the line height to ultra condensed */
-    .lh#{$variant}-condensed-ultra { line-height: $lh-condensed-ultra !important; }
+    .lh#{$variant}-condensed-ultra {
+      line-height: $lh-condensed-ultra !important;
+    }
+
     /* Set the line height to condensed */
-    .lh#{$variant}-condensed { line-height: $lh-condensed !important; }
+    .lh#{$variant}-condensed {
+      line-height: $lh-condensed !important;
+    }
+
     /* Set the line height to default */
-    .lh#{$variant}-default { line-height: $lh-default !important; }
+    .lh#{$variant}-default {
+      line-height: $lh-default !important;
+    }
+
     /* Set the line height to zero */
-    .lh#{$variant}-0 { line-height: 0 !important; }
+    .lh#{$variant}-0 {
+      line-height: 0 !important;
+    }
   }
 }
 
 // Text alignments
 // Responsive text alignment
-@each $breakpoint, $variant in $responsive-variants {
+@each $breakpoint,
+$variant in $responsive-variants {
   @include breakpoint($breakpoint) {
+
     /* Text align to the right */
-    .text#{$variant}-right { text-align: right !important; }
+    .text#{$variant}-right {
+      text-align: right !important;
+    }
+
     /* Text align to the left */
-    .text#{$variant}-left { text-align: left !important; }
+    .text#{$variant}-left {
+      text-align: left !important;
+    }
+
     /* Text align to the center */
-    .text#{$variant}-center { text-align: center !important; }
+    .text#{$variant}-center {
+      text-align: center !important;
+    }
   }
 }
 
 // Text styles
 /* Set the font weight to normal */
-.text-normal { font-weight: $font-weight-normal !important; }
+.text-normal {
+  font-weight: var(--base-text-weight-normal, $font-weight-normal) !important;
+}
+
 /* Set the font weight to bold */
-.text-bold { font-weight: $font-weight-bold !important; }
-.text-semibold { font-weight: $font-weight-semibold !important; }
-.text-light { font-weight: $font-weight-light !important; }
+.text-bold {
+  font-weight: var(--base-text-weight-semibold, $font-weight-bold) !important;
+}
+
+.text-semibold {
+  font-weight: var(--base-text-weight-medium, $font-weight-semibold) !important;
+}
+
+.text-light {
+  font-weight: var(--base-text-weight-light, $font-weight-light) !important;
+}
+
 /* Set the font to italic */
-.text-italic { font-style: italic !important; }
+.text-italic {
+  font-style: italic !important;
+}
+
 /* Make text uppercase */
-.text-uppercase { text-transform: uppercase !important; }
+.text-uppercase {
+  text-transform: uppercase !important;
+}
+
 /* Underline text */
-.text-underline { text-decoration: underline !important; }
+.text-underline {
+  text-decoration: underline !important;
+}
+
 /* Don't underline text */
-.no-underline { text-decoration: none !important; }
+.no-underline {
+  text-decoration: none !important;
+}
+
 /* Don't wrap white space */
-.no-wrap { white-space: nowrap !important; }
+.no-wrap {
+  white-space: nowrap !important;
+}
+
 /* Normal white space */
-.ws-normal { white-space: normal !important; }
+.ws-normal {
+  white-space: normal !important;
+}
 
 /* Force long "words" to wrap if they exceed the width of the container */
 .wb-break-word {
@@ -225,14 +316,18 @@
  *
  * see: https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#Values
  */
-.wb-break-all { word-break: break-all !important; }
+.wb-break-all {
+  word-break: break-all !important;
+}
 
 .text-emphasized {
-  font-weight: $font-weight-bold;
+  font-weight: var(--base-text-weight-semibold, $font-weight-bold);
 }
 
 // List styles
-.list-style-none { list-style: none !important; }
+.list-style-none {
+  list-style: none !important;
+}
 
 /* Set to monospace font */
 .text-mono {

--- a/src/utilities/typography.scss
+++ b/src/utilities/typography.scss
@@ -72,7 +72,6 @@
 // Type utilities that match type sale
 /* Set the font size to 26px */
 .f1 {
-
   font-size: var(--h1-size-mobile, $h1-size-mobile) !important;
 
   @include breakpoint(md) {
@@ -82,7 +81,6 @@
 
 /* Set the font size to 22px */
 .f2 {
-
   font-size: var(--h2-size-mobile, $h2-size-mobile) !important;
 
   @include breakpoint(md) {
@@ -92,7 +90,6 @@
 
 /* Set the font size to 18px */
 .f3 {
-
   font-size: var(--h3-size-mobile, $h3-size-mobile) !important;
 
   @include breakpoint(md) {
@@ -132,7 +129,6 @@
 
 /* Set the font size to 32px and weight to light */
 .f0-light {
-
   font-size: var(--h0-size-mobile, $h0-size-mobile) !important;
   font-weight: var(--base-text-weight-light, $font-weight-light) !important;
 
@@ -143,7 +139,6 @@
 
 /* Set the font size to 26px and weight to light */
 .f1-light {
-
   font-size: var(--h1-size-mobile, $h1-size-mobile) !important;
   font-weight: var(--base-text-weight-light, $font-weight-light) !important;
 
@@ -154,7 +149,6 @@
 
 /* Set the font size to 22px and weight to light */
 .f2-light {
-
   font-size: var(--h2-size-mobile, $h2-size-mobile) !important;
   font-weight: var(--base-text-weight-light, $font-weight-light) !important;
 


### PR DESCRIPTION
### What are you trying to accomplish?

Safely test rem units for all typography base and utility styles behind a feature flag. Each change is using a CSS var that only exists behind a feature flag, with a fallback to the current value (scss var). There should be **no** visual changes to typography styles with this change.

Closes https://github.com/github/primer/issues/41

### What approach did you choose and why?

CSS vars with fallbacks as this has been a useful method for testing our new set of design tokens.

### What should reviewers focus on?

- Spelling/typos

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
