### PR TITLE
Change ordered list order, lower-alpha before lower-roman

### DIFF
--- a/src/base/typography-base.scss
+++ b/src/base/typography-base.scss
@@ -48,14 +48,14 @@ ol {
 
 ol ol,
 ul ol {
-  list-style-type: lower-roman;
+  list-style-type: lower-alpha;
 }
 
 ul ul ol,
 ul ol ol,
 ol ul ol,
 ol ol ol {
-  list-style-type: lower-alpha;
+  list-style-type: lower-roman;
 }
 
 dd {


### PR DESCRIPTION
### What are you trying to accomplish?

Change ordered list styles used in markdown in at least issues and wikis to use what seems like the [more common and intuitive order](https://talk.commonmark.org/t/letter-ordered-lists/173): decimal, lower-alpha, lower-roman. This alternates numbers and letters and seems to follow more common convention, at least among U.S. english styles. I looked at least briefly and couldn't find style guidance or use of the current order over the proposed new order.

I read and tried various ways to override the order just for my content, but this seems to be difficult if not impossible since GitHub blocks various style/CSS modifications ([probably for legitimate security reasons](https://github.com/orgs/community/discussions/22728)).

Here are a semi-related [issue](https://github.com/github/markup/issues/991) and [discussion](https://github.com/orgs/community/discussions/124850).

### What approach did you choose and why?

Changed the order, simplest possible change. Note that I did not test this at all.

### What should reviewers focus on?

Whether or not to change the order. Some may prefer the current order? Existing ordered lists would change.

### Can these changes ship as is?

I think so.

### Reprex

```
1. Dog (1.)
   1. German Shepherd (should be a.)
   1. Belgian Shepherd (b.)
      1. Malinois (i.)
      1. Groenendael (ii.)
      1. Tervuren (iii.)
1. Cat (2.)
   1. Siberian (a.)
   1. Siamese (b.)
```

1. Dog (1.)
   1. German Shepherd (should be a.)
   1. Belgian Shepherd (b.)
      1. Malinois (i.)
      1. Groenendael (ii.)
      1. Tervuren (iii.)
1. Cat (2.)
   1. Siberian (a.)
   1. Siamese (b.)