### PR TITLE
Use `control` border on default btn in an input group

### DIFF
--- a/.changeset/mean-kangaroos-burn.md
+++ b/.changeset/mean-kangaroos-burn.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Use `control` border on default btn in an input group

--- a/src/forms/input-group.scss
+++ b/src/forms/input-group.scss
@@ -54,6 +54,11 @@
   border-bottom-right-radius: 0;
 }
 
+.input-group .form-control:first-child,
+.input-group-button:first-child .btn:not(.btn-primary) {
+  border-color: var(--control-borderColor-rest, var(--color-border-default));
+}
+
 .input-group-button:first-child .btn {
   // stylelint-disable-next-line primer/spacing
   margin-right: -1px;
@@ -63,6 +68,11 @@
 .input-group-button:last-child .btn {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
+}
+
+.input-group .form-control:last-child,
+.input-group-button:last-child .btn:not(.btn-primary) {
+  border-color: var(--control-borderColor-rest, var(--color-border-default));
 }
 
 .input-group-button:last-child .btn {


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->

If a default button appears in a group with an input and no space between them, use the `emphasis` border-color for the button.

This looks very subtle now but will become more obvious over the next month.

| before | after |
| -- | -- |
| <img width="336" alt="button with input before" src="https://github.com/github/github/assets/18661030/19ed36ef-ae8f-43b1-9333-87c641400844"> | <img width="359" alt="button with input after" src="https://github.com/github/github/assets/18661030/e3d88a73-a213-450a-90a2-aca24b665c5b"> |

### What approach did you choose and why?

<!-- Here you can explain your approach and reasoning in more detail. -->

- Target the `btn` if its not `primary` within the group

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [ ] Yes, this PR does not depend on additional changes. 🚢 
