### PR TITLE
Revert "Set `text-rendering: optimizeSpeed` globally to fix font fallback bug"

### DIFF
--- a/.changeset/healthy-nails-repair.md
+++ b/.changeset/healthy-nails-repair.md
@@ -1,5 +1,0 @@
----
-"@primer/css": patch
----
-
-Set `text-rendering: optimizeSpeed` globally to fix font fallback bug

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -19,7 +19,6 @@ body {
   line-height: $body-line-height;
   color: var(--fgColor-default, var(--color-fg-default));
   background-color: var(--bgColor-default, var(--color-canvas-default));
-  text-rendering: optimizeSpeed;
 }
 
 a {


### PR DESCRIPTION
Reverts primer/css#3063