### PR TITLE
Add `forms-rails` bundle

### DIFF
--- a/src/forms-rails/index.scss
+++ b/src/forms-rails/index.scss
@@ -1,0 +1,18 @@
+// This is the same as `forms/` except without the `FormControl.scss` import.
+// It's used for PVC's Lookbook that already has the FormControl styles.
+
+// ## TODO
+// Remove `forms-rails/` again when:
+// - Either `Primer::Alpha::AutoComplete` is removed or doesn't use `form-control`.
+// - Or in the next major version of PCSS we can probably remove the `FormControl.scss` again.
+
+@import '../support/index.scss';
+@import '../forms/form-control.scss';
+@import '../forms/form-select.scss';
+@import '../forms/form-group.scss';
+@import '../forms/form-validation.scss';
+@import '../forms/input-group.scss';
+@import '../forms/radio-group.scss';
+
+// new pvc components
+// @import '../forms/FormControl.scss';


### PR DESCRIPTION
### What are you trying to accomplish?

This is a follow-up to https://github.com/primer/css/pull/2343.

### What approach did you choose and why?

This is the same as `forms/` except without the `FormControl.scss` import:

```diff
// forms-rails/index.scss
@import '../support/index.scss';
@import '../forms/form-control.scss';
@import '../forms/form-select.scss';
@import '../forms/form-group.scss';
@import '../forms/form-validation.scss';
@import '../forms/input-group.scss';
@import '../forms/radio-group.scss';

- // new pvc components
- @import '../forms/FormControl.scss';
```

In PVC we'll then use this new bundle to only load the old form styles since the `FormControl` styles are already present:

```diff
/*
 *= require_tree .
 *= require_self
 *= require @primer/css/dist/primitives.css
 *= require @primer/css/dist/color-modes.css
 *= require @primer/css/dist/base.css
 *= require @primer/css/dist/buttons.css
- *= require @primer/css/dist/forms.css
+ *= require @primer/css/dist/forms-rails.css
 *= require @primer/css/dist/layout.css
 *= require @primer/css/dist/utilities.css
 *= require @primer/css/dist/markdown.css
*/
```

We can remove `forms-rails/` again when:

- Either `Primer::Alpha::AutoComplete` is removed or doesn't use `form-control`.
- Or in the next major version of PCSS we can probably remove the `FormControl.scss` again.

### What should reviewers focus on?

Not sure about this. It feels a bit overkill having to add this just so that PVC's `Primer::Alpha::AutoComplete` has styles in Lookbook. I think we have these options:

1. This PR. Add a new `forms-rails` bundle and use it for PVC.
2. Remove the `FormControl.scss` import from the `forms/` bundle without making a major version. It's pretty new and was never documented. **Downside**: Someone might already uses the `FormControl` styles.
3. In PVC we could just remove the [`forms.css`](https://github.com/primer/view_components/blob/ee7f476dd13b58e1c38538950780493b97142c8b/demo/app/assets/stylesheets/application.css#L8) import. It's only needed for the deprecated `Primer::Alpha::AutoComplete`. **Downside**: `Primer::Alpha::AutoComplete` will look un-styled in Lookbook.
4. Do nothing (for now). **Downside**: If we remove something in PVC's `FormControl`, e.g. `margin` it will still be present from PCSS's `FormControl`. It's not a problem on dotocm (separate imports), just when debugging in Lookbook we'd have to keep it in mind.

Hmmm.. personally, I slowly start to favor option 3. Just because `Primer::Alpha::AutoComplete` is deprcated, so seeing it un-styled in Lookbook should help in preventing people from using it. 😉 

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- Follow-up change in PVC is needed.
