### PR TITLE
Add `::selection` to `color-mode-theme()` mixin

### DIFF
--- a/.changeset/eleven-vans-repair.md
+++ b/.changeset/eleven-vans-repair.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Add `::selection` to `color-mode-theme()` mixin

--- a/src/support/mixins/color-modes.scss
+++ b/src/support/mixins/color-modes.scss
@@ -52,6 +52,35 @@
   }
 }
 
+// This mixin wraps styles with light or dark mode selectors
+// If possible, use a color variable instead.
+//
+// Example:
+//
+// @include color-mode('dark') {
+//   .my-class {
+//     color: red;
+//   }
+// }
+//
+// Returns:
+//
+// [data-color-mode=light][data-light-theme*=dark] .my-class,
+// [data-color-mode=dark][data-dark-theme*=dark] .my-class {
+//   color: red;
+// }
+//
+// @media (prefers-color-scheme: light) {
+//   [data-color-mode=auto][data-light-theme*=dark] .my-class {
+//     color: red;
+//   }
+// }
+// @media (prefers-color-scheme: dark) {
+//   [data-color-mode=auto][data-dark-theme*=dark] .my-class {
+//     color: red;
+//   }
+// }
+
 @mixin color-mode($mode) {
   @if $mode == light {
     :root,

--- a/src/support/mixins/color-modes.scss
+++ b/src/support/mixins/color-modes.scss
@@ -1,13 +1,21 @@
 // This mixin is used to output the tokens/variables from Primitives
 //
-// Warning: Don't use this mixin with a class as @content since
-// the `::selection` will make the selector invalid
-//
 // Example:
 //
 // @include color-mode-theme(dark) {
 //   --color: black;
 // }
+//
+// Warning!!!
+// Don't use this mixin with a class. E.g.
+// @include color-mode-theme(dark) {
+//   .my-class {
+//     color: red;
+//   }
+// }
+//
+// The outputted `::selection .my-class` will make the selector invalid and the entire ruleset is disregarded.
+// At some point we hopefully can remove the need for `&, &::selection {}` again (once the spec/implementation changes).
 
 @mixin color-mode-theme($theme-name, $include-root: false) {
   @if $include-root {

--- a/src/support/mixins/color-modes.scss
+++ b/src/support/mixins/color-modes.scss
@@ -1,9 +1,23 @@
+// This mixin is used to output the tokens/variables from Primitives
+//
+// Warning: Don't use this mixin with a class as @content since
+// the `::selection` will make the selector invalid
+//
+// Example:
+//
+// @include color-mode-theme(dark) {
+//   --color: black;
+// }
+
 @mixin color-mode-theme($theme-name, $include-root: false) {
   @if $include-root {
     :root,
     [data-color-mode="light"][data-light-theme="#{$theme-name}"],
     [data-color-mode="dark"][data-dark-theme="#{$theme-name}"] {
-      @content;
+      &,
+      &::selection {
+        @content;
+      }
 
       /*! */ // This is a fix for a cssstats bug see https://github.com/cssstats/cssstats/issues/331
     }
@@ -12,19 +26,28 @@
   @else {
     [data-color-mode="light"][data-light-theme="#{$theme-name}"],
     [data-color-mode="dark"][data-dark-theme="#{$theme-name}"] {
-      @content;
+      &,
+      &::selection {
+        @content;
+      }
     }
   }
 
   @media (prefers-color-scheme: light) {
     [data-color-mode="auto"][data-light-theme="#{$theme-name}"] {
-      @content;
+      &,
+      &::selection {
+        @content;
+      }
     }
   }
 
   @media (prefers-color-scheme: dark) {
     [data-color-mode="auto"][data-dark-theme="#{$theme-name}"] {
-      @content;
+      &,
+      &::selection {
+        @content;
+      }
     }
   }
 }


### PR DESCRIPTION
### What are you trying to accomplish?

This fixes https://github.com/primer/css/issues/2411 by adding `::selection` to the `color-mode-theme()` mixin.

### What approach did you choose and why?

It's similar to https://github.com/primer/css/pull/2437 that needed to be [reverted](https://github.com/primer/css/pull/2468) again. But in this attempt, the `::selection` is only added to the `color-mode-theme()` mixin. To make the `::selection` work with CSS variables and all color modes, I had to add it everywhere `@content` is used. It's a bit cumbersome, but not sure if there is a better approach? 🤔 

A usage example of

```scss
@include color-mode-theme(light, true) {
  --color: red;
}
```

should output:

#### Before

```css
:root,
[data-color-mode=light][data-light-theme=light],
[data-color-mode=dark][data-dark-theme=light] {
  --color: red;
}

@media (prefers-color-scheme: light) {
  [data-color-mode=auto][data-light-theme=light] {
    --color: red;
  }
}
@media (prefers-color-scheme: dark) {
  [data-color-mode=auto][data-dark-theme=light] {
    --color: red;
  }
}
```

#### After

```css
:root,
:root::selection,
[data-color-mode=light][data-light-theme=light],
[data-color-mode=light][data-light-theme=light]::selection,
[data-color-mode=dark][data-dark-theme=light],
[data-color-mode=dark][data-dark-theme=light]::selection {
  --color: red;
}

@media (prefers-color-scheme: light) {
  [data-color-mode=auto][data-light-theme=light],
  [data-color-mode=auto][data-light-theme=light]::selection {
    --color: red;
  }
}
@media (prefers-color-scheme: dark) {
  [data-color-mode=auto][data-dark-theme=light],
  [data-color-mode=auto][data-dark-theme=light]::selection {
    --color: red;
  }
}
```

Downside is that we can't use this mixin with a class anymore, like

```scss
@include color-mode-theme(dark) {
  .my-class {
    --color: red;
  }
}
```

since that would output `... ::selection .my-class` and [as seen](https://github.com/primer/css/pull/2468), make the selector invalid and the entire ruleset is discarded. 😩 I added a warning as a comment. At some point we hopefully can remove the `&, &::selection {}` part again (once the spec/implementation changes). 🙏 

More infos:

- [Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1412395)
- [Spec discussion](https://github.com/w3c/csswg-drafts/issues/6641)
- [Blog post](https://www.azabani.com/2022/09/01/meet-the-css-highlight-pseudos.html#accessing-global-constants)

### What should reviewers focus on?

Note that [this issue](https://github.com/primer/css/issues/2411) is currently only reproducible with Chrome's `chrome://flags/#enable-experimental-web-platform-features` enabled.

I'll try to test this first with a canary version on dotcom to avoid any more surprises.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
