### PR TITLE
Prevent `.show-on-focus` to change width/height

### DIFF
--- a/.changeset/shy-pumpkins-walk.md
+++ b/.changeset/shy-pumpkins-walk.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Prevent `.show-on-focus` to change width/height

--- a/docs/src/stories/utilities/Layout.stories.jsx
+++ b/docs/src/stories/utilities/Layout.stories.jsx
@@ -285,6 +285,13 @@ export const ScreenReaderOnly = ({}) => (
   </div>
 )
 
+export const ShowOnFocus = ({}) => (
+  <div>
+    <div class="mb-2">Click here and press tab to make the ".show-on-focus" element appear</div>
+    <button type="button" class="btn show-on-focus">.show-on-focus</button>
+  </div>
+)
+
 export const MediaObject = ({}) => (
   <div class="clearfix p-3 border">
     <div class="float-left p-3 mr-3 color-bg-subtle">

--- a/src/utilities/visibility-display.scss
+++ b/src/utilities/visibility-display.scss
@@ -107,17 +107,18 @@
 
 // Only display content on focus
 .show-on-focus {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: 0;
-  overflow: hidden;
-  clip: rect(1px, 1px, 1px, 1px);
+  position: absolute !important;
+
+  &:not(:focus) {
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+    clip: rect(1px, 1px, 1px, 1px) !important;
+    border: 0 !important;
+  }
 
   &:focus {
     z-index: 999;
-    width: auto;
-    height: auto;
-    clip: auto;
   }
 }


### PR DESCRIPTION
### What are you trying to accomplish?

This came up in [Slack](https://github.slack.com/archives/C02PTFZQ5LZ/p1677189718816639). Currently the `.show-on-focus` utility sets the width/height to `auto` when focused. This is fine for most elements but causes the new `.Button--iconOnly` to loose its fixed width/height.

### What approach did you choose and why?

This PR...

- moves most of the properties into a `:not(:focus)` selector. This makes sure that the `:focus` selector doesn't need to set the width/height to `auto`.
- uses `!important` to override longer selectors and other utilties.
- adds a story so we can document `.show-on-focus` on https://primer.style/design/foundations/css-utilities/layout.

https://user-images.githubusercontent.com/378023/221568895-9955b542-154b-4492-8183-e03ade6b431e.mov


### What should reviewers focus on?

Any alternatives? Was thinking we could also use a wrapper element that is shown with `:focus-within`. But adding a wrapper element makes things more complex and could mess up things like flexbox or so.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
