### PR TITLE
Remove outdated version specification in unpkg url

### DIFF
--- a/.changeset/heavy-gifts-yell.md
+++ b/.changeset/heavy-gifts-yell.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Remove outdated version specification in unpkg url

--- a/docs/content/getting-started/index.md
+++ b/docs/content/getting-started/index.md
@@ -122,5 +122,5 @@ Since GitHub pages is currently [locked to version `1.5.2` of `jekyll-sass-conve
 You won't need to install any node modules or Sass compilers for a static site; you can use the built CSS. The best thing to do is to [download the built CSS](https://unpkg.com/@primer/css/dist/primer.css) from [unpkg.com](https://unpkg.com) and host it yourself. If that's not an option, you can include a CDN link in your HTML:
 
 ```html
-<link href="https://unpkg.com/@primer/css@^20.2.4/dist/primer.css" rel="stylesheet" />
+<link href="https://unpkg.com/@primer/css/dist/primer.css" rel="stylesheet" />
 ```


### PR DESCRIPTION
### What are you trying to accomplish?

Original version of this page specified the version as 20.2.4 which might be outdated.


### What approach did you choose and why?

I remove this specification because unpkg can automatically use the latest release. But I think build this page with variables might be better.

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 
