### PR TITLE
add more backdrop selectors to properly inherit theme colors

### DIFF
--- a/.changeset/popular-hounds-sin.md
+++ b/.changeset/popular-hounds-sin.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Fix styles for ::backdrop

--- a/src/support/mixins/color-modes.scss
+++ b/src/support/mixins/color-modes.scss
@@ -31,7 +31,7 @@
     }
 
     ::backdrop,
-    [data-color-mode="light"][data-light-theme="#{$theme-name}"],
+    [data-color-mode="light"][data-light-theme="#{$theme-name}"]::backdrop,
     [data-color-mode="dark"][data-dark-theme="#{$theme-name}"]::backdrop {
       @content;
 
@@ -47,6 +47,14 @@
         @content;
       }
     }
+    
+    ::backdrop,
+    [data-color-mode="light"][data-light-theme="#{$theme-name}"]::backdrop,
+    [data-color-mode="dark"][data-dark-theme="#{$theme-name}"]::backdrop {
+      @content;
+
+      /*! */ // Must remain separate from the above selector to not break browsers which don't support ::backdrop, e.g. Safari 14.
+    }
   }
 
   @media (prefers-color-scheme: light) {
@@ -56,6 +64,12 @@
         @content;
       }
     }
+    
+    [data-color-mode="auto"][data-light-theme="#{$theme-name}"]::backdrop {
+      @content;
+
+      /*! */ // Must remain separate from the above selector to not break browsers which don't support ::backdrop, e.g. Safari 14.
+    }
   }
 
   @media (prefers-color-scheme: dark) {
@@ -64,6 +78,12 @@
       &::selection {
         @content;
       }
+    }
+    
+    [data-color-mode="auto"][data-light-theme="#{$theme-name}"]::backdrop {
+      @content;
+
+      /*! */ // Must remain separate from the above selector to not break browsers which don't support ::backdrop, e.g. Safari 14.
     }
   }
 }


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->
The `::backdrop` styles do not properly reflect the current theme due to bugs in https://github.com/primer/css/pull/2519.

### What approach did you choose and why?

<!-- Here you can explain your approach and reasoning in more detail. -->
Added `::backdrop` in more places.

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
