### PR TITLE
[a11y] Removing `!important` from `letter-spacing` marketing typography

### DIFF
--- a/.changeset/proud-rockets-kiss.md
+++ b/.changeset/proud-rockets-kiss.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+removing !important from letter-spacing marketing typography

--- a/src/marketing/type/typography.scss
+++ b/src/marketing/type/typography.scss
@@ -10,7 +10,7 @@
   font-feature-settings: $mktg-font-feature-settings;
   // stylelint-disable-next-line primer/typography
   font-weight: $mktg-header-weight-default !important;
-  letter-spacing: $mktg-header-spacing-default !important;
+  letter-spacing: $mktg-header-spacing-default;
 }
 
 @each $header, $sizes in $mktg-headers {
@@ -30,7 +30,7 @@
         line-height: map-get($pairing-md, 'lh') !important;
 
         @if (map-get($pairing-md, 'size') >= $mktg-header-spacing-threshold and map-get($pairing, 'size') < $mktg-header-spacing-threshold) {
-          letter-spacing: $mktg-header-spacing-large !important;
+          letter-spacing: $mktg-header-spacing-large;
         }
 
         @if (map-get($pairing-md, 'size') >= $mktg-header-weight-threshold and map-get($pairing, 'size') < $mktg-header-weight-threshold) {
@@ -45,7 +45,7 @@
         line-height: map-get($pairing-lg, 'lh') !important;
 
         @if (map-get($pairing-lg, 'size') >= $mktg-header-spacing-threshold and map-get($pairing-md, 'size') < $mktg-header-spacing-threshold) {
-          letter-spacing: $mktg-header-spacing-large !important;
+          letter-spacing: $mktg-header-spacing-large;
         }
 
         @if (map-get($pairing-lg, 'size') >= $mktg-header-weight-threshold and map-get($pairing-md, 'size') < $mktg-header-weight-threshold) {
@@ -77,7 +77,7 @@
     font-size: map-get($pairing, 'size') !important;
     line-height: map-get($pairing, 'lh') !important;
 
-    @if (map-get($pairing, 'size') >= $mktg-body-spacing-threshold) { letter-spacing: $mktg-body-spacing-large !important; }
+    @if (map-get($pairing, 'size') >= $mktg-body-spacing-threshold) { letter-spacing: $mktg-body-spacing-large; }
 
     @if (map-get($pairing, 'size') >= $mktg-body-weight-threshold) { font-weight: $font-weight-semibold; }
 
@@ -87,7 +87,7 @@
         line-height: map-get($pairing-md, 'lh') !important;
 
         @if (map-get($pairing-md, 'size') >= $mktg-body-spacing-threshold and map-get($pairing, 'size') < $mktg-body-spacing-threshold) {
-          letter-spacing: $mktg-body-spacing-large !important;
+          letter-spacing: $mktg-body-spacing-large;
         }
 
         @if (map-get($pairing-md, 'size') >= $mktg-body-weight-threshold and map-get($pairing, 'size') < $mktg-body-weight-threshold) {
@@ -102,7 +102,7 @@
         line-height: map-get($pairing-lg, 'lh') !important;
 
         @if (map-get($pairing-lg, 'size') >= $mktg-body-spacing-threshold and map-get($pairing-md, 'size') < $mktg-body-spacing-threshold) {
-          letter-spacing: $mktg-body-spacing-large !important;
+          letter-spacing: $mktg-body-spacing-large;
         }
 
         @if (map-get($pairing-lg, 'size') >= $mktg-body-weight-threshold and map-get($pairing-md, 'size') < $mktg-body-weight-threshold) {


### PR DESCRIPTION
### What are you trying to accomplish?

Hello there! 👋 

We've got like "trillion" accessibility issues for not allowing letter spacing change by the assistive plugins on dotcom marketing pages. So I would really like to solve these and remove `!important` on letter spacing. 🙏 

I've created an override only for the `/marketing/type/typography.scss` file on dotcom https://github.com/github/github/pull/322450 : 
1. Firstly to prove that nothing will be broken - nothing is at first glance, all other utilities with letter spacign work, order of class placement seems about right to not need `!important`.
2. Secondly to use as a temporary solution - but I don't really want ot use the override since it's not managable.

The only concern is that the users that might use the `mktg` styles might get impacted, but i think that Impact is minor, if not nonexiting.

That's about it. Do help me merge/deploy this 🙏 ❤️ 

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
