### PR TITLE
Replace @import with @use for theme styles

### DIFF
--- a/src/color-modes/index.scss
+++ b/src/color-modes/index.scss
@@ -1,11 +1,11 @@
 // All themes
 
-@import './themes/light.scss';
-@import './themes/light_colorblind.scss';
-@import './themes/light_high_contrast.scss';
-@import './themes/light_tritanopia.scss';
-@import './themes/dark.scss';
-@import './themes/dark_dimmed.scss';
-@import './themes/dark_high_contrast.scss';
-@import './themes/dark_colorblind.scss';
-@import './themes/dark_tritanopia.scss';
+@use './themes/light.scss';
+@use './themes/light_colorblind.scss';
+@use './themes/light_high_contrast.scss';
+@use './themes/light_tritanopia.scss';
+@use './themes/dark.scss';
+@use './themes/dark_dimmed.scss';
+@use './themes/dark_high_contrast.scss';
+@use './themes/dark_colorblind.scss';
+@use './themes/dark_tritanopia.scss';


### PR DESCRIPTION
## Description

Fixes #2781 

This PR addresses the Sass deprecation warnings by migrating from `@import` to `@use` in the color-modes module.

## Changes
- Replaced all `@import` statements with `@use` in `src/color-modes/index.scss`
- This removes Sass deprecation warnings for `@import` directives
- Follows the modern Sass module system best practices

## Related Issue
Closes #2781

## Testing
- [ ] Verified that the styles compile without deprecation warnings
- [ ] Confirmed that the color modes still work as expected