### PR TITLE
Fix code block color inside a `<blockquote>`

### DIFF
--- a/.changeset/pink-geese-invite.md
+++ b/.changeset/pink-geese-invite.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Fix code block color inside a `<blockquote>`

--- a/src/markdown/code.scss
+++ b/src/markdown/code.scss
@@ -58,6 +58,7 @@
     font-size: 85%;
     // stylelint-disable-next-line primer/typography
     line-height: 1.45;
+    color: var(--color-fg-default);
     background-color: var(--color-canvas-subtle);
     border-radius: $border-radius;
   }


### PR DESCRIPTION
### What are you trying to accomplish?

This fixes https://github.com/github/primer/issues/1778 where code blocks would inherit the subtle text color [when inside a `blockquote`](https://github.com/primer/css/blob/5a0764a63d7099ab107958819bd8c92fc4f6ea93/src/markdown/markdown-body.scss#L84):

Before | After
--- | ---
![Screen Shot 2023-02-03 at 11 22 07](https://user-images.githubusercontent.com/378023/216497547-b0eff483-db6c-43e5-8b14-07c1c00be073.png) | ![Screen Shot 2023-02-03 at 11 22 34](https://user-images.githubusercontent.com/378023/216497549-046e81c5-66a6-4e2b-a771-e6d98fe1b914.png)

Live example:

<blockquote>

```js
for (let line = "#"; line.length < 8; line += "#") {
console.log(line)
}
```                          

</blockquote>

### What approach did you choose and why?

Adding `color: var(--color-fg-default);` to `.markdown-body .highlight pre` should override the `blockquote` color. 

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
