### PR TITLE
Include primitives.css in the main primer.css export

### DIFF
--- a/.changeset/little-toes-reflect.md
+++ b/.changeset/little-toes-reflect.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Import `primitives/index.scss` in the main `primer.css` file.

--- a/src/index.scss
+++ b/src/index.scss
@@ -12,6 +12,7 @@
 
 // CSS color variables
 @import './color-modes/index.scss';
+@import './primitives/index.scss';
 
 // Global requirements
 @import './core/index.scss';


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/primer/css/issues/2648

### What approach did you choose and why?

This broke because in https://github.com/primer/css/pull/2634 I converted a lot of `$spacer-1` sass variables to CSS variables before. We never included the primitives in the main primer.css file before. So it was harder to notice that we were missing them. I think it makes sense to include them in the main primer.css file so that people don't have to include an extra file to get the primitives.

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 
