### PR TITLE
Revert #2461 default selection color

### DIFF
--- a/.changeset/fair-cows-sing.md
+++ b/.changeset/fair-cows-sing.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Revert #2461 default selection color

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -3,10 +3,6 @@
   box-sizing: border-box;
 }
 
-*::selection {
-  background-color: var(--bgColor-accent-muted, var(--color-accent-subtle));
-}
-
 input,
 select,
 textarea,


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->

Reverts https://github.com/primer/css/pull/2461

This selector seems risky and we _think_ is only a bug for a small amount of users impacted by a Chrome feature flag.

### What approach did you choose and why?

<!-- Here you can explain your approach and reasoning in more detail. -->

Delete the code.

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
