### PR TITLE
Bugfix: Adding whitespace normal to Overlay element

### DIFF
--- a/src/overlay/overlay.scss
+++ b/src/overlay/overlay.scss
@@ -23,6 +23,7 @@ $primer-borderRadius-large: 0.75rem;
   border-radius: $primer-borderRadius-large;
   box-shadow: var(--color-overlay-shadow);
   opacity: 1;
+  white-space: normal;
 
   &.Overlay--size-auto {
     min-width: 192px;


### PR DESCRIPTION
### What are you trying to accomplish?

<img width="482" alt="image" src="https://user-images.githubusercontent.com/54012/200945800-3ba74d23-00c8-4715-b8c7-f8447cc3874f.png">

There are places where the dialog menu is used in a `dropdown-item` and the `white-space: nowrap` from the dropdown item is causing the elements to overflow. This resets the white-space inside the overlay menu.

<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->

### What approach did you choose and why?

<!-- Here you can explain your approach and reasoning in more detail. -->

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [ ] Yes, this PR does not depend on additional changes. 🚢 
