### PR TITLE
Remove no-fund option from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 git-tag-version=false
 legacy-peer-deps=true
-no-audit=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
 git-tag-version=false
 legacy-peer-deps=true
 no-audit=true
-no-fund=true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "sass": "index.scss",
   "type": "module",
   "main": "dist/primer.js",
-  "repository": "https://github.com/primer/css",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/primer/css.git"
+  },
   "bugs": {
     "url": "https://github.com/primer/css/issues"
   },


### PR DESCRIPTION
### What are you trying to accomplish?

Was debugging a breaking workflow and saw a bunch of warnings posing as errors creating noise in the logs

> npm warn Unknown env config "no-fund". This will stop working in the next major version of npm. 
>  npm warn Unknown project config "no-audit". This will stop working in the next major version of npm.
> npm warn publish "repository" was changed from a string to an object


<img width="830" height="850" alt="screenshot of the logs with the warnings from above" src="https://github.com/user-attachments/assets/5a9e7ca3-3abf-45db-b612-6cea60417562" />


### What approach did you choose and why?

Clean up warnings by removing no-fund and no-audit from .npmrc and fixing repository field in package.json

After:

<img width="822" height="321" alt="no warnings anymore in the logs" src="https://github.com/user-attachments/assets/4096b488-4a03-448b-8a10-87161be054f7" />


### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
