### PR TITLE
Bug fix: Removing complex padding calc on kbd

### DIFF
--- a/.changeset/nice-cats-guess.md
+++ b/.changeset/nice-cats-guess.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Bug fix: Removing complex padding calc on kbd

--- a/src/base/kbd.scss
+++ b/src/base/kbd.scss
@@ -3,7 +3,7 @@
 
 kbd {
   display: inline-block;
-  padding: calc(var(--base-size-4) - 1) calc(var(--base-size-4) + 1);
+  padding: var(--base-size-4);
   font: 11px $mono-font;
   // stylelint-disable-next-line primer/typography
   line-height: 10px;


### PR DESCRIPTION
### What are you trying to accomplish?

**Before**

![CleanShot 2024-06-25 at 10 48 29@2x](https://github.com/user-attachments/assets/bad3b8f6-7183-4e50-afae-26f3a522efca)


**After**

![CleanShot 2024-06-25 at 10 45 14@2x](https://github.com/user-attachments/assets/24a52970-f4d5-45de-82ae-97d6cfc33387)


### What approach did you choose and why?

When transitioning from scss math to css calc, the padding was subtracting and adding too much since the size changed from pixels to rems.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
