### PR TITLE
Use tabular numbers in tables

### DIFF
--- a/.changeset/wise-ducks-beam.md
+++ b/.changeset/wise-ducks-beam.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Use tabular numbers in tables

--- a/src/markdown/tables.scss
+++ b/src/markdown/tables.scss
@@ -8,6 +8,7 @@
     width: max-content;
     max-width: 100%;
     overflow: auto;
+    font-variant: tabular-nums;
 
     th {
       font-weight: $font-weight-bold;


### PR DESCRIPTION
### What are you trying to accomplish?

As tables are frequently used for comparing columns of numeric data (and have the ability to be right-aligned) we should make sure that we make it as easy as possibly. Toggling tabular numbers on givens you the ability to scan columns of numbers effectively, assuming the font supports it.

Here’s an example from [a recent PR](https://github.com/standardebooks/tools/pull/741#issuecomment-2292280809) without this CSS:

<img width="556" alt="Screenshot 2024-08-16 at 17 48 13" src="https://github.com/user-attachments/assets/b74a627c-f371-4ccc-9f11-621d3f85f6b2">

and with `font-variant: tabular-nums`:

<img width="556" alt="Screenshot 2024-08-16 at 17 48 01" src="https://github.com/user-attachments/assets/2a579fb8-6319-4a13-bc81-4c48a2becc18">

### What approach did you choose and why?

Flipping the switch with CSS is trivial. If the font doesn’t support this functionality then this doesn’t have any effect, but is no worse than the current behaviour.

### What should reviewers focus on?

First commit to Primer. Please let me know if I’m doing anything wrong, especially with the changeset which is new to me.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
