### PR TITLE
Add spaces to `::backdrop`

### DIFF
--- a/.changeset/shy-ducks-work.md
+++ b/.changeset/shy-ducks-work.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+fix backdrop selector

--- a/src/support/mixins/color-modes.scss
+++ b/src/support/mixins/color-modes.scss
@@ -31,8 +31,8 @@
     }
 
     ::backdrop,
-    [data-color-mode="light"][data-light-theme="#{$theme-name}"]::backdrop,
-    [data-color-mode="dark"][data-dark-theme="#{$theme-name}"]::backdrop {
+    [data-color-mode="light"][data-light-theme="#{$theme-name}"] ::backdrop,
+    [data-color-mode="dark"][data-dark-theme="#{$theme-name}"] ::backdrop {
       @content;
 
       /*! */ // Must remain separate from the above selector to not break browsers which don't support ::backdrop, e.g. Safari 14.
@@ -47,10 +47,10 @@
         @content;
       }
     }
-    
+
     ::backdrop,
-    [data-color-mode="light"][data-light-theme="#{$theme-name}"]::backdrop,
-    [data-color-mode="dark"][data-dark-theme="#{$theme-name}"]::backdrop {
+    [data-color-mode="light"][data-light-theme="#{$theme-name}"] ::backdrop,
+    [data-color-mode="dark"][data-dark-theme="#{$theme-name}"] ::backdrop {
       @content;
 
       /*! */ // Must remain separate from the above selector to not break browsers which don't support ::backdrop, e.g. Safari 14.
@@ -64,8 +64,8 @@
         @content;
       }
     }
-    
-    [data-color-mode="auto"][data-light-theme="#{$theme-name}"]::backdrop {
+
+    [data-color-mode="auto"][data-light-theme="#{$theme-name}"] ::backdrop {
       @content;
 
       /*! */ // Must remain separate from the above selector to not break browsers which don't support ::backdrop, e.g. Safari 14.
@@ -79,8 +79,8 @@
         @content;
       }
     }
-    
-    [data-color-mode="auto"][data-light-theme="#{$theme-name}"]::backdrop {
+
+    [data-color-mode="auto"][data-light-theme="#{$theme-name}"] ::backdrop {
       @content;
 
       /*! */ // Must remain separate from the above selector to not break browsers which don't support ::backdrop, e.g. Safari 14.


### PR DESCRIPTION
Fixes issue with `::backdrop` showing wrong theme colors https://github.com/primer/view_components/pull/2364