### PR TITLE
fix: Don’t use deprecated CSS properties in `.sr-only`

### DIFF
--- a/.changeset/spotty-bottles-jam.md
+++ b/.changeset/spotty-bottles-jam.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Replace deprecated CSS properties in '.sr-only'

--- a/src/utilities/visibility-display.scss
+++ b/src/utilities/visibility-display.scss
@@ -99,9 +99,9 @@
   height: 1px;
   padding: 0;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: rect(0 0 0 0);
   // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1241631
-  word-wrap: normal;
+  overflow-wrap: normal;
   border: 0;
 }
 


### PR DESCRIPTION
### What are you trying to accomplish?

This PR replaces `clip` and `word-wrap` in the `.sr-only` class:

- [`clip`](https://developer.mozilla.org/en-US/docs/Web/CSS/clip) is deprecated. MDN recommends [`clip-path`](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path) instead.

- [`word-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/word-wrap) was never a standard CSS property. MDN explains it is aliased to [`overflow-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap), which is standardized.

### What approach did you choose and why?

This PR replaces deprecated and non-standard CSS properties with supported and standardized ones, in order to ensure the `.sr-only` class works as expected.

### What should reviewers focus on?

Browser support for this PR’s replacement properties is good—all our supported browsers include them.

Do we have any tests that could ensure this change doesn’t visually regress?

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 
