### PR TITLE
Make list type selector case sensitive

### DIFF
--- a/.changeset/quiet-lamps-smile.md
+++ b/.changeset/quiet-lamps-smile.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Make list type selector case sensitive

--- a/src/markdown/lists.scss
+++ b/src/markdown/lists.scss
@@ -14,19 +14,19 @@
     }
   }
 
-  ol[type='a'] {
+  ol[type='a s'] {
     list-style-type: lower-alpha;
   }
 
-  ol[type='A'] {
+  ol[type='A s'] {
     list-style-type: upper-alpha;
   }
 
-  ol[type='i'] {
+  ol[type='i s'] {
     list-style-type: lower-roman;
   }
 
-  ol[type='I'] {
+  ol[type='I s'] {
     list-style-type: upper-roman;
   }
 


### PR DESCRIPTION
### What are you trying to accomplish?

This is a follow-up to https://github.com/primer/css/pull/2305 and closes https://github.com/primer/css/issues/2406 by making the list type selector case sensitive.

Example code

```html
<ol type="a">
    <li>Item 1
    <li>Item 2
</ol>

<ol type="A">
    <li>Item 1
    <li>Item 2
</ol>
```

rendered:

Before | After
--- | ---
![Screen Shot 2023-04-04 at 12 08 40](https://user-images.githubusercontent.com/378023/229677097-e25a2325-d291-4a1a-9df6-61e1ae350df7.png) | ![Screen Shot 2023-04-04 at 12 09 33](https://user-images.githubusercontent.com/378023/229677101-9e869814-9984-4336-ab84-5f3008fb6cd2.png)

### What approach did you choose and why?

The problem was that the `ol[type='A']` selector overrides the `ol[type='a']` since it comes after in the source order.

https://github.com/primer/css/blob/e631273fa6248c450348eca1c2599d9bd79b4b59/src/markdown/lists.scss#L17-L23

 Adding `s` to the selector (`ol[type='A' s]`) makes it case sensitive, so the order doesn't matter anymore. Used this 👀  [Codepen](https://codepen.io/simurai/pen/QWVevLL/1824a65ebee5103fae3b85aa01bafd8d?editors=1100) to test. Note that [MDN says](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#browser_compatibility) the case-sensitive modifier (`s`) is not widely supported yet, but tested in Chrome, Edge, Firefox, Safari and they all seem to work. Maybe the MDN table is just not updated yet? 🤔 

### What should reviewers focus on?

I was wondering why we even need these styles and couldn't just use the browser default. But I assume they are needed because we have some opinionated way when nesting lists:

https://github.com/primer/css/blob/e631273fa6248c450348eca1c2599d9bd79b4b59/src/base/typography-base.scss#L49-L59

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
