### PR TITLE
Add upper-roman and upper-alpha list types

### DIFF
--- a/.changeset/beige-files-move.md
+++ b/.changeset/beige-files-move.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Add upper-roman and upper-alpha list types

--- a/src/markdown/lists.scss
+++ b/src/markdown/lists.scss
@@ -14,16 +14,24 @@
     }
   }
 
-  ol[type='1'] {
-    list-style-type: decimal;
-  }
-
   ol[type='a'] {
     list-style-type: lower-alpha;
   }
 
+  ol[type='A'] {
+    list-style-type: upper-alpha;
+  }
+
   ol[type='i'] {
     list-style-type: lower-roman;
+  }
+
+  ol[type='I'] {
+    list-style-type: upper-roman;
+  }
+
+  ol[type='1'] {
+    list-style-type: decimal;
   }
 
   // Reset <ol> style to decimal (HTML default) specifically for AsciiDoc


### PR DESCRIPTION
Fixes https://github.com/github/primer/issues/1376

### What are you trying to accomplish?

Adds support for `upper-alpha` and `upper-roman` in ordered lists.

<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->

Question: Is this stylesheet shared by React instances?

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
