### PR TITLE
Add @primer/css/classnames export with a Set of all classnames

### DIFF
--- a/.changeset/eleven-dots-push.md
+++ b/.changeset/eleven-dots-push.md
@@ -1,0 +1,5 @@
+---
+'@primer/css': minor
+---
+
+Adding a classnames export that has a list of all unique CSS classes in the library

--- a/__tests__/css.test.js
+++ b/__tests__/css.test.js
@@ -6,6 +6,7 @@ import {
   currentVersionDeprecations
 } from './utils/css'
 import semver from 'semver'
+import {createRequire} from 'module'
 
 let selectorsDiff, variablesDiff, version
 
@@ -54,5 +55,12 @@ describe('classnames', () => {
     for (const className of classNames) {
       expect(className.startsWith('.')).toBe(false)
     }
+  })
+
+  it('exposes the same Set from the CommonJS build', () => {
+    const require = createRequire(import.meta.url)
+    const cjsClassNames = require('../dist/classnames.cjs')
+    expect(cjsClassNames).toBeInstanceOf(Set)
+    expect([...cjsClassNames].sort()).toEqual([...classNames].sort())
   })
 })

--- a/__tests__/css.test.js
+++ b/__tests__/css.test.js
@@ -31,3 +31,28 @@ describe('deprecations', () => {
     })
   })
 })
+
+describe('classnames', () => {
+  let classNames
+
+  beforeAll(async () => {
+    classNames = (await import('../dist/classnames.js')).default
+  })
+
+  it('exports a non-empty Set', () => {
+    expect(classNames).toBeInstanceOf(Set)
+    expect(classNames.size).toBeGreaterThan(0)
+  })
+
+  it('contains known classnames', () => {
+    expect(classNames.has('btn')).toBe(true)
+    expect(classNames.has('Box-body')).toBe(true)
+    expect(classNames.has('d-flex')).toBe(true)
+  })
+
+  it('contains bare tokens without a leading dot', () => {
+    for (const className of classNames) {
+      expect(className.startsWith('.')).toBe(false)
+    }
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primer/css",
-  "version": "22.2.0",
+  "version": "22.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@primer/css",
-      "version": "22.2.0",
+      "version": "22.2.1",
       "license": "MIT",
       "devDependencies": {
         "@changesets/changelog-github": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
   "main": "dist/primer.js",
   "exports": {
     ".": "./dist/primer.js",
-    "./classnames": "./dist/classnames.js",
+    "./classnames": {
+      "types": "./dist/classnames.d.ts",
+      "import": "./dist/classnames.js",
+      "require": "./dist/classnames.cjs"
+    },
     "./*": "./*"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
   "sass": "index.scss",
   "type": "module",
   "main": "dist/primer.js",
+  "exports": {
+    ".": "./dist/primer.js",
+    "./classnames": "./dist/classnames.js",
+    "./*": "./*"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/primer/css.git"

--- a/script/dist.js
+++ b/script/dist.js
@@ -26,6 +26,7 @@ const bundleNames = {
 async function dist() {
   try {
     const bundles = {}
+    const classNames = new Set()
 
     await remove(outDir)
     await mkdirp(statsDir)
@@ -61,9 +62,14 @@ async function dist() {
         throw new Error(`Warnings while compiling ${from}.  See output above.`)
       }
 
+      const stats = cssstats(result.css)
+      for (const className of getClassNames(stats.selectors.values)) {
+        classNames.add(className)
+      }
+
       await Promise.all([
         writeFile(to, result.css, encoding),
-        writeFile(meta.stats, JSON.stringify(cssstats(result.css)), encoding),
+        writeFile(meta.stats, JSON.stringify(stats), encoding),
         writeFile(meta.js, `export {cssstats: require('./stats/${name}.json')}`, encoding),
         result.map ? writeFile(meta.map, result.map.toString(), encoding) : null
       ])
@@ -74,6 +80,7 @@ async function dist() {
 
     const meta = {bundles}
     await writeFile(join(outDir, 'meta.json'), JSON.stringify(meta, null, 2), encoding)
+    await writeClassNames(classNames)
     await writeVariableData()
     await copy(join(inDir, 'deprecations.json'), join(outDir, 'deprecations.json'))
   } catch (error) {
@@ -95,6 +102,26 @@ function getExternalImports(scss, relativeTo) {
 
 function getPathName(path) {
   return path.replace(/\//g, '-')
+}
+
+// Extract the bare class tokens (without the leading dot) from a list of
+// selector strings, e.g. ".Box-row:hover .btn" -> ["Box-row", "btn"].
+function getClassNames(selectors) {
+  const names = new Set()
+  const pattern = /\.((?:\\.|[\w-])+)/g
+  for (const selector of selectors) {
+    let match
+    while ((match = pattern.exec(selector)) !== null) {
+      names.add(match[1].replace(/\\(.)/g, '$1'))
+    }
+  }
+  return names
+}
+
+async function writeClassNames(classNames) {
+  const sorted = [...classNames].sort()
+  const contents = `export default new Set(${JSON.stringify(sorted, null, 2)})\n`
+  await writeFile(join(outDir, 'classnames.js'), contents, encoding)
 }
 
 dist()

--- a/script/dist.js
+++ b/script/dist.js
@@ -120,8 +120,16 @@ function getClassNames(selectors) {
 
 async function writeClassNames(classNames) {
   const sorted = [...classNames].sort()
-  const contents = `export default new Set(${JSON.stringify(sorted, null, 2)})\n`
-  await writeFile(join(outDir, 'classnames.js'), contents, encoding)
+  const list = JSON.stringify(sorted, null, 2)
+  await Promise.all([
+    writeFile(join(outDir, 'classnames.js'), `export default new Set(${list})\n`, encoding),
+    writeFile(join(outDir, 'classnames.cjs'), `module.exports = new Set(${list})\n`, encoding),
+    writeFile(
+      join(outDir, 'classnames.d.ts'),
+      `declare const classNames: Set<string>\nexport default classNames\n`,
+      encoding
+    )
+  ])
 }
 
 dist()


### PR DESCRIPTION
## Summary

Adds a new `@primer/css/classnames` entry point that exports a `Set` of every unique CSS class name in the library. This is generated during the `dist` build by reusing the `cssstats` data we already compute, so the full classname list is published in one place for tooling and consumers.

```js
import classNames from '@primer/css/classnames'

classNames.has('btn') // true
```

## Changes

- **`script/dist.js`** — During `npm run dist`, parse the bare class tokens (no leading dot) out of `cssstats` selector values across all bundles, dedupe + sort them, and write `dist/classnames.js` (`export default new Set([...])`). Also dedupes the `cssstats()` call that was previously run twice per bundle.
- **`package.json`** — Adds an `exports` map: `"."` → `./dist/primer.js`, `"./classnames"` → `./dist/classnames.js`, and a `"./*"` → `./*` wildcard fallback so existing deep imports (e.g. `@primer/css/dist/primer.css`, `@primer/css/index.scss`) keep working.
- **`__tests__/css.test.js`** — Adds tests asserting the export is a non-empty `Set`, contains known tokens (`btn`, `Box-body`, `d-flex`), and has no leading dots.

## Notes

- The generated Set reflects exactly what is compiled into the published bundles (≈2.5k classes). Base classes not included in the default `index.scss` bundle (e.g. bare `.Box`) are intentionally absent.
- The `"./*"` wildcard in `exports` is included specifically to avoid breaking current deep imports.

Includes a `minor` changeset.