### PR TITLE
Default to primitive CSS variable values for SASS typography line-height and size

### DIFF
--- a/.changeset/align-line-height.md
+++ b/.changeset/align-line-height.md
@@ -1,0 +1,6 @@
+---
+"@primer/css": minor
+---
+
+- Reduce `$lh-default` typography default line-height to match primitive CSS value
+- Update SASS typography variables to rely on primitive CSS variables

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -18,7 +18,7 @@ $h4-size: 16px !default;
 $h5-size: 14px !default;
 $h6-size: 12px !default;
 
-$font-size-small: 12px !default;
+$font-size-small: var(--text-body-size-small, 12px) !default;
 
 // Font weights
 $font-weight-bold: var(--base-text-weight-semibold, 600) !default;
@@ -29,7 +29,7 @@ $font-weight-light: var(--base-text-weight-light, 300) !default;
 // Line heights
 $lh-condensed-ultra: 1 !default;
 $lh-condensed: 1.25 !default;
-$lh-default: 1.5 !default;
+$lh-default: var(--text-body-lineHeight-medium, 1.4285) !default;
 
 // Font stacks
 $body-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji' !default;
@@ -39,5 +39,5 @@ $body-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetic
 $mono-font: var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace) !default;
 
 // The base body size
-$body-font-size: 14px !default;
+$body-font-size: var(--text-body-size-medium, 14px) !default;
 $body-line-height: $lh-default !default;


### PR DESCRIPTION
### What are you trying to accomplish?

The typography SASS variables for font sizes align with the primitive CSS variables in value, but the default line-height differs. This results in inconsistent spacing in body text - for example, the Markdown editor uses the `1.4285` value while the `markdown-body` class uses `1.5`, resulting in inconsistent spacing across the Markdown preview vs editor ([as noted on Slack](https://github.slack.com/archives/C0ECZ1Y76/p1736546591841039)).


### What approach did you choose and why?

To fix this, we can update the value for `lh-default` to match the primitive. To ensure future consistency I updated it to _be_ the primitive. I also updated the small & default font sizes to use the primitives as well (this has no visual change). This reduces the line-height by 0.0715 (1.001 px).

Note that I did not update `lh-condensed` and `lh-condensed-ultra` since there are no existing primitives that match these values (that I know of).


### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
