### PR TITLE
Fix npm release 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,42 +7,8 @@ on:
 jobs:
   release:
     name: Final
-    if: ${{ github.repository == 'primer/css' }}
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - id: get-access-token
-        uses: camertron/github-app-installation-auth-action@v1
-        with:
-          app-id: ${{ vars.PRIMER_APP_ID_SHARED }}
-          private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
-          client-id: ${{ vars.PRIMER_APP_CLIENT_ID_SHARED }}
-          client-secret: ${{ secrets.PRIMER_APP_CLIENT_SECRET_SHARED }}
-          installation-id: ${{ vars.PRIMER_APP_INSTALLATION_ID_SHARED }}
-
-      - name: Create release pull request or publish to npm
-        id: changesets
-        uses: changesets/action@master
-        with:
-          title: Release Tracking
-          # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: npm run release
-        env:
-          GITHUB_TOKEN: ${{ steps.get-access-token.outputs.access-token }}
-          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
+    if: ${{ github.repository == 'primer/css' && github.ref_name == 'main' }}
+    uses: primer/.github/.github/workflows/release.yml@main
+    secrets:
+      gh_token: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
+      npm_token: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'main'
       - 'next_major'
+  workflow_dispatch:
+
 jobs:
   release:
     name: Final

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 'changeset-release/**'
+  workflow_dispatch:
 
 jobs:
   release-candidate:


### PR DESCRIPTION
### What are you trying to accomplish?

Fixing the library release to npm by using our Primer org workflow instead of a custom, local one.

### What approach did you choose and why?

- Last two releases have failed
- I suspect they failed because the custom access token doesn't have the correct permission scopes, as [described here](https://github.com/changesets/changesets/issues/795#issuecomment-1631250128).
- Switching to our org workflow, which uses org-wide secrets _should_ fix this because we have other libraries that have used this to ship releases recently without issue
- Using an org workflow simplifies the CI/CD process, so this is also good codebase hygiene 

### What should reviewers focus on?

We manually rerun the release after merging this. Added ability to manually run the release via GitHub UI.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
