### PR TITLE
update default for flex wrap styles

### DIFF
--- a/.changeset/perfect-foxes-compete.md
+++ b/.changeset/perfect-foxes-compete.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+update default for flex wrap styles

--- a/docs/content/utilities/flexbox.md
+++ b/docs/content/utilities/flexbox.md
@@ -141,8 +141,8 @@ You can choose whether flex items are forced into a single line or wrapped onto 
 
 | Class | Description |
 | --- | --- |
-| `.flex-wrap` | Flex items will break onto multiple lines (default) |
-| `.flex-nowrap` | Flex items are laid out in a single line, even if they overflow |
+| `.flex-wrap` | Flex items will break onto multiple lines |
+| `.flex-nowrap` | Flex items are laid out in a single line, even if they overflow (default) |
 | `.flex-wrap-reverse` | Behaves the same as wrap but cross-start and cross-end are permuted. |
 
 ### `flex-wrap` example


### PR DESCRIPTION
### What are you trying to accomplish?
- updates documentation to indicate that the default wrap style for flexbox is `flex-wrap: no-wrap`

<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->

### What approach did you choose and why?

<!-- Here you can explain your approach and reasoning in more detail. -->

- Per [the W3 spec](https://www.w3.org/TR/css-flexbox-1/#flex-wrap-property) `no-wrap` is the default value
- I haven't found the declaration for `.d-flex` in https://github.com/primer/css, but looking at how the CSS is applied in the browser it doesn't look like Primer sets `wrap` on that class either, so it wouldn't be the default for an application using Primer (although our application may be behind in Primer versions)

![image](https://user-images.githubusercontent.com/2359538/220478833-feaf7b7a-dfeb-40bc-a9d4-79956395509c.png)




### What should reviewers focus on?
- Is this change correct? Have I missed something in Primer or misunderstood the spec?
- If this change is correct should the `flex-nowrap` line be first in the list in the documentation, as the default?
<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
