### PR TITLE
Add `font-size` to `html` tag to make rem units "safe"

### DIFF
--- a/.changeset/popular-wasps-compare.md
+++ b/.changeset/popular-wasps-compare.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Add `font-size` to `html` tag to make rem units "safe"

--- a/src/base/normalize.scss
+++ b/src/base/normalize.scss
@@ -7,6 +7,7 @@
  */
 
 html {
+  font-size: 16px; /* this can be removed when all of GitHub uses rem units */
   font-family: sans-serif; /* 1 */
   -ms-text-size-adjust: 100%; /* 2 */
   -webkit-text-size-adjust: 100%; /* 2 */


### PR DESCRIPTION
### What are you trying to accomplish?

We've had a feature flag in dotcom for awhile testing `rem` units. We know that nothing is "breaking" with this change, so it's safe to rollout with the next Primitives major release v8. However, since parts of GitHub (most of it) still use pixels, the browser zoom experience is degraded by introducing `rem` units. Some UI will scale, and other's won't, which causes a lot of visual bugs.

![image](https://user-images.githubusercontent.com/18661030/228065308-836b9b79-605f-4316-ad69-3af4799445fc.png)

I'm setting a hard pixel value on the `html` tag that allows us to keep using `rem` units combined with pixels while we transition. This shouldn't introduce any new accessibility issues, and ideally creates a safe environment to slowly transition to `rem` units. 

### What should reviewers focus on?

Whaddya think, good idea? Bad idea?

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [ ] Yes, this PR does not depend on additional changes. 🚢 
