### PR TITLE
Add default `::selection` color

### DIFF
--- a/.changeset/happy-brooms-lick.md
+++ b/.changeset/happy-brooms-lick.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Add default `::selection` color

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -3,6 +3,10 @@
   box-sizing: border-box;
 }
 
+*::selection {
+  background-color: var(--color-accent-subtle);
+}
+
 input,
 select,
 textarea,


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->

The current release includes a bug in some browsers where selection styles aren't visible. This PR adds a default color.

Closes https://github.com/primer/css/issues/2454

### What approach did you choose and why?

<!-- Here you can explain your approach and reasoning in more detail. -->

Used the suggestion from the issue to target `::selection` globally

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [ ] Yes, this PR does not depend on additional changes. 🚢 
