### PR TITLE
Move prod @primer/* dependencies to dev

### DIFF
--- a/.changeset/afraid-houses-grin.md
+++ b/.changeset/afraid-houses-grin.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': minor
+---
+
+Move prod @primer/\* dependencies to dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@changesets/cli": "^2.27.1",
         "@csstools/postcss-sass": "^5.1.1",
         "@github/prettier-config": "^0.0.6",
-        "@primer/primitives": "^9.0.3",
         "@primer/stylelint-config": "^13.0.0-rc.af5663d",
         "@primer/view-components": "^0.34.0",
         "autoprefixer": "^10.4.18",
@@ -42,6 +41,9 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@primer/primitives": "^9.0.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,14 @@
       "name": "@primer/css",
       "version": "21.4.0",
       "license": "MIT",
-      "dependencies": {
-        "@primer/primitives": "^9.0.3",
-        "@primer/view-components": "^0.34.0"
-      },
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.1",
         "@csstools/postcss-sass": "^5.1.1",
         "@github/prettier-config": "^0.0.6",
+        "@primer/primitives": "^9.0.3",
         "@primer/stylelint-config": "^13.0.0-rc.af5663d",
+        "@primer/view-components": "^0.34.0",
         "autoprefixer": "^10.4.18",
         "chokidar-cli": "^3.0.0",
         "cssstats": "^4.0.5",
@@ -1356,6 +1354,7 @@
     },
     "node_modules/@github/auto-check-element": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@github/mini-throttle": "^1.0.7"
@@ -1363,12 +1362,14 @@
     },
     "node_modules/@github/auto-check-element/node_modules/@github/mini-throttle": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@github/auto-complete-element": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/@github/auto-complete-element/-/auto-complete-element-3.6.2.tgz",
       "integrity": "sha512-AgkrawNa2Focapn05yc/mNVTlAOqPFlMPhqkkMygPtOddms6NYxlCuVx8OM6aCTzBeEJlYur+/CS56hk4mvwmA==",
+      "dev": true,
       "dependencies": {
         "@github/combobox-nav": "^2.1.7"
       }
@@ -1380,28 +1381,34 @@
     },
     "node_modules/@github/catalyst": {
       "version": "1.6.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@github/clipboard-copy-element": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@github/clipboard-copy-element/-/clipboard-copy-element-1.3.0.tgz",
-      "integrity": "sha512-wyntkQkwoLbLo+Hqg2LIVMXDIzcvUb9bSDz+clX6nVJItwzh103rHxdXFRZD+DmxVbuEW5xSznYQXkz1jZT+xg=="
+      "integrity": "sha512-wyntkQkwoLbLo+Hqg2LIVMXDIzcvUb9bSDz+clX6nVJItwzh103rHxdXFRZD+DmxVbuEW5xSznYQXkz1jZT+xg==",
+      "dev": true
     },
     "node_modules/@github/combobox-nav": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@github/combobox-nav/-/combobox-nav-2.3.1.tgz",
-      "integrity": "sha512-gwxPzLw8XKecy1nP63i9lOBritS3bWmxl02UX6G0TwMQZbMem1BCS1tEZgYd3mkrkiDrUMWaX+DbFCuDFo3K+A=="
+      "integrity": "sha512-gwxPzLw8XKecy1nP63i9lOBritS3bWmxl02UX6G0TwMQZbMem1BCS1tEZgYd3mkrkiDrUMWaX+DbFCuDFo3K+A==",
+      "dev": true
     },
     "node_modules/@github/details-menu-element": {
       "version": "1.0.13",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@github/image-crop-element": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@github/include-fragment-element": {
       "version": "6.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@github/prettier-config": {
@@ -1411,15 +1418,18 @@
     },
     "node_modules/@github/relative-time-element": {
       "version": "4.1.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@github/remote-input-element": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@github/remote-input-element/-/remote-input-element-0.4.0.tgz",
-      "integrity": "sha512-apsMwsFW24F+w2wzT8oKoBi9lpm6GeFOmtuL+1YwDVmIiwixfHOD3MnEsEOv0RwmHsMdWmIjP9mxWyTWPKZHGg=="
+      "integrity": "sha512-apsMwsFW24F+w2wzT8oKoBi9lpm6GeFOmtuL+1YwDVmIiwixfHOD3MnEsEOv0RwmHsMdWmIjP9mxWyTWPKZHGg==",
+      "dev": true
     },
     "node_modules/@github/tab-container-element": {
       "version": "3.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
@@ -1969,7 +1979,8 @@
     "node_modules/@oddbird/popover-polyfill": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.4.0.tgz",
-      "integrity": "sha512-jrqoTI8lk5UziDsDPJ2Y+nmXYCcRhmr6uMARr3v/W6AMxRgsnRLWJyWKYr6FjaGMgbyxXG+OkCUPQY4Xl3toGg=="
+      "integrity": "sha512-jrqoTI8lk5UziDsDPJ2Y+nmXYCcRhmr6uMARr3v/W6AMxRgsnRLWJyWKYr6FjaGMgbyxXG+OkCUPQY4Xl3toGg==",
+      "dev": true
     },
     "node_modules/@pkgr/core": {
       "version": "0.1.1",
@@ -1987,6 +1998,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@prettier/sync/-/sync-0.5.2.tgz",
       "integrity": "sha512-Yb569su456XNx5BsH/Vyem7xD6g/y9iLmLUzRKM1a/dhU/D7HqqvkAG72znulXlMXztbV0iiu9O5AL8K98TzZQ==",
+      "dev": true,
       "dependencies": {
         "make-synchronized": "^0.2.8"
       },
@@ -2000,12 +2012,14 @@
     "node_modules/@primer/behaviors": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.3.5.tgz",
-      "integrity": "sha512-HWwz+6MrfK5NTWcg9GdKFpMBW/yrAV937oXiw2eDtsd88P3SRwoCt6ZO6QmKp9RP3nDU9cbqmuGZ0xBh0eIFeg=="
+      "integrity": "sha512-HWwz+6MrfK5NTWcg9GdKFpMBW/yrAV937oXiw2eDtsd88P3SRwoCt6ZO6QmKp9RP3nDU9cbqmuGZ0xBh0eIFeg==",
+      "dev": true
     },
     "node_modules/@primer/primitives": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-9.1.2.tgz",
       "integrity": "sha512-KecRJpUdIf14J3gVpoyMMJeQD6Sh5kcHk93N5bYch4XGB0GOZP3ypxz+NByMjr/2HHPsRfCCO5EEgNjmeWYUGQ==",
+      "dev": true,
       "dependencies": {
         "@prettier/sync": "^0.5.2",
         "prettier": "3.3"
@@ -2038,6 +2052,7 @@
       "version": "0.34.0",
       "resolved": "https://registry.npmjs.org/@primer/view-components/-/view-components-0.34.0.tgz",
       "integrity": "sha512-ZtIMakgQ8q+wm/1zdN2wjecyK0ctpBIcubdG11lK0vKhys/RBIfB6qSaQC0FuCi5xDso55sRsucH0TxRL+XdDQ==",
+      "dev": true,
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",
@@ -6787,6 +6802,7 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/make-synchronized/-/make-synchronized-0.2.9.tgz",
       "integrity": "sha512-4wczOs8SLuEdpEvp3vGo83wh8rjJ78UsIk7DIX5fxdfmfMJGog4bQzxfvOwq7Q3yCHLC4jp1urPHIxRS/A93gA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/fisker/make-synchronized?sponsor=1"
       }
@@ -7559,6 +7575,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@changesets/cli": "^2.27.1",
     "@csstools/postcss-sass": "^5.1.1",
     "@github/prettier-config": "^0.0.6",
-    "@primer/primitives": "^9.0.3",
     "@primer/stylelint-config": "^13.0.0-rc.af5663d",
     "@primer/view-components": "^0.34.0",
     "autoprefixer": "^10.4.18",
@@ -73,6 +72,9 @@
     "semver": "^7.6.0",
     "stylelint": "^16.9.0",
     "table": "^6.8.1"
+  },
+  "peerDependencies": {
+    "@primer/primitives": "^9.0.3"
   },
   "jest": {
     "testEnvironment": "node",

--- a/package.json
+++ b/package.json
@@ -41,15 +41,15 @@
     "build:storybook": "cd docs && npm i && npm run build:storybook"
   },
   "dependencies": {
-    "@primer/primitives": "^9.0.3",
-    "@primer/view-components": "^0.34.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",
     "@csstools/postcss-sass": "^5.1.1",
     "@github/prettier-config": "^0.0.6",
+    "@primer/primitives": "^9.0.3",
     "@primer/stylelint-config": "^13.0.0-rc.af5663d",
+    "@primer/view-components": "^0.34.0",
     "autoprefixer": "^10.4.18",
     "chokidar-cli": "^3.0.0",
     "cssstats": "^4.0.5",


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Please provide a short description of the changes and link to any related issues. Include screenshots or videos for visual changes.  -->

Both primer/view-components and primer/primitives are only used during build and therefore do not need to be listed as prod dependencies. Since primer/css is not updated very often anymore, leaving these two packages as prod dependencies is causing conflicts in other projects that use newer versions.

### What approach did you choose and why?

<!-- Here you can explain your approach and reasoning in more detail. -->

I moved primer/view-components and primer/behaviors to `devDependencies` in the package.json.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
