### PR TITLE
Fix typo in Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The CSS implementation of GitHub's Primer Design System
 > :warning: **This project is in KTLO mode!** Use existing utility classes from this project where needed. For more complete patterns that include styling and markup, please use [primer/react](https://github.com/primer/react) or, if necessary, [primer/view_components](https://github.com/primer/view_components).
 
 ## Documentation
-Our documentation site lives at [primer.style/css](https://primer.style/css). You'll be able to find detailed documentation on getting started, all of the components, our theme, our principles, and more.
+Our documentation site lives at [primer.style/css](https://primer.style/css). You can find detailed documentation on getting started, all of the components, our theme, our principles, and more.
 
 ## Install
 This repository is distributed with [npm]. After [installing npm][install-npm], you can install `@primer/css` with this command:


### PR DESCRIPTION
This PR removes a stray "+" character in the Documentation section of the README.

No structural or functional changes.
