### PR TITLE
Bump @primer/primitives to `7.11.5`

### DIFF
--- a/.changeset/chatty-elephants-fry.md
+++ b/.changeset/chatty-elephants-fry.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Bump @primer/primitives to `7.11.5`

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "storybook": "cd docs && yarn && yarn storybook"
   },
   "dependencies": {
-    "@primer/primitives": "^7.11.3",
+    "@primer/primitives": "^7.11.5",
     "@primer/view-components": "^0.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1203,10 +1203,12 @@
   resolved "https://registry.yarnpkg.com/@primer/behaviors/-/behaviors-1.3.1.tgz#febae28e5f7824f1fa547389b3ff8563e171da58"
   integrity sha512-aMRDUQ350lk0FxtL5gJWPFHHOSSzDbJ6uNJVIt8XSqiGe1pxuW5mVVfrEp1uvzZ0pCHkCdm9fycjnfOeMeIrOQ==
 
-"@primer/primitives@^7.11.3":
-  version "7.11.3"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.11.3.tgz#ec41816368cd827a5902a5a933b1535204b47194"
-  integrity sha512-od+rjE04X5sAtGncn9v7/ehZS2O9/tBpQpRsNirU5d4EuOwWMXTt3c6zMBkke136jbmJ0VbGhU+DrLwhj0AM9w==
+"@primer/primitives@^7.11.5":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.11.5.tgz#df36599f70d7a8283ce967c17c0e808ecb3984a2"
+  integrity sha512-UmFQA0BZ5BIQKrlKg1TOEjDzeeI2NWyeh/5cCvXVOjfLegCXIlHf/xCLl1KCYO4YeegHmC9g5tpPLTlWjtcbaA==
+  dependencies:
+    markdown-table-ts "^1.0.3"
 
 "@primer/stylelint-config@^12.4.0":
   version "12.7.0"
@@ -4244,6 +4246,11 @@ map-obj@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
+
+markdown-table-ts@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/markdown-table-ts/-/markdown-table-ts-1.0.3.tgz#46e4163805f1ca0b1076863b93996ba77436f990"
+  integrity sha512-lYrp7FXmBqpmGmsEF92WnSukdgYvLm15FPIODZOx9+3nobkxJxjBYcszqZf5VqTjBtISPSNC7zjU9o3zwpL6AQ==
 
 mathml-tag-names@^2.1.3:
   version "2.1.3"


### PR DESCRIPTION
### What are you trying to accomplish?

### [@primer/primitives@7.11.4](https://github.com/primer/primitives/pull/556)

-   [#555](https://github.com/primer/primitives/pull/555) [`98ca36a`](https://github.com/primer/primitives/commit/98ca36a05a2633e55bb6bef8010f61aa0fd5ef26) Thanks [@lukasoppermann](https://github.com/lukasoppermann)! - Fix for primary color in cvd modes

### [@primer/primitives@7.11.5](https://github.com/primer/primitives/pull/545)

-   [#557](https://github.com/primer/primitives/pull/557) [`c9101b7`](https://github.com/primer/primitives/commit/c9101b78d716e6d5189ab0bebb215e9fb2818db5) Thanks [@lukasoppermann](https://github.com/lukasoppermann)! - Updated fg.default and fg.muted for most themes to reset to previous versions

These color changes fix regressions in non-default themes. The most noticeable is fixing the **color blind themes** where the Primary Button should be blue instead of green, reported here: https://github.com/orgs/community/discussions/51943

Before | After
--- | ---
![Screen Shot 2023-04-06 at 8 25 30](https://user-images.githubusercontent.com/378023/230233697-47444500-26e5-43bb-972b-8afdc025d174.png) | ![Screen Shot 2023-04-06 at 8 25 42](https://user-images.githubusercontent.com/378023/230233699-d01d4fe2-4eac-414a-9679-a62e556e8456.png)

### What approach did you choose and why?

```
yarn add @primer/primitives@^7.11.5
```

### What should reviewers focus on?

Note that this is not super urgent since we added the `@primer/primitives` directly to dotcom and in our docs we only show the default light/dark themes.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
