### PR TITLE
Temporarily hide old docs banner

### DIFF
--- a/docs/stories/Introduction.mdx
+++ b/docs/stories/Introduction.mdx
@@ -1,8 +1,11 @@
 <img src="hero-illustration.svg" alt="" class="mb-3" />
 
+{/*
+TODO: Fix old docs deploy & get working link
 <div className="color-fg-accent border rounded-2 color-bg-accent p-3 color-border-accent-emphasis mb-5">
   <p className="m-0 h4">Looking for the old docs site? Find it <a className="color-fg-accent" href="https://gh.io/AAlnj9s">here</a>.</p>
 </div>
+*/}
 
 # Introduction
 


### PR DESCRIPTION
### What are you trying to accomplish?

Hiding the banner advertising the old docs deploy as the link may be broken for an extended period of time.

Essentially negates #2496 

<details>
  <summary><b>Screenshots</b></summary>
  <p>Before:<br>
    <img src="https://github.com/primer/css/assets/46414358/d045b495-74e8-422b-935f-abcdce6d8cfd" title="For my next magic trick, I will make this banner disappear! Mwahahaha...">
  </p>
  <p>After:<br>
    <img src="https://github.com/primer/css/assets/46414358/86b92761-2182-43c6-a810-5e4cc93fd952" title="*excessive audience applause over a small banner* Thank you, thank you.">
  </p>
</details>

### What approach did you choose and why?

The banner element was commented out, which leaves it ready to go in the source code while still being excluded from the compiled docs.

### What should reviewers focus on?

Whether or not the banner was successfully removed from the compiled docs.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [X] Yes, this PR does not depend on additional changes. 🚢 
