### PR TITLE
fix(markdown): remove underlined space inside anchors wrapping images

### DIFF
--- a/src/markdown/images.scss
+++ b/src/markdown/images.scss
@@ -2,7 +2,9 @@
 // stylelint-disable selector-no-qualifying-type
 // stylelint-disable selector-max-type
 .markdown-body {
-  // Images & Stuff
+  a[href]:has(img) {
+    display: inline-flex;
+  }
   img {
     max-width: 100%;
     // because we put padding on the images to hide header lines, and some people


### PR DESCRIPTION
### What are you trying to accomplish?
This PR fixes the issue where whitespace inside `<a>` tags wrapping `<img>` tags renders as an underlined gap in `.markdown-body`.

Fixes #3128

### What approach did you choose and why?
Added `display: inline-flex` to `a[href]:has(img)` inside `.markdown-body`. This removes unnecessary whitespace painting under anchor tags wrapping images without affecting adjacent elements.

### What should reviewers focus on?
Please verify that anchor tags with nested images render correctly without unwanted underlines, and that adjacent elements retain their normal layout.

### Can these changes ship as is?
- [x] Yes, this PR does not depend on additional changes. 🚢