### PR TITLE
Use `control` borders for subnav + disabled button fix

### DIFF
--- a/.changeset/red-flowers-own.md
+++ b/.changeset/red-flowers-own.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Use `control` borders for subnav + disabled button fix

--- a/src/buttons/button.scss
+++ b/src/buttons/button.scss
@@ -93,8 +93,8 @@
   &.disabled,
   &[aria-disabled='true'] {
     color: var(--fgColor-disabled, var(--color-primer-fg-disabled));
-    background-color: var(--button-default-bgColor-rest, var(--color-btn-bg));
-    border-color: var(--button-default-borderColor-rest, var(--color-btn-border));
+    background-color: var(--button-default-bgColor-disabled, var(--color-btn-bg));
+    border-color: var(--button-default-borderColor-disabled, var(--color-btn-border));
 
     .octicon {
       color: var(--fgColor-disabled, var(--color-primer-fg-disabled));

--- a/src/navigation/subnav.scss
+++ b/src/navigation/subnav.scss
@@ -28,7 +28,7 @@
   // stylelint-disable-next-line primer/typography
   line-height: 20px;
   color: var(--fgColor-default, var(--color-fg-default));
-  border: $border-width $border-style var(--borderColor-default, var(--color-border-default));
+  border: $border-width $border-style var(--control-borderColor-rest, var(--color-border-default));
 
   + .subnav-item {
     // stylelint-disable-next-line primer/spacing


### PR DESCRIPTION
- Use control borders to help with updating contrast in the future
- Fix disabled button borders