### PR TITLE
Apply dynamic sizing for octicons

### DIFF
--- a/.changeset/some-wings-lose.md
+++ b/.changeset/some-wings-lose.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Apply dynamic `rem`-based sizing for octicons

--- a/src/base/octicons.scss
+++ b/src/base/octicons.scss
@@ -3,4 +3,10 @@
   overflow: visible !important;
   vertical-align: text-bottom;
   fill: currentColor;
+  /* Icon svg elements have `height="16" width="16"` set, hardcoding their dimensions to 16px.
+  This is useful for sizing in case CSS is missing/not yet loaded, but prevents icons from
+  responding to changes in font size/zoom. Using base-size applies the same size by default
+  but allows for dynamic sizing when base font size changes. */
+  height: var(--base-size-16);
+  width: var(--base-size-16);
 }


### PR DESCRIPTION
### What are you trying to accomplish?

Octicons are currently hardcoded to `16px` dimensions due to `svg` element `height` and `width` attributes. This prevents them from changing in response to changes in base font size, even when everything else on the page does change, making them look disproportionately small or large if the base font size is overidden to anything other than the default. 

- Fixes https://github.com/github/ui-quality/issues/66


### What approach did you choose and why?

The simple fix is to apply `base-size` Primer tokens here, which are `rem` based and will adjust in response to base font size changes.

### What should reviewers focus on?

Not much to see here really, it's pretty straightforward.

### Can these changes ship as is?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [x] Yes, this PR does not depend on additional changes. 🚢 
