### PR TITLE
Change `contrast` input background to `bgColor-default`

### DIFF
--- a/.changeset/wet-moose-beg.md
+++ b/.changeset/wet-moose-beg.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Change `contrast` input background to `bgColor-default`

--- a/src/forms/form-control.scss
+++ b/src/forms/form-control.scss
@@ -85,8 +85,9 @@ textarea.form-control {
 }
 
 // Inputs with contrast for easy light gray backgrounds against white.
+// changing the value to default as to not remove the class all together, but deprecate the visual distinction for "contrast"
 .input-contrast {
-  background-color: var(--bgColor-muted, var(--color-canvas-inset));
+  background-color: var(--bgColor-default);
 
   &:focus {
     background-color: var(--bgColor-default, var(--color-canvas-default));


### PR DESCRIPTION
We've had this change staff shipped for awhile now ([hubbers only](https://github.com/github/github/blob/9d297e07880acc21a3cc954b53cf1d376334cfcc/app/views/layouts/_primer_deprecate_input_contrast_mode_test.html.erb#L4)) and it seems pretty low risk to change the color value of this field type.