### PR TITLE
Create a new CSS `@layer` for octicons

### DIFF
--- a/src/base/octicons.scss
+++ b/src/base/octicons.scss
@@ -1,6 +1,8 @@
-.octicon {
-  display: inline-block;
-  overflow: visible !important;
-  vertical-align: text-bottom;
-  fill: currentColor;
+@layer primer.icons {
+  .octicon {
+    display: inline-block;
+    overflow: visible !important;
+    vertical-align: text-bottom;
+    fill: currentColor;
+  }
 }


### PR DESCRIPTION
When styles downstream in Primer React interact with an icon, and `.octicon` is present on the page, the `.octicon` call will take precedence since it is in the anonymous layer and Primer React styles are brought in through the `primer-react` layer.

This change updates the `.octicon` class to be wrapped in a `@layer` named `primer.icons`. We should make sure this layer appears first to avoid any overrides in the future.