### PR TITLE
Set the markdown `<hr>` thickness to 1px (`$border-width`)

### DIFF
--- a/.changeset/markdown-hr-thickness.md
+++ b/.changeset/markdown-hr-thickness.md
@@ -1,0 +1,5 @@
+---
+"@primer/css": patch
+---
+
+Set the markdown `<hr>` (thematic break) thickness to 1px using `$border-width`, down from 4px, so it matches Primer's line weight and the ~1px used by other markdown renderers.

--- a/src/markdown/markdown-body.scss
+++ b/src/markdown/markdown-body.scss
@@ -76,7 +76,7 @@
   }
 
   hr {
-    height: $em-spacer-3;
+    height: $border-width;
     padding: 0;
     margin: var(--base-size-24) 0;
     // stylelint-disable-next-line primer/colors


### PR DESCRIPTION
`---` (the markdown thematic break) currently renders as a 4px solid bar. This changes it to a standard 1px rule.

I did not expect to develop strong feelings about a four-pixel line this week, and yet.

Everywhere else in the system, rules and edges use the `$border-width` (1px) border token: headings, tables, blockquote. The `<hr>` is the exception. It uses a *spacing* token, `$em-spacer-3` (0.25em / 4px), as a thickness, which makes it roughly 4x heavier than the equivalent line in every other markdown renderer.

**Change:** set the `<hr>` thickness to `$border-width` (1px) instead of `$em-spacer-3` (0.25em / 4px). That is the only change: same margins, same full width, same solid fill, just 1px. `$border-width` is Primer's line-thickness token (already used for the system's other rules), so the divider tracks it if it ever changes, rather than borrowing a spacing token as a thickness.

**Why**

- **Consistency with Primer's own weight.** `$border-width` (1px) is the token used for every other rule in the system; the `<hr>` is the only place a spacing token stands in for a line weight.
- **Peer norm.** Browser defaults, VS Code's markdown preview, Bootstrap, Tailwind Typography, Notion, Linear, Medium, Material (1dp), and Apple's HIG separators all land at ~1px. GitHub's 4px is the outlier.

**Why this belongs in `@primer/css` (which is in KTLO mode).** There is no newer package for it to move to. `.markdown-body` styles server-rendered markdown output, plain HTML emitted by the markdown pipeline, which `primer/react` and `primer/view_components` components do not produce and cannot style. It is a global stylesheet concern, which is what `@primer/css` still owns, so a one-line tweak to this existing, still-shipped rule belongs here rather than as new work in a component library.

**Heads-up for reviewers:** `.markdown-body` is a widely-inherited default, so this is a visible change anywhere Primer-styled markdown renders. Flagging for design review rather than treating it as routine.

<details>
<summary><b>Evidence: how other renderers and design systems draw this line</b></summary>

| Source | Divider / `hr` weight |
|---|---|
| Browser default (Blink / Gecko / WebKit) | ~1px hairline |
| VS Code markdown preview | 1px |
| Bootstrap 5 | 1px (25% opacity) |
| Tailwind Typography (`prose`) | 1px |
| Notion divider | ~1px |
| Slack / Linear UI dividers | ~1px |
| Medium section break | ~1px (or a 3-dot asterism) |
| Material Design divider | 1dp |
| Apple HIG separator | 1px hairline (0.5pt on Retina) |
| **GitHub markdown `<hr>`** | **4px solid bar** |

</details>
