### PR TITLE
Revert "Add `::selection` to root color vars"

### DIFF
--- a/.changeset/hungry-pandas-roll.md
+++ b/.changeset/hungry-pandas-roll.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Fix bug with `color-mode` mixin not applying correctly due to `::selection`

--- a/src/support/mixins/color-modes.scss
+++ b/src/support/mixins/color-modes.scss
@@ -1,7 +1,6 @@
 @mixin color-mode-theme($theme-name, $include-root: false) {
   @if $include-root {
     :root,
-    ::selection,
     [data-color-mode="light"][data-light-theme="#{$theme-name}"],
     [data-color-mode="dark"][data-dark-theme="#{$theme-name}"] {
       @content;
@@ -33,7 +32,6 @@
 @mixin color-mode($mode) {
   @if $mode == light {
     :root,
-    ::selection,
     [data-color-mode="light"][data-light-theme*="#{$mode}"],
     [data-color-mode="dark"][data-dark-theme*="#{$mode}"] {
       @content;


### PR DESCRIPTION
Reverts primer/css#2437

@langermank This PR will need reverting because the introduction of `::selection` blows the whole selector away. The `::selection` style needs to be standalone it seems. In particular, the following:

```sass
@include color-mode("light") {
  p {
    color: green
  }
}
```

gets compiled into


```sass
:root p,
::selection p {
  color: green
}
```

which it seems is discarded. Here's a minimal repro to demonstrate that the selector is discarded:

https://codepen.io/keithamus/pen/mdQrGMo

Refs https://github.com/github/issues/issues/6741, https://github.com/orgs/community/discussions/58723#discussioncomment-6250327