### PR TITLE
[Do not merge] Just a test to run axe

### DIFF
--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Use Node.js
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-node@v3
+        with:
+          node-version: 14
       - run: yarn
         if: steps.changed-files.outputs.any_changed == 'true'
       - run: yarn dist

--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -29,8 +29,6 @@ jobs:
       - name: Use Node.js
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-node@v3
-        with:
-          node-version: 14
       - run: yarn
         if: steps.changed-files.outputs.any_changed == 'true'
       - run: yarn dist

--- a/docs/content/components/alerts.md
+++ b/docs/content/components/alerts.md
@@ -13,7 +13,7 @@ Flash messages, or alerts, inform users of successful or pending actions. Use th
 Flash messages start off looking decently neutral—they're just light blue rounded rectangles.
 
 ```html live
-<div class="flash">
+<div class="flash mt-3">
   Flash message goes here.
 </div>
 ```

--- a/script/axe-docs
+++ b/script/axe-docs
@@ -88,10 +88,10 @@ if [ ${#doc_urls[@]} -eq 0 ]; then
   exit
 else
   echo "Installing axe..."
-  # TODO: Remove pinned version once ChromeDriver bug is fixed
-  npm install -g @axe-core/cli@4.4.3
+  npm install -g @axe-core/cli
   # https://github.com/dequelabs/axe-core-npm/tree/develop/packages/cli
   # We exclude rules that depend on full page context.
   echo "Running axe..."
-  axe ${doc_urls[@]} --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,color-contrast,landmark-unique,landmark-one-main --exit --show-errors
+  # TODO: Remove chromedriver-path once ChromeDriver bug is fixed in @axe-core/cli
+  axe ${doc_urls[@]} --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,color-contrast,landmark-unique,landmark-one-main --exit --show-errors --chromedriver-path https://chromedriver.storage.googleapis.com/108.0.5359.22/chromedriver_linux64.zip
 fi

--- a/script/axe-docs
+++ b/script/axe-docs
@@ -89,7 +89,7 @@ if [ ${#doc_urls[@]} -eq 0 ]; then
 else
   echo "Installing axe..."
   # TODO: Remove pinned version once ChromeDriver bug is fixed
-  npm install -g @axe-core/cli@4.4.5
+  npm install -g @axe-core/cli@4.3.2
   # https://github.com/dequelabs/axe-core-npm/tree/develop/packages/cli
   # We exclude rules that depend on full page context.
   echo "Running axe..."

--- a/script/axe-docs
+++ b/script/axe-docs
@@ -88,10 +88,10 @@ if [ ${#doc_urls[@]} -eq 0 ]; then
   exit
 else
   echo "Installing axe..."
-  # TODO: Remove pinned version once ChromeDriver bug is fixed
-  npm install -g @axe-core/cli@4.3.2
+  npm install -g @axe-core/cli
   # https://github.com/dequelabs/axe-core-npm/tree/develop/packages/cli
   # We exclude rules that depend on full page context.
   echo "Running axe..."
-  axe ${doc_urls[@]} --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,color-contrast,landmark-unique,landmark-one-main --exit --show-errors --verbose
+  # TODO: Add back `--exit` once ChromeDriver bug is fixed in @axe-core/cli
+  axe ${doc_urls[@]} --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,color-contrast,landmark-unique,landmark-one-main --show-errors
 fi

--- a/script/axe-docs
+++ b/script/axe-docs
@@ -88,7 +88,8 @@ if [ ${#doc_urls[@]} -eq 0 ]; then
   exit
 else
   echo "Installing axe..."
-  npm install -g @axe-core/cli@4.5.2
+  # TODO: Remove pinned version once ChromeDriver bug is fixed
+  npm install -g @axe-core/cli@4.4.2
   # https://github.com/dequelabs/axe-core-npm/tree/develop/packages/cli
   # We exclude rules that depend on full page context.
   echo "Running axe..."

--- a/script/axe-docs
+++ b/script/axe-docs
@@ -88,9 +88,10 @@ if [ ${#doc_urls[@]} -eq 0 ]; then
   exit
 else
   echo "Installing axe..."
-  npm install -g @axe-core/cli
+  # TODO: Remove pinned version once ChromeDriver bug is fixed
+  npm install -g @axe-core/cli@4.4.5
   # https://github.com/dequelabs/axe-core-npm/tree/develop/packages/cli
   # We exclude rules that depend on full page context.
   echo "Running axe..."
-  axe ${doc_urls[@]} --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,color-contrast,landmark-unique,landmark-one-main --exit --show-errors
+  axe ${doc_urls[@]} --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,color-contrast,landmark-unique,landmark-one-main --exit --show-errors --verbose
 fi

--- a/script/axe-docs
+++ b/script/axe-docs
@@ -92,6 +92,5 @@ else
   # https://github.com/dequelabs/axe-core-npm/tree/develop/packages/cli
   # We exclude rules that depend on full page context.
   echo "Running axe..."
-  # TODO: Remove `--browser firefox` once the ChromeDriver bug is fixed in @axe-core/cli
-  axe ${doc_urls[@]} --browser firefox --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,color-contrast,landmark-unique,landmark-one-main --exit --show-errors
+  axe ${doc_urls[@]} --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,color-contrast,landmark-unique,landmark-one-main --exit --show-errors
 fi

--- a/script/axe-docs
+++ b/script/axe-docs
@@ -88,7 +88,7 @@ if [ ${#doc_urls[@]} -eq 0 ]; then
   exit
 else
   echo "Installing axe..."
-  npm install -g @axe-core/cli
+  npm install -g @axe-core/cli@4.5.2
   # https://github.com/dequelabs/axe-core-npm/tree/develop/packages/cli
   # We exclude rules that depend on full page context.
   echo "Running axe..."

--- a/script/axe-docs
+++ b/script/axe-docs
@@ -88,7 +88,8 @@ if [ ${#doc_urls[@]} -eq 0 ]; then
   exit
 else
   echo "Installing axe..."
-  npm install -g @axe-core/cli
+  # TODO: Remove pinned version once ChromeDriver bug is fixed
+  npm install -g @axe-core/cli@4.4.3
   # https://github.com/dequelabs/axe-core-npm/tree/develop/packages/cli
   # We exclude rules that depend on full page context.
   echo "Running axe..."

--- a/script/axe-docs
+++ b/script/axe-docs
@@ -88,8 +88,7 @@ if [ ${#doc_urls[@]} -eq 0 ]; then
   exit
 else
   echo "Installing axe..."
-  # TODO: Remove pinned version once ChromeDriver bug is fixed
-  npm install -g @axe-core/cli@4.4.2
+  npm install -g @axe-core/cli
   # https://github.com/dequelabs/axe-core-npm/tree/develop/packages/cli
   # We exclude rules that depend on full page context.
   echo "Running axe..."

--- a/script/axe-docs
+++ b/script/axe-docs
@@ -92,6 +92,6 @@ else
   # https://github.com/dequelabs/axe-core-npm/tree/develop/packages/cli
   # We exclude rules that depend on full page context.
   echo "Running axe..."
-  # TODO: Remove chromedriver-path once ChromeDriver bug is fixed in @axe-core/cli
-  axe ${doc_urls[@]} --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,color-contrast,landmark-unique,landmark-one-main --exit --show-errors --chromedriver-path https://chromedriver.storage.googleapis.com/108.0.5359.22/chromedriver_linux64.zip
+  # TODO: Remove `--browser edge` once the ChromeDriver bug is fixed in @axe-core/cli
+  axe ${doc_urls[@]} --browser edge --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,color-contrast,landmark-unique,landmark-one-main --exit --show-errors
 fi

--- a/script/axe-docs
+++ b/script/axe-docs
@@ -92,6 +92,6 @@ else
   # https://github.com/dequelabs/axe-core-npm/tree/develop/packages/cli
   # We exclude rules that depend on full page context.
   echo "Running axe..."
-  # TODO: Remove `--browser edge` once the ChromeDriver bug is fixed in @axe-core/cli
-  axe ${doc_urls[@]} --browser edge --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,color-contrast,landmark-unique,landmark-one-main --exit --show-errors
+  # TODO: Remove `--browser firefox` once the ChromeDriver bug is fixed in @axe-core/cli
+  axe ${doc_urls[@]} --browser firefox --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,color-contrast,landmark-unique,landmark-one-main --exit --show-errors
 fi


### PR DESCRIPTION
The `axe` check [seems to fail with](https://github.com/primer/css/actions/runs/3690899101/jobs/6248387035#step:9:46):

```bash
Running axe-core 4.4.3 in chrome-headless
Error: SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version 106
Current browser version is 108.0.5359.94 with binary path /usr/bin/google-chrome
```

Not sure how to fix it? Maybe:

- Just wait a bit until `@axe-core/cli` updated ChromeDriver.
- There is a way to set the [`--chromedriver-path`](https://github.com/dequelabs/axe-core-npm/blob/develop/packages/cli/README.md#chromedriver-path). But not sure if that only works locally?
- Pin an older version
- Disable the `axe` check, for now.