### PR TITLE
Import CSS files directly into Sass

### DIFF
--- a/.changeset/nasty-parrots-crash.md
+++ b/.changeset/nasty-parrots-crash.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Removed .css extension from @import and modified @primer/primitives to be output as Sass code.

--- a/src/color-modes/themes/dark.scss
+++ b/src/color-modes/themes/dark.scss
@@ -1,1 +1,1 @@
-@import '@primer/primitives/dist/css/functional/themes/dark.css';
+@import '@primer/primitives/dist/css/functional/themes/dark';

--- a/src/color-modes/themes/dark_colorblind.scss
+++ b/src/color-modes/themes/dark_colorblind.scss
@@ -1,1 +1,1 @@
-@import '@primer/primitives/dist/css/functional/themes/dark-colorblind.css';
+@import '@primer/primitives/dist/css/functional/themes/dark-colorblind';

--- a/src/color-modes/themes/dark_dimmed.scss
+++ b/src/color-modes/themes/dark_dimmed.scss
@@ -1,1 +1,1 @@
-@import '@primer/primitives/dist/css/functional/themes/dark-dimmed.css';
+@import '@primer/primitives/dist/css/functional/themes/dark-dimmed';

--- a/src/color-modes/themes/dark_high_contrast.scss
+++ b/src/color-modes/themes/dark_high_contrast.scss
@@ -1,1 +1,1 @@
-@import '@primer/primitives/dist/css/functional/themes/dark-high-contrast.css';
+@import '@primer/primitives/dist/css/functional/themes/dark-high-contrast';

--- a/src/color-modes/themes/dark_tritanopia.scss
+++ b/src/color-modes/themes/dark_tritanopia.scss
@@ -1,1 +1,1 @@
-@import '@primer/primitives/dist/css/functional/themes/dark-tritanopia.css';
+@import '@primer/primitives/dist/css/functional/themes/dark-tritanopia';

--- a/src/color-modes/themes/light.scss
+++ b/src/color-modes/themes/light.scss
@@ -1,1 +1,1 @@
-@import '@primer/primitives/dist/css/functional/themes/light.css';
+@import '@primer/primitives/dist/css/functional/themes/light';

--- a/src/color-modes/themes/light_colorblind.scss
+++ b/src/color-modes/themes/light_colorblind.scss
@@ -1,1 +1,1 @@
-@import '@primer/primitives/dist/css/functional/themes/light-colorblind.css';
+@import '@primer/primitives/dist/css/functional/themes/light-colorblind';

--- a/src/color-modes/themes/light_high_contrast.scss
+++ b/src/color-modes/themes/light_high_contrast.scss
@@ -1,1 +1,1 @@
-@import '@primer/primitives/dist/css/functional/themes/light-high-contrast.css';
+@import '@primer/primitives/dist/css/functional/themes/light-high-contrast';

--- a/src/color-modes/themes/light_tritanopia.scss
+++ b/src/color-modes/themes/light_tritanopia.scss
@@ -1,1 +1,1 @@
-@import '@primer/primitives/dist/css/functional/themes/light-tritanopia.css';
+@import '@primer/primitives/dist/css/functional/themes/light-tritanopia';


### PR DESCRIPTION
### What are you trying to accomplish?

Fixed a bug that prevented package users from resolving CSS paths in `@primer/primitives` when trying to import `@primer/css/color-modes`.

### What approach did you choose and why?

Removed `.css` extension from `@import` and modified `@primer/primitives` to be output as Sass code.

### What should reviewers focus on?

Please review that this approach is reasonable.

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 
