### PR TITLE
provide css vars to ::backdrop

### DIFF
--- a/src/support/mixins/color-modes.scss
+++ b/src/support/mixins/color-modes.scss
@@ -29,6 +29,14 @@
 
       /*! */ // This is a fix for a cssstats bug see https://github.com/cssstats/cssstats/issues/331
     }
+
+    ::backdrop,
+    [data-color-mode="light"][data-light-theme="#{$theme-name}"],
+    [data-color-mode="dark"][data-dark-theme="#{$theme-name}"]::backdrop {
+      @content;
+
+      /*! */ // Must remain separate from the above selector to not break browsers which don't support ::backdrop, e.g. Safari 14.
+    }
   }
 
   @else {


### PR DESCRIPTION
### What are you trying to accomplish?

Attempting to use Primer's css variables in a `::backdrop` element. This doesn't work because `::backdrop` is like `::selection` in that it does not inherit from `:root`. Consequently, `::backdrop` needs to be provided all the CSS vars.

In addition, `::backdrop` is not supported by all browsers (Safari 14 does not support it), so we need to give it its own separate style rule so that it does not break the parsing of the `:root` style rule when encountered.

### What approach did you choose and why?

I chose to add `::backdrop` as a second style rule in the `@if $include-root` section of the `color-mode-theme` block.

### What should reviewers focus on?

Alternatives would be to not use `::backdrop`, but that is far more complex.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
