### PR TITLE
Use fontStack token in $body-font

### DIFF
--- a/.changeset/cute-bats-chew.md
+++ b/.changeset/cute-bats-chew.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': patch
+---
+
+Add --fontStack-sansSerif to $body-font variable

--- a/src/support/variables/typography.scss
+++ b/src/support/variables/typography.scss
@@ -32,7 +32,7 @@ $lh-condensed: 1.25 !default;
 $lh-default: 1.5 !default;
 
 // Font stacks
-$body-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji' !default;
+$body-font: var(--fontStack-sansSerif, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji') !default;
 
 // Monospace font stack
 // Note: SFMono-Regular needs to come before SF Mono to fix an older version of the font in Chrome


### PR DESCRIPTION
Updating $body-font variable to use `--fontStack-sansSerif`

### What are you trying to accomplish?

Make sure that the primitives token  `--fontStack-sansSerif` is used for text on github via the `$body-font` variable.

### What approach did you choose and why?

Add `--fontStack-sansSerif` token to the `$body-font` variable.

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
