### PR TITLE
normalize: use --color-fg-default on mark

### DIFF
--- a/.changeset/chatty-squids-think.md
+++ b/.changeset/chatty-squids-think.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Use `--color-fg-default` for `mark`

--- a/src/base/normalize.scss
+++ b/src/base/normalize.scss
@@ -153,7 +153,7 @@ h1 {
 
 mark {
   background-color: var(--color-attention-subtle);
-  color: var(--color-text-primary);
+  color: var(--color-fg-default);
 }
 
 /**


### PR DESCRIPTION
The style for `<mark>` uses `--color-text-primary` which is no longer defined on github.com/primer.

<img width="369" alt="CleanShot 2022-11-26 at 19 06 06@2x" src="https://user-images.githubusercontent.com/1306747/204117399-82184061-1795-4930-ba1d-f7d35190a0f5.png">
