### PR TITLE
Add note about unmaintained docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 
 ## Documentation
 
+> :warning: **The documentation of this repo is not maintained anymore**. Please raise any documentation-specific pull requests in [primer.style/design](https://github.com/primer/design/) 
+
 Our documentation site lives at [primer.style/css](https://primer.style/css). You'll be able to find detailed documentation on getting started, all of the components, our theme, our principles, and more.
 
 ## Install


### PR DESCRIPTION
### What are you trying to accomplish?

This is part of https://github.com/github/primer/issues/1705 and adds the following note to the README:

> :warning: **The documentation of this repo is not maintained anymore**. Please raise any documentation-specific pull requests in [primer.style/design](https://github.com/primer/design/) 

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
