### PR TITLE
design-reviewers and engineer-reviewers as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-*       @primer/css-reviewers
+* @primer/design-reviewers
+package.json @primer/design-reviewers @primer/engineer-reviewers
+package-lock.json @primer/design-reviewers @primer/engineer-reviewers


### PR DESCRIPTION
### What are you trying to accomplish?

In codeowners, swap [css-reviewers](https://github.com/orgs/primer/teams/css-reviewers) with [design-reviewers](https://github.com/orgs/primer/teams/design-reviewers) + [engineering-reviewers](https://github.com/orgs/primer/teams/engineering-reviewers)

### What approach did you choose and why?

For now, I have only added engineering-reviews on package files so that they can share the load of dependabot PRs (especially during first responder)

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
