### PR TITLE
Add 'skip changeset' label to dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
       all:
         patterns:
         - "*"
+    labels:
+      - 'skip changeset'
 
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
@@ -24,3 +26,5 @@ updates:
       all:
         patterns:
         - "*"
+    labels:
+      - 'skip changeset'


### PR DESCRIPTION
Added 'skip changeset' label to all dependency groups to get a green CI from the start