### PR TITLE
Remove primitives css tokens import from support package

### DIFF
--- a/.changeset/gorgeous-jeans-camp.md
+++ b/.changeset/gorgeous-jeans-camp.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Remove primitives css tokens import from support package

--- a/src/support/index.scss
+++ b/src/support/index.scss
@@ -2,7 +2,6 @@
 @import './variables/typography.scss';
 @import './variables/layout.scss';
 @import './variables/misc.scss';
-@import '../primitives/temp-typography-tokens.scss';
 
 // mixins
 @import './mixins/color-modes.scss';


### PR DESCRIPTION
### What are you trying to accomplish?

closes https://github.com/github/primer/issues/2875

<!-- Please fill in a much as you can of this issue template. It's OK to leave sections blank if you don't have that information.
Describe the bug with as much detail as possible. -->

<!-- Note: If you include screenshots, images, and other visual media, please include alt text or, if there are several of them, a higher level written explanation of what's represented in the images. -->


### Describe the bug

The `@import '@primer/css/support/index.scss';` import is rendering duplicate CSS in all bundles on github. This [line in the index](https://github.com/primer/css/blob/df764e1a617d13af34d97bd7b4f06b8a478facd2/src/support/index.scss#L5) file is importing [from this file](https://github.com/primer/css/blob/df764e1a617d13af34d97bd7b4f06b8a478facd2/src/primitives/temp-typography-tokens.scss).

https://github.com/github/primer/assets/54012/443decb0-0176-4970-94ce-0c5bcf16e583

### Expected behavior

The `support` package ideally shouldn't be rendering any CSS. Because it's meant to be a Sass variable/mixin package it's imported everywhere in the codebase.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
