### PR TITLE
Enable `color-contrast` AXE check

### DIFF
--- a/docs/content/components/alerts.md
+++ b/docs/content/components/alerts.md
@@ -15,7 +15,7 @@ Flash messages start off looking decently neutral—they're just light blue roun
 
 ```html live
 <div class="flash">
-  Flash message goes here!
+  Flash message goes here.
 </div>
 ```
 

--- a/docs/content/components/alerts.md
+++ b/docs/content/components/alerts.md
@@ -15,7 +15,7 @@ Flash messages start off looking decently neutral—they're just light blue roun
 
 ```html live
 <div class="flash">
-  Flash message goes here.
+  Flash message goes here!
 </div>
 ```
 

--- a/docs/content/components/box.md
+++ b/docs/content/components/box.md
@@ -15,7 +15,7 @@ The `.Box` component can be used for something as simple as a rounded corner box
 A `.Box` is a container with a white background, a light gray border, and rounded corners. By default there are no additional styles such as padding, these can be added as needed with utility classes. Other styles and layouts can be achieved with box elements and modifiers shown in the documentation below.
 
 ```html live
-<div class="Box">
+<div class="Box color-bg-emphasis">
   This is a box.
 </div>
 ```

--- a/script/axe-docs
+++ b/script/axe-docs
@@ -48,7 +48,7 @@ needs_to_be_fixed=(
   /components/timeline
   /components/toasts
   /utilities/flexbox
-  /utilities/layout 
+  /utilities/layout
 )
 
 echo "Pages that included in this starting point violations list are excluded from checks:"
@@ -56,7 +56,7 @@ printf '%s\n' "${needs_to_be_fixed[@]}"
 
 doc_urls=()
 skipped=()
-for i in "${nav_paths[@]}"; 
+for i in "${nav_paths[@]}";
 do
   if containsElement "${i//\"/}" "${needs_to_be_fixed[@]}"; then
     skipped+=($i)
@@ -92,5 +92,5 @@ else
   # https://github.com/dequelabs/axe-core-npm/tree/develop/packages/cli
   # We exclude rules that depend on full page context.
   echo "Running axe..."
-  axe ${doc_urls[@]} --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,color-contrast,landmark-unique,landmark-one-main --exit --show-errors
+  axe ${doc_urls[@]} --include "iframe" --disable html-has-lang,frame-title,page-has-heading-one,region,landmark-unique,landmark-one-main --exit --show-errors
 fi


### PR DESCRIPTION
### What are you trying to accomplish?

This enables the `color-contrast` AXE check to make sure colors are used in an accessible way.

### What approach did you choose and why?

Removed the `color-contrast` disable

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
