### PR TITLE
Set `text-rendering: optimizeSpeed` globally to fix font fallback bug

### DIFF
--- a/.changeset/healthy-nails-repair.md
+++ b/.changeset/healthy-nails-repair.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Set `text-rendering: optimizeSpeed` globally to fix font fallback bug

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -19,7 +19,13 @@ body {
   line-height: $body-line-height;
   color: var(--fgColor-default, var(--color-fg-default));
   background-color: var(--bgColor-default, var(--color-canvas-default));
-  text-rendering: optimizeSpeed;
+}
+
+@supports (-webkit-touch-callout: none) {
+  body {
+    // WebKit-only workaround for macOS text fallback/rendering issues
+    text-rendering: optimizeSpeed;
+  }
 }
 
 a {

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -19,13 +19,7 @@ body {
   line-height: $body-line-height;
   color: var(--fgColor-default, var(--color-fg-default));
   background-color: var(--bgColor-default, var(--color-canvas-default));
-}
-
-@supports (-webkit-touch-callout: none) {
-  body {
-    // WebKit-only workaround for macOS text fallback/rendering issues
-    text-rendering: optimizeSpeed;
-  }
+  text-rendering: optimizeSpeed;
 }
 
 a {

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -19,6 +19,7 @@ body {
   line-height: $body-line-height;
   color: var(--fgColor-default, var(--color-fg-default));
   background-color: var(--bgColor-default, var(--color-canvas-default));
+  text-rendering: optimizeSpeed;
 }
 
 a {


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/6670

### What are you trying to accomplish?

Set `text-rendering: optimizeSpeed;` on the `body` to fix intermittent SF Pro font fallback issues on macOS.

### What approach did you choose and why?

Added `text-rendering: optimizeSpeed;` to the global `body` selector in base.scss for consistent system font rendering.

### What should reviewers focus on?

Confirm global styles are applied and there are no regressions in font rendering.

### Can these changes ship as is?

- [x] Yes, this PR does not depend on additional changes. 🚢 