### PR TITLE
Remove default color styles for data-color-mode

### DIFF
--- a/.changeset/small-tigers-tell.md
+++ b/.changeset/small-tigers-tell.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": minor
+---
+
+Remove default color styles for data-color-mode

--- a/src/base/native-colors.scss
+++ b/src/base/native-colors.scss
@@ -5,11 +5,6 @@
 
 @include color-mode(dark) { color-scheme: dark; }
 
-[data-color-mode] {
-  color: var(--fgColor-default, var(--color-fg-default));
-  background-color: var(--bgColor-default, var(--color-canvas-default));
-}
-
 // Windows High Contrast mode
 
 // Improves focus state for various components when Windows High Contrast mode is enabled


### PR DESCRIPTION
ref https://github.com/github/primer/issues/6568

Removed default color mode styles for data-color-mode.

### What are you trying to accomplish?

This removes the background and color properties for all `data-color-mode` attributes. To fix a bug where it's styling areas that are not meant to have these:

<img width="1508" height="316" alt="CleanShot 2026-05-18 at 11 36 50@2x" src="https://github.com/user-attachments/assets/5b348bab-f0fd-4718-bba7-d02e5773fc69" />

I believe this was originally added to try and support "nested themes" however this is an artifact from a different time in our engineering. We no longer support nested themes in this way.

### What should reviewers focus on?

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [ ] Yes, this PR does not depend on additional changes. 🚢 
