### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - id: changeset-count
-        run: echo "::set-output name=change_count::$(ls .changeset/*.md | grep -v README | wc -l | xargs)"
+        run: echo "change_count=$(ls .changeset/*.md | grep -v README | wc -l | xargs)" >> $GITHUB_OUTPUT
 
       # Log changeset count for debugging purposes
       - name: Log changeset count


### PR DESCRIPTION
### Description

Closes #2479 

Update `.github/workflows/deploy_production.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
run: echo "::set-output name=change_count::$(ls .changeset/*.md | grep -v README | wc -l | xargs)"
```

**TO-BE**

```yaml
run: echo "change_count=$(ls .changeset/*.md | grep -v README | wc -l | xargs)" >> $GITHUB_OUTPUT
```

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
