### PR TITLE
Remove trailing margin from HTML elements within markdown tables

### DIFF
--- a/.changeset/hot-parrots-shave.md
+++ b/.changeset/hot-parrots-shave.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Remove trailing margin from last-child within a markdown table cell

--- a/src/markdown/markdown-body.scss
+++ b/src/markdown/markdown-body.scss
@@ -78,6 +78,12 @@
     border: 0;
   }
 
+  td {
+    > :last-child {
+      margin-bottom: 0;
+    }
+  }
+
   blockquote {
     // stylelint-disable-next-line primer/spacing
     padding: 0 1em;

--- a/src/markdown/markdown-body.scss
+++ b/src/markdown/markdown-body.scss
@@ -78,12 +78,6 @@
     border: 0;
   }
 
-  td {
-    > :last-child {
-      margin-bottom: 0;
-    }
-  }
-
   blockquote {
     // stylelint-disable-next-line primer/spacing
     padding: 0 1em;

--- a/src/markdown/tables.scss
+++ b/src/markdown/tables.scss
@@ -20,6 +20,12 @@
       border: $border-width $border-style var(--color-border-default);
     }
 
+    td {
+      > :last-child {
+        margin-bottom: 0;
+      }
+    }
+
     tr {
       background-color: var(--color-canvas-default);
       border-top: $border-width $border-style var(--color-border-muted);

--- a/src/markdown/tables.scss
+++ b/src/markdown/tables.scss
@@ -1,5 +1,5 @@
 // Needs refactoring
-// stylelint-disable selector-max-type
+// stylelint-disable selector-max-type, selector-max-compound-selectors
 .markdown-body {
   // Tables
   table {


### PR DESCRIPTION
### What are you trying to accomplish?

Hi 👋 , I have a pretty niche styling problem which happens when using an HTML element within a table cell within a `.markdown-body` class. The existing `.markdown-body` styles add a trailing margin to various elements. When inside a table cell, this margin causes misalignment and makes the cell stand out from other text-only cells.

For my specific use-case, I'm using a `<details>` element within a table when adding comments to GitHub pull requests.

**Before**
<img width="341" alt="image" src="https://user-images.githubusercontent.com/720908/211594320-8fd2bc8b-cd7b-49eb-9391-d16b05f0f063.png"><img width="343" alt="image" src="https://user-images.githubusercontent.com/720908/211594833-af2ea723-3025-46a0-a6ec-83d9d6795c27.png">

**After**
<img width="342" alt="image" src="https://user-images.githubusercontent.com/720908/211594590-bc777e6c-2719-47ca-9526-c35286531a1a.png"><img width="340" alt="image" src="https://user-images.githubusercontent.com/720908/211594992-2e5473ef-cbe4-4ee1-9305-8e64da770e37.png">

### What approach did you choose and why?

I followed the example set by the existing `.markdown-body blockquote > :last-child` selector, adding a child combinator to remove the `margin-bottom`. This means it will apply to _any_ direct child element for consistency.

### What should reviewers focus on?

I'm new here so have no concept of the scope of this change! I'm not using Primer directly, just as part of the GitHub UI.

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 
