### PR TITLE
Fix inline code collapsing spaces

### DIFF
--- a/.changeset/forty-swans-dress.md
+++ b/.changeset/forty-swans-dress.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Fix collapsing spaces within inline code blocks

--- a/src/markdown/code.scss
+++ b/src/markdown/code.scss
@@ -10,6 +10,7 @@
     font-size: 85%;
     background-color: var(--color-neutral-muted);
     border-radius: $border-radius;
+    white-space: break-spaces;
 
     br { display: none; }
   }

--- a/src/markdown/code.scss
+++ b/src/markdown/code.scss
@@ -10,7 +10,7 @@
     font-size: 85%;
     background-color: var(--color-neutral-muted);
     border-radius: $border-radius;
-    white-space: break-spaces;
+    white-space: break-spaces; // keeps rendering spaces, but breaks them onto multiple lines 
 
     br { display: none; }
   }


### PR DESCRIPTION
### What are you trying to accomplish?

Prevent spaces from collapsing within inline code blocks.

### What approach did you choose and why?

Added a CSS rule to prevent this from happening. The `break-spaces` value was chosen to allow the content to wrap correctly if many spaces are used within the line.

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 
