### PR TITLE
Add link to old docs preview deploy

### DIFF
--- a/docs/stories/Introduction.mdx
+++ b/docs/stories/Introduction.mdx
@@ -1,5 +1,9 @@
 <img src="hero-illustration.svg" alt="" class="mb-3" />
 
+<div className="color-fg-accent border rounded-2 color-bg-accent p-3 color-border-accent-emphasis mb-5">
+  <p className="m-0 h4">Looking for the old docs site? Find it <a className="color-fg-accent" href="https://gh.io/AAlnj9s">here</a>.</p>
+</div>
+
 # Introduction
 
 Our goal is to create a system that enables us to build consistent user experiences with ease, yet with enough flexibility to support the broad spectrum of GitHub websites. This goal is embedded in our design and code decisions. Our approach to CSS is influenced by Object Oriented CSS principles, functional CSS, and BEM architecture.


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->

Adds a link to an old preview deploy to access the old Gatsby docs

![Alert box with link to old docs site](https://github.com/primer/css/assets/18661030/05fed64a-3d07-483d-8b7d-1013fa8fda4e)


### What approach did you choose and why?

<!-- Here you can explain your approach and reasoning in more detail. -->

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [ ] Yes, this PR does not depend on additional changes. 🚢 
