### PR TITLE
Move some `form` styles to `base.scss`

### DIFF
--- a/.changeset/giant-boxes-vanish.md
+++ b/.changeset/giant-boxes-vanish.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Move `fieldset` + `label` styles to `base.scss`

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -44,6 +44,12 @@ label {
   font-weight: $font-weight-bold;
 }
 
+// Custom styling for HTML5 validation bubbles (WebKit only)
+::placeholder {
+  color: var(--color-fg-subtle);
+  opacity: 1; // override opacity in normalize.css
+}
+
 // Horizontal lines
 //
 // TODO-MDO: Remove `.rule` from everywhere and replace with `<hr>`s

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -34,6 +34,16 @@ strong {
   font-weight: $font-weight-bold;
 }
 
+fieldset {
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+label {
+  font-weight: $font-weight-bold;
+}
+
 // Horizontal lines
 //
 // TODO-MDO: Remove `.rule` from everywhere and replace with `<hr>`s

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -86,12 +86,6 @@ textarea.form-control {
   }
 }
 
-// Custom styling for HTML5 validation bubbles (WebKit only)
-::placeholder {
-  color: var(--color-fg-subtle);
-  opacity: 1; // override opacity in normalize.css
-}
-
 // Mini inputs, to match .minibutton
 .input-sm {
   min-height: $size-4;

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -5,16 +5,6 @@
 //
 // Overrides for common inputs for easier styling.
 
-fieldset {
-  padding: 0;
-  margin: 0;
-  border: 0;
-}
-
-label {
-  font-weight: $font-weight-bold;
-}
-
 .form-control,
 .form-select {
   // stylelint-disable-next-line primer/spacing


### PR DESCRIPTION
### What are you trying to accomplish?

This moves the

- [x] `fieldset`
- [x] `label`
- [x] `::placeholder`

styles to `base.scss`.

### What approach did you choose and why?

This is in support of https://github.com/primer/view_components/pull/1638.

I think we shouldn't move all of the old [form-control.scss](https://github.com/primer/css/blob/main/src/forms/form-control.scss) styles to PVC. But specifically the `fieldset` + `::placeholder` are still needed in PVC. So making them part of `base.scss` feels like a good approach to make them more broadly available. They also don't use a class but instead use the element as selector. So having them in `base.scss` seems a good place.

### What should reviewers focus on?

Any alternative? We _could_ also move it to [normalize.scss](https://github.com/primer/css/blob/aee4b6f571d88f391fcf98170857c4eed7b1ae82/src/base/normalize.scss#LL305-L309C2)

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
