### PR TITLE
Drop “display: none” from details element contents styling

### DIFF
--- a/.changeset/slow-rabbits-hunt.md
+++ b/.changeset/slow-rabbits-hunt.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+drop “display: none” from details element contents styling

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -96,13 +96,6 @@ details {
   summary {
     cursor: pointer;
   }
-
-  &:not([open]) {
-    // Set details content hidden by default for browsers that don't do this
-    > *:not(summary) {
-      display: none;
-    }
-  }
 }
 
 // global focus styles


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #2592

### What approach did you choose and why?

Removed `display: none` from `details` contents styling

### What should reviewers focus on?

See https://github.com/primer/css/issues/2592#issue-2199903597 for repro/test steps

### Can these changes ship as is?

- [X] Yes, this PR does not depend on additional changes. 🚢